### PR TITLE
feat(settings): configure GeoDjango with PostGIS backend

### DIFF
--- a/tosca_api/settings/base.py
+++ b/tosca_api/settings/base.py
@@ -50,6 +50,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "django.contrib.sites",
+    "django.contrib.gis",  # GeoDjango for PostGIS support
     # Local apps that override third-party templates
     "tosca_api.apps.authentication",  # Override allauth templates
     # Third-party
@@ -109,7 +110,7 @@ ASGI_APPLICATION = "tosca_api.asgi.application"
 
 DATABASES = {
         "default": {
-            "ENGINE": "django.db.backends.postgresql",
+            "ENGINE": "django.contrib.gis.db.backends.postgis",
             "NAME": env("PG_DATABASE"),
             "USER": env("PG_API_USER"),
             "PASSWORD": env("PG_API_PASSWORD"),


### PR DESCRIPTION
- Add django.contrib.gis to INSTALLED_APPS
- Switch database engine to django.contrib.gis.db.backends.postgis Enables use of PointField, GeometryField for spatial models.

## Summary

- [x] Description of changes
- [ ] Related issue link

## Testing

- [ ] `uv run pytest`
- [ ] Other (describe)
