### PR TITLE
feat(docker): add GDAL/GEOS/PROJ to Django image

### DIFF
--- a/docker/django/Dockerfile
+++ b/docker/django/Dockerfile
@@ -8,7 +8,16 @@ ENV PYTHONUNBUFFERED=1
 ENV UV_VENV_IN_PROJECT=1
 ENV UV_VENV_CLEAR=1
 
-# Sadece dependency tanımı
+# System dependencies for GeoDjango
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    gdal-bin \
+    libgdal-dev \
+    libgeos-dev \
+    libproj-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Dependency management
 
 RUN pip install --upgrade pip \
- && pip install uv 
+    && pip install uv 


### PR DESCRIPTION
Install geospatial libraries required for GeoDjango:
- gdal-bin, libgdal-dev
- libgeos-dev
- libproj-dev

This enables django.contrib.gis for PostGIS geometry fields.

## Summary

- [x] Description of changes
- [ ] Related issue link

## Testing

- [x] `uv run pytest`
- [ ] Other (describe)
