### PR TITLE
feat(campaigns): add REST API endpoints

### DIFF
--- a/tosca_api/apps/campaigns/serializers.py
+++ b/tosca_api/apps/campaigns/serializers.py
@@ -1,0 +1,23 @@
+from rest_framework import serializers
+
+from .models import Campaign
+
+
+class CampaignSerializer(serializers.ModelSerializer):
+    """
+    Serializer for Campaign model.
+    """
+
+    class Meta:
+        model = Campaign
+        fields = [
+            "id",
+            "title",
+            "summary",
+            "status",
+            "visibility",
+            "created_by",
+            "created_at",
+            "updated_at",
+        ]
+        read_only_fields = ["id", "created_by", "created_at", "updated_at"]

--- a/tosca_api/apps/campaigns/tests/test_api.py
+++ b/tosca_api/apps/campaigns/tests/test_api.py
@@ -1,0 +1,64 @@
+import pytest
+from django.contrib.auth import get_user_model
+from rest_framework.test import APIClient
+
+from tosca_api.apps.campaigns.models import Campaign
+
+User = get_user_model()
+
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+
+@pytest.fixture
+def user():
+    return User.objects.create_user(username="apiuser", password="password")
+
+
+@pytest.fixture
+def campaign(user):
+    return Campaign.objects.create(title="Existing Campaign", created_by=user)
+
+
+@pytest.mark.django_db
+def test_campaign_list_unauthenticated(api_client):
+    """Test that unauthenticated users cannot list campaigns."""
+    response = api_client.get("/api/v1/campaigns/")
+    assert response.status_code == 403  # or 401 depending on DRF setting
+
+
+@pytest.mark.django_db
+def test_campaign_list_authenticated(api_client, user, campaign):
+    """Test that authenticated users can list campaigns."""
+    api_client.force_authenticate(user=user)
+    response = api_client.get("/api/v1/campaigns/")
+    assert response.status_code == 200
+    assert len(response.data["results"]) >= 1
+    assert response.data["results"][0]["title"] == "Existing Campaign"
+
+
+@pytest.mark.django_db
+def test_campaign_create_authenticated(api_client, user):
+    """Test that authenticated users can create campaigns."""
+    api_client.force_authenticate(user=user)
+    data = {
+        "title": "New API Campaign",
+        "summary": "Created via API",
+        "status": "draft",
+        "visibility": "private",
+    }
+    response = api_client.post("/api/v1/campaigns/", data)
+    assert response.status_code == 201
+    assert response.data["title"] == "New API Campaign"
+    assert response.data["created_by"] == user.id
+
+
+@pytest.mark.django_db
+def test_campaign_retrieve(api_client, user, campaign):
+    """Test retrieving a specific campaign."""
+    api_client.force_authenticate(user=user)
+    response = api_client.get(f"/api/v1/campaigns/{campaign.id}/")
+    assert response.status_code == 200
+    assert response.data["id"] == str(campaign.id)

--- a/tosca_api/apps/campaigns/urls.py
+++ b/tosca_api/apps/campaigns/urls.py
@@ -1,0 +1,11 @@
+from django.urls import include, path
+from rest_framework.routers import DefaultRouter
+
+from .views import CampaignViewSet
+
+router = DefaultRouter()
+router.register(r"campaigns", CampaignViewSet)
+
+urlpatterns = [
+    path("", include(router.urls)),
+]

--- a/tosca_api/apps/campaigns/views.py
+++ b/tosca_api/apps/campaigns/views.py
@@ -1,0 +1,27 @@
+from rest_framework import permissions, viewsets
+from rest_framework.pagination import CursorPagination
+
+from .models import Campaign
+from .serializers import CampaignSerializer
+
+
+class StandardCursorPagination(CursorPagination):
+    """
+    Standard cursor pagination for avoiding offset scanning.
+    """
+    page_size = 20
+    ordering = "-created_at"
+
+
+class CampaignViewSet(viewsets.ModelViewSet):
+    """
+    API endpoint that allows campaigns to be viewed or edited.
+    """
+    queryset = Campaign.objects.all()
+    serializer_class = CampaignSerializer
+    permission_classes = [permissions.IsAuthenticated]
+    pagination_class = StandardCursorPagination
+
+    def perform_create(self, serializer):
+        """Set the creator to the current user."""
+        serializer.save(created_by=self.request.user)

--- a/tosca_api/urls.py
+++ b/tosca_api/urls.py
@@ -22,5 +22,6 @@ from tosca_api.apps.authentication.views import KeycloakLogoutView
 urlpatterns = [
     path('admin/logout/', KeycloakLogoutView.as_view(), name='admin_logout'),  # Override Django admin logout
     path('', include('tosca_api.apps.authentication.urls')),  # ← Include authentication app URLs
+    path('api/v1/', include('tosca_api.apps.campaigns.urls')),
     path('admin/', admin.site.urls),
 ]


### PR DESCRIPTION
Implement Campaign API (CRUD) under /api/v1/campaigns/:
- Views: ModelViewSet with CursorPagination for performance.
- Security: Enforce authentication and automatic `created_by` assignment.
- Serializers: Standard ModelSerializer.
- Tests: Coverage for list, create (auth/unauth), and retrieve.

Closes #18

## Summary

- [x] Description of changes
- [x] Related issue link

## Testing

- [x] `uv run pytest`
- [x] Other (describe)
