### PR TITLE
feat(security): implement strict input sanitization

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "dj-rest-auth>=7.0.1",
     "ruff>=0.14.7",
     "python-json-logger>=4.0.0",
+    "nh3>=0.3.2",
 ]
 
 [project.optional-dependencies]

--- a/tosca_api/apps/campaigns/models.py
+++ b/tosca_api/apps/campaigns/models.py
@@ -13,13 +13,14 @@ from django.conf import settings
 from django.db import models
 
 from tosca_api.apps.core.models import TimeStampedModel
+from tosca_api.apps.core.sanitization import sanitize_simple
 
 
 class Campaign(TimeStampedModel):
     """
     Campaign model for grouping features (stories, events, feedback) under a
     thematic initiative.
-
+    
     Attributes:
         id: UUID primary key
         title: Campaign name (required)
@@ -66,3 +67,9 @@ class Campaign(TimeStampedModel):
 
     def __str__(self) -> str:
         return self.title
+
+    def save(self, *args, **kwargs) -> None:
+        """Override save to sanitize text fields enforce Zero Trust."""
+        self.title = sanitize_simple(self.title)
+        self.summary = sanitize_simple(self.summary)
+        super().save(*args, **kwargs)

--- a/tosca_api/apps/campaigns/tests/test_models.py
+++ b/tosca_api/apps/campaigns/tests/test_models.py
@@ -72,3 +72,24 @@ def test_campaign_visibility_choices(test_user):
         created_by=test_user,
     )
     assert campaign.visibility == "public"
+
+
+@pytest.mark.django_db
+def test_campaign_sanitization(test_user):
+    """Test that campaign fields are sanitized."""
+    unsafe_title = "My <b>Campaign</b><script>alert(1)</script>"
+    unsafe_summary = "A summary with <script>bad</script> tags."
+    
+    campaign = Campaign.objects.create(
+        title=unsafe_title,
+        summary=unsafe_summary,
+        created_by=test_user,
+    )
+    
+    # Simple sanitization strips ALL tags
+    assert "<script>" not in campaign.title
+    assert "<b>" not in campaign.title
+    assert campaign.title == "My Campaign"
+    
+    assert "<script>" not in campaign.summary
+    assert campaign.summary == "A summary with  tags."

--- a/tosca_api/apps/core/sanitization.py
+++ b/tosca_api/apps/core/sanitization.py
@@ -1,0 +1,82 @@
+"""
+HTML Sanitization Utilities.
+
+This module provides functions to sanitize HTML content using the `nh3` library
+(Rust-based, fast, and secure). It supports different levels of sanitization
+based on the context (simple text vs. rich HTML).
+"""
+
+import nh3
+
+# Allowlist for rich content (based on decisions.md and tasks.md)
+ALLOWED_TAGS = {
+    "p", "br", "strong", "em", "b", "i", "u",
+    "a", "ul", "ol", "li",
+    "h1", "h2", "h3", "h4",
+    "blockquote", "pre", "code",
+    "img", "figure", "figcaption",
+}
+
+ALLOWED_ATTRS = {
+    "a": {"href", "title", "target"},
+    "img": {"src", "alt", "width", "height"},
+}
+
+ALLOWED_URL_SCHEMES = {"http", "https", "mailto"}
+
+
+def sanitize_simple(content: str) -> str:
+    """
+    Strip ALL HTML tags, returning plain text only.
+    
+    Args:
+        content: The input string to sanitize.
+        
+    Returns:
+        The sanitized string with no HTML tags.
+    """
+    if not content:
+        return ""
+    # Empty set of tags means strip everything
+    return nh3.clean(content, tags=set())
+
+
+def sanitize_rich(content: str) -> str:
+    """
+    Allow only whitelisted HTML tags and attributes.
+    Refuses inline styles, event handlers, and dangerous URL schemes (javascript:).
+    
+    Args:
+        content: The input HTML string.
+        
+    Returns:
+        The sanitized HTML string.
+    """
+    if not content:
+        return ""
+    
+    return nh3.clean(
+        content,
+        tags=ALLOWED_TAGS,
+        attributes=ALLOWED_ATTRS,
+        link_rel=None,  # Do not force rel="noopener noreferrer" automatically unless configured? 
+                        # nh3 defaults might be safe enough.
+        url_schemes=ALLOWED_URL_SCHEMES,
+    )
+
+
+def sanitize_content(content: str, content_type: str) -> str:
+    """
+    Sanitize content based on its type.
+    
+    Args:
+        content: The text content.
+        content_type: 'simple' or 'rich'.
+        
+    Returns:
+        The sanitized content.
+    """
+    if content_type == "rich":
+        return sanitize_rich(content)
+    # Default to strict sanitization for 'simple' or unknown types
+    return sanitize_simple(content)

--- a/tosca_api/apps/core/tests/test_sanitization.py
+++ b/tosca_api/apps/core/tests/test_sanitization.py
@@ -1,0 +1,59 @@
+"""
+Tests for sanitization utilities.
+"""
+
+from tosca_api.apps.core.sanitization import (
+    sanitize_simple,
+    sanitize_rich,
+    sanitize_content
+)
+
+
+def test_sanitize_simple_strips_tags():
+    """Test that sanitize_simple removes all HTML tags."""
+    unsafe = "<p>Hello <b>World</b></p><script>alert(1)</script>"
+
+    result = sanitize_simple(unsafe)
+    assert "<p>" not in result
+    assert "<b>" not in result
+    assert "<script>" not in result
+    assert result == "Hello World"
+
+
+def test_sanitize_rich_removes_script():
+    """Test that rich sanitization strips script tags."""
+    unsafe = "<script>alert(1)</script><p>Safe</p>"
+    result = sanitize_rich(unsafe)
+    assert "<script>" not in result
+    assert "alert(1)" not in result
+    assert "<p>Safe</p>" in result
+
+
+def test_sanitize_rich_removes_event_handlers():
+    """Test rejection of onerror/onclick."""
+    unsafe = '<img src="x" onerror="alert(1)" alt="test">'
+    result = sanitize_rich(unsafe)
+    assert 'onerror' not in result
+    assert '<img' in result
+    assert 'src="x"' in result
+    assert 'alt="test"' in result
+
+
+def test_sanitize_rich_removes_javascript_urls():
+    """Test rejection of javascript: hrefs."""
+    unsafe = '<a href="javascript:alert(1)">Click me</a>'
+    result = sanitize_rich(unsafe)
+    assert 'javascript:' not in result
+    assert 'Click me' in result
+
+
+def test_sanitize_rich_preserves_allowlist():
+    """Test that allowed tags pass through."""
+    safe = '<h1>Title</h1><p><strong>Bold</strong></p>'
+    assert sanitize_rich(safe) == safe
+
+
+def test_sanitize_content_router():
+    """Test the router function."""
+    assert sanitize_content("<b>Hi</b>", "simple") == "Hi"
+    assert sanitize_content("<b>Hi</b>", "rich") == "<b>Hi</b>"

--- a/tosca_api/apps/geocontext/models.py
+++ b/tosca_api/apps/geocontext/models.py
@@ -15,6 +15,7 @@ from django.conf import settings
 from django.db import models
 
 from tosca_api.apps.core.models import TimeStampedModel
+from tosca_api.apps.core.sanitization import sanitize_content
 
 
 class GeoContext(TimeStampedModel):
@@ -57,3 +58,8 @@ class GeoContext(TimeStampedModel):
         # Return first 50 chars of content or a placeholder
         preview = self.content[:50] if self.content else "(empty)"
         return f"GeoContext: {preview}..."
+
+    def save(self, *args, **kwargs) -> None:
+        """Override save to sanitize content before persistence."""
+        self.content = sanitize_content(self.content, self.content_type)
+        super().save(*args, **kwargs)

--- a/uv.lock
+++ b/uv.lock
@@ -463,6 +463,39 @@ wheels = [
 ]
 
 [[package]]
+name = "nh3"
+version = "0.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/a5/34c26015d3a434409f4d2a1cd8821a06c05238703f49283ffeb937bef093/nh3-0.3.2.tar.gz", hash = "sha256:f394759a06df8b685a4ebfb1874fb67a9cbfd58c64fc5ed587a663c0e63ec376", size = 19288, upload-time = "2025-10-30T11:17:45.948Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/01/a1eda067c0ba823e5e2bb033864ae4854549e49fb6f3407d2da949106bfb/nh3-0.3.2-cp314-cp314t-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:d18957a90806d943d141cc5e4a0fefa1d77cf0d7a156878bf9a66eed52c9cc7d", size = 1419839, upload-time = "2025-10-30T11:17:09.956Z" },
+    { url = "https://files.pythonhosted.org/packages/30/57/07826ff65d59e7e9cc789ef1dc405f660cabd7458a1864ab58aefa17411b/nh3-0.3.2-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:45c953e57028c31d473d6b648552d9cab1efe20a42ad139d78e11d8f42a36130", size = 791183, upload-time = "2025-10-30T11:17:11.99Z" },
+    { url = "https://files.pythonhosted.org/packages/af/2f/e8a86f861ad83f3bb5455f596d5c802e34fcdb8c53a489083a70fd301333/nh3-0.3.2-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2c9850041b77a9147d6bbd6dbbf13eeec7009eb60b44e83f07fcb2910075bf9b", size = 829127, upload-time = "2025-10-30T11:17:13.192Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/77aef4daf0479754e8e90c7f8f48f3b7b8725a3b8c0df45f2258017a6895/nh3-0.3.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:403c11563e50b915d0efdb622866d1d9e4506bce590ef7da57789bf71dd148b5", size = 997131, upload-time = "2025-10-30T11:17:14.677Z" },
+    { url = "https://files.pythonhosted.org/packages/41/ee/fd8140e4df9d52143e89951dd0d797f5546004c6043285289fbbe3112293/nh3-0.3.2-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:0dca4365db62b2d71ff1620ee4f800c4729849906c5dd504ee1a7b2389558e31", size = 1068783, upload-time = "2025-10-30T11:17:15.861Z" },
+    { url = "https://files.pythonhosted.org/packages/87/64/bdd9631779e2d588b08391f7555828f352e7f6427889daf2fa424bfc90c9/nh3-0.3.2-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:0fe7ee035dd7b2290715baf29cb27167dddd2ff70ea7d052c958dbd80d323c99", size = 994732, upload-time = "2025-10-30T11:17:17.155Z" },
+    { url = "https://files.pythonhosted.org/packages/79/66/90190033654f1f28ca98e3d76b8be1194505583f9426b0dcde782a3970a2/nh3-0.3.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a40202fd58e49129764f025bbaae77028e420f1d5b3c8e6f6fd3a6490d513868", size = 975997, upload-time = "2025-10-30T11:17:18.77Z" },
+    { url = "https://files.pythonhosted.org/packages/34/30/ebf8e2e8d71fdb5a5d5d8836207177aed1682df819cbde7f42f16898946c/nh3-0.3.2-cp314-cp314t-win32.whl", hash = "sha256:1f9ba555a797dbdcd844b89523f29cdc90973d8bd2e836ea6b962cf567cadd93", size = 583364, upload-time = "2025-10-30T11:17:20.286Z" },
+    { url = "https://files.pythonhosted.org/packages/94/ae/95c52b5a75da429f11ca8902c2128f64daafdc77758d370e4cc310ecda55/nh3-0.3.2-cp314-cp314t-win_amd64.whl", hash = "sha256:dce4248edc427c9b79261f3e6e2b3ecbdd9b88c267012168b4a7b3fc6fd41d13", size = 589982, upload-time = "2025-10-30T11:17:21.384Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/bd/c7d862a4381b95f2469704de32c0ad419def0f4a84b7a138a79532238114/nh3-0.3.2-cp314-cp314t-win_arm64.whl", hash = "sha256:019ecbd007536b67fdf76fab411b648fb64e2257ca3262ec80c3425c24028c80", size = 577126, upload-time = "2025-10-30T11:17:22.755Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/3e/f5a5cc2885c24be13e9b937441bd16a012ac34a657fe05e58927e8af8b7a/nh3-0.3.2-cp38-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:7064ccf5ace75825bd7bf57859daaaf16ed28660c1c6b306b649a9eda4b54b1e", size = 1431980, upload-time = "2025-10-30T11:17:25.457Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/f7/529a99324d7ef055de88b690858f4189379708abae92ace799365a797b7f/nh3-0.3.2-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c8745454cdd28bbbc90861b80a0111a195b0e3961b9fa2e672be89eb199fa5d8", size = 820805, upload-time = "2025-10-30T11:17:26.98Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/62/19b7c50ccd1fa7d0764822d2cea8f2a320f2fd77474c7a1805cb22cf69b0/nh3-0.3.2-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72d67c25a84579f4a432c065e8b4274e53b7cf1df8f792cf846abfe2c3090866", size = 803527, upload-time = "2025-10-30T11:17:28.284Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/ca/f022273bab5440abff6302731a49410c5ef66b1a9502ba3fbb2df998d9ff/nh3-0.3.2-cp38-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:13398e676a14d6233f372c75f52d5ae74f98210172991f7a3142a736bd92b131", size = 1051674, upload-time = "2025-10-30T11:17:29.909Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/f7/5728e3b32a11daf5bd21cf71d91c463f74305938bc3eb9e0ac1ce141646e/nh3-0.3.2-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:03d617e5c8aa7331bd2659c654e021caf9bba704b109e7b2b28b039a00949fe5", size = 1004737, upload-time = "2025-10-30T11:17:31.205Z" },
+    { url = "https://files.pythonhosted.org/packages/53/7f/f17e0dba0a99cee29e6cee6d4d52340ef9cb1f8a06946d3a01eb7ec2fb01/nh3-0.3.2-cp38-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f2f55c4d2d5a207e74eefe4d828067bbb01300e06e2a7436142f915c5928de07", size = 911745, upload-time = "2025-10-30T11:17:32.945Z" },
+    { url = "https://files.pythonhosted.org/packages/42/0f/c76bf3dba22c73c38e9b1113b017cf163f7696f50e003404ec5ecdb1e8a6/nh3-0.3.2-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7bb18403f02b655a1bbe4e3a4696c2ae1d6ae8f5991f7cacb684b1ae27e6c9f7", size = 797184, upload-time = "2025-10-30T11:17:34.226Z" },
+    { url = "https://files.pythonhosted.org/packages/08/a1/73d8250f888fb0ddf1b119b139c382f8903d8bb0c5bd1f64afc7e38dad1d/nh3-0.3.2-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6d66f41672eb4060cf87c037f760bdbc6847852ca9ef8e9c5a5da18f090abf87", size = 838556, upload-time = "2025-10-30T11:17:35.875Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/09/deb57f1fb656a7a5192497f4a287b0ade5a2ff6b5d5de4736d13ef6d2c1f/nh3-0.3.2-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:f97f8b25cb2681d25e2338148159447e4d689aafdccfcf19e61ff7db3905768a", size = 1006695, upload-time = "2025-10-30T11:17:37.071Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/61/8f4d41c4ccdac30e4b1a4fa7be4b0f9914d8314a5058472f84c8e101a418/nh3-0.3.2-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:2ab70e8c6c7d2ce953d2a58102eefa90c2d0a5ed7aa40c7e29a487bc5e613131", size = 1075471, upload-time = "2025-10-30T11:17:38.225Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/c6/966aec0cb4705e69f6c3580422c239205d5d4d0e50fac380b21e87b6cf1b/nh3-0.3.2-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:1710f3901cd6440ca92494ba2eb6dc260f829fa8d9196b659fa10de825610ce0", size = 1002439, upload-time = "2025-10-30T11:17:39.553Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/c8/97a2d5f7a314cce2c5c49f30c6f161b7f3617960ade4bfc2fd1ee092cb20/nh3-0.3.2-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:91e9b001101fb4500a2aafe3e7c92928d85242d38bf5ac0aba0b7480da0a4cd6", size = 987439, upload-time = "2025-10-30T11:17:40.81Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/95/2d6fc6461687d7a171f087995247dec33e8749a562bfadd85fb5dbf37a11/nh3-0.3.2-cp38-abi3-win32.whl", hash = "sha256:169db03df90da63286e0560ea0efa9b6f3b59844a9735514a1d47e6bb2c8c61b", size = 589826, upload-time = "2025-10-30T11:17:42.239Z" },
+    { url = "https://files.pythonhosted.org/packages/64/9a/1a1c154f10a575d20dd634e5697805e589bbdb7673a0ad00e8da90044ba7/nh3-0.3.2-cp38-abi3-win_amd64.whl", hash = "sha256:562da3dca7a17f9077593214a9781a94b8d76de4f158f8c895e62f09573945fe", size = 596406, upload-time = "2025-10-30T11:17:43.773Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/7e/a96255f63b7aef032cbee8fc4d6e37def72e3aaedc1f72759235e8f13cb1/nh3-0.3.2-cp38-abi3-win_arm64.whl", hash = "sha256:cf5964d54edd405e68583114a7cba929468bcd7db5e676ae38ee954de1cfc104", size = 584162, upload-time = "2025-10-30T11:17:44.96Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "25.0"
 source = { registry = "https://pypi.org/simple" }
@@ -706,6 +739,7 @@ dependencies = [
     { name = "django-allauth" },
     { name = "django-environ" },
     { name = "djangorestframework" },
+    { name = "nh3" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-json-logger" },
@@ -736,6 +770,7 @@ requires-dist = [
     { name = "django-environ", specifier = ">=0.11.0" },
     { name = "djangorestframework", specifier = ">=3.15.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11.0" },
+    { name = "nh3", specifier = ">=0.3.2" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2.0" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.8.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },


### PR DESCRIPTION
Enforce "Zero Trust" content sanitization policy across the backend:

- Add `nh3` dependency for secure HTML cleaning.
- Create `core.sanitization` utility with [sanitize_simple] and [sanitize_rich].
- Enforce sanitization in `GeoContext.save()`: simple types get stripped, rich types get sanitized.
- Enforce sanitization in `Campaign.save()`: Title and Summary are now strictly plain text.
- Add comprehensive tests covering XSS vectors, script stripping, and event handler removal.

This ensures all persisted text content is safe from XSS, regardless of the input source (Admin, API, Shell).

## Summary

- [x] Description of changes
- [x] Related issue link

## Testing

- [x] `uv run pytest`
- [x] Other (describe)
