### PR TITLE
feat(geostory): enhance API for read consumption

### DIFF
--- a/tosca_api/apps/core/schema.py
+++ b/tosca_api/apps/core/schema.py
@@ -1,0 +1,126 @@
+"""
+OpenAPI schema customization for drf-spectacular.
+
+This module provides hooks to add common error responses to all API endpoints.
+"""
+
+# Common error response schemas
+ERROR_RESPONSES = {
+    "400": {
+        "description": "Bad Request - Validation error or malformed request",
+        "content": {
+            "application/json": {
+                "schema": {
+                    "type": "object",
+                    "properties": {
+                        "detail": {"type": "string", "example": "Invalid input."},
+                        "field_errors": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                            },
+                            "example": {"title": ["This field is required."]},
+                        },
+                    },
+                }
+            }
+        },
+    },
+    "401": {
+        "description": "Unauthorized - Authentication credentials were not provided or are invalid",
+        "content": {
+            "application/json": {
+                "schema": {
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "type": "string",
+                            "example": "Authentication credentials were not provided.",
+                        }
+                    },
+                }
+            }
+        },
+    },
+    "403": {
+        "description": "Forbidden - You do not have permission to perform this action",
+        "content": {
+            "application/json": {
+                "schema": {
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "type": "string",
+                            "example": "You do not have permission to perform this action.",
+                        }
+                    },
+                }
+            }
+        },
+    },
+    "404": {
+        "description": "Not Found - The requested resource does not exist",
+        "content": {
+            "application/json": {
+                "schema": {
+                    "type": "object",
+                    "properties": {
+                        "detail": {"type": "string", "example": "Not found."}
+                    },
+                }
+            }
+        },
+    },
+    "500": {
+        "description": "Internal Server Error - An unexpected error occurred",
+        "content": {
+            "application/json": {
+                "schema": {
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "type": "string",
+                            "example": "A server error occurred.",
+                        }
+                    },
+                }
+            }
+        },
+    },
+}
+
+# Map HTTP methods to their typical error responses
+METHOD_RESPONSES = {
+    "get": ["401", "403", "404", "500"],
+    "post": ["400", "401", "403", "500"],
+    "put": ["400", "401", "403", "404", "500"],
+    "patch": ["400", "401", "403", "404", "500"],
+    "delete": ["401", "403", "404", "500"],
+}
+
+
+def add_common_responses(result, generator, request, public):
+    """
+    Postprocessing hook to add common error responses to all API endpoints.
+
+    This ensures ReDoc/Swagger shows 4xx and 5xx responses for all endpoints.
+    """
+    paths = result.get("paths", {})
+
+    for path, methods in paths.items():
+        for method, operation in methods.items():
+            if method not in METHOD_RESPONSES:
+                continue
+
+            # Get existing responses or create empty dict
+            responses = operation.get("responses", {})
+
+            # Add common error responses for this method
+            for status_code in METHOD_RESPONSES[method]:
+                if status_code not in responses:
+                    responses[status_code] = ERROR_RESPONSES[status_code]
+
+            operation["responses"] = responses
+
+    return result

--- a/tosca_api/apps/featurelinks/models.py
+++ b/tosca_api/apps/featurelinks/models.py
@@ -130,14 +130,15 @@ class FeatureLink(TimeStampedModel):
 
         # 4. Campaign boundary check
         # Both source and target must belong to the same campaign as this link
-        if self.source_object and hasattr(self.source_object, "campaign"):
-            if self.source_object.campaign != self.campaign:
+        # Note: Check campaign_id first to avoid RelatedObjectDoesNotExist on unsaved instances
+        if self.campaign_id and self.source_object and hasattr(self.source_object, "campaign"):
+            if self.source_object.campaign_id != self.campaign_id:
                 errors["source_object_id"] = (
                     "Source object must belong to the same campaign."
                 )
 
-        if self.target_object and hasattr(self.target_object, "campaign"):
-            if self.target_object.campaign != self.campaign:
+        if self.campaign_id and self.target_object and hasattr(self.target_object, "campaign"):
+            if self.target_object.campaign_id != self.campaign_id:
                 errors["target_object_id"] = (
                     "Target object must belong to the same campaign."
                 )

--- a/tosca_api/apps/geostories/serializers.py
+++ b/tosca_api/apps/geostories/serializers.py
@@ -1,12 +1,142 @@
+from django.contrib.contenttypes.models import ContentType
 from rest_framework import serializers
 
-from .models import GeoStory
+from tosca_api.apps.featurelinks.models import FeatureLink
+from tosca_api.apps.geocontext.models import GeoContext
+from tosca_api.apps.layerrefs.models import LayerRef
+
+from .models import GeoStory, GeoStoryLayer
+
+
+# =============================================================================
+# Nested Serializers (for Detail view)
+# =============================================================================
+
+
+class GeoContextSerializer(serializers.ModelSerializer):
+    """Serializer for GeoContext - exposes content for reading."""
+
+    class Meta:
+        model = GeoContext
+        fields = ["id", "content", "content_type"]
+        read_only_fields = ["id", "content", "content_type"]
+
+
+class LayerRefSerializer(serializers.ModelSerializer):
+    """Serializer for LayerRef - exposes layer name."""
+
+    class Meta:
+        model = LayerRef
+        fields = ["id", "layer_name"]
+        read_only_fields = ["id", "layer_name"]
+
+
+class GeoStoryLayerSerializer(serializers.ModelSerializer):
+    """
+    Serializer for GeoStoryLayer through model.
+    Includes layer details and display order.
+    """
+
+    id = serializers.UUIDField(source="layer.id", read_only=True)
+    layer_name = serializers.CharField(source="layer.layer_name", read_only=True)
+
+    class Meta:
+        model = GeoStoryLayer
+        fields = ["id", "layer_name", "display_order"]
+        read_only_fields = ["id", "layer_name", "display_order"]
+
+
+class FeatureLinkSerializer(serializers.ModelSerializer):
+    """
+    Serializer for outgoing FeatureLinks.
+    Shows target info for navigation.
+    """
+
+    target_type = serializers.SerializerMethodField()
+
+    class Meta:
+        model = FeatureLink
+        fields = ["id", "target_content_type", "target_object_id", "target_type", "link_type"]
+        read_only_fields = ["id", "target_content_type", "target_object_id", "target_type", "link_type"]
+
+    def get_target_type(self, obj) -> str:
+        """Return human-readable target type (e.g. 'geostory')."""
+        return obj.target_content_type.model
+
+
+# =============================================================================
+# GeoStory Serializers
+# =============================================================================
+
+
+class GeoStoryListSerializer(serializers.ModelSerializer):
+    """
+    Slim serializer for GeoStory list view.
+    Optimized for fast loading of story cards.
+    """
+
+    class Meta:
+        model = GeoStory
+        fields = [
+            "id",
+            "title",
+            "summary",
+            "campaign",
+            "created_at",
+        ]
+        read_only_fields = fields
+
+
+class GeoStoryDetailSerializer(serializers.ModelSerializer):
+    """
+    Full serializer for GeoStory detail view.
+    Includes nested context, layers, and feature links.
+    """
+
+    context = GeoContextSerializer(read_only=True)
+    layers = serializers.SerializerMethodField()
+    feature_links = serializers.SerializerMethodField()
+
+    class Meta:
+        model = GeoStory
+        fields = [
+            "id",
+            "title",
+            "summary",
+            "status",
+            "campaign",
+            "context",
+            "layers",
+            "feature_links",
+            "created_at",
+            "updated_at",
+        ]
+        read_only_fields = fields
+
+    def get_layers(self, obj) -> list:
+        """
+        Return layers ordered by display_order.
+        Uses the through model to get ordering.
+        """
+        through_qs = GeoStoryLayer.objects.filter(geostory=obj).select_related("layer")
+        return GeoStoryLayerSerializer(through_qs, many=True).data
+
+    def get_feature_links(self, obj) -> list:
+        """
+        Return outgoing feature links (where this story is the source).
+        """
+        geostory_ct = ContentType.objects.get_for_model(GeoStory)
+        links = FeatureLink.objects.filter(
+            source_content_type=geostory_ct,
+            source_object_id=obj.id,
+        ).select_related("target_content_type")
+        return FeatureLinkSerializer(links, many=True).data
 
 
 class GeoStorySerializer(serializers.ModelSerializer):
     """
     Serializer for GeoStory model.
-    Basic CRUD - no nested writes (context, layers) yet.
+    Used for create/update operations (Admin/Editor use).
     """
 
     class Meta:

--- a/tosca_api/apps/geostories/tests/test_api.py
+++ b/tosca_api/apps/geostories/tests/test_api.py
@@ -1,9 +1,13 @@
 import pytest
 from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
 from rest_framework.test import APIClient
 
 from tosca_api.apps.campaigns.models import Campaign
-from tosca_api.apps.geostories.models import GeoStory
+from tosca_api.apps.featurelinks.models import FeatureLink
+from tosca_api.apps.geocontext.models import GeoContext
+from tosca_api.apps.geostories.models import GeoStory, GeoStoryLayer
+from tosca_api.apps.layerrefs.models import LayerRef
 
 User = get_user_model()
 
@@ -19,17 +23,56 @@ def user():
 
 
 @pytest.fixture
+def staff_user():
+    return User.objects.create_user(username="staffuser", password="password", is_staff=True)
+
+
+@pytest.fixture
 def campaign(user):
     return Campaign.objects.create(title="Test Campaign", created_by=user)
 
 
 @pytest.fixture
-def geostory(user, campaign):
+def geocontext(user):
+    return GeoContext.objects.create(
+        content="This is the story content.",
+        content_type=GeoContext.ContentType.SIMPLE,
+        created_by=user,
+    )
+
+
+@pytest.fixture
+def layer_ref():
+    return LayerRef.objects.create(layer_name="workspace:test_layer")
+
+
+@pytest.fixture
+def geostory(user, campaign, geocontext):
+    """Create a published story with context."""
     return GeoStory.objects.create(
         title="Existing Story",
+        summary="Story summary",
+        status=GeoStory.Status.PUBLISHED,
+        campaign=campaign,
+        author=user,
+        context=geocontext,
+    )
+
+
+@pytest.fixture
+def draft_story(user, campaign):
+    """Create a draft story."""
+    return GeoStory.objects.create(
+        title="Draft Story",
+        status=GeoStory.Status.DRAFT,
         campaign=campaign,
         author=user,
     )
+
+
+# =============================================================================
+# Authentication Tests
+# =============================================================================
 
 
 @pytest.mark.django_db
@@ -39,13 +82,179 @@ def test_geostory_list_unauthenticated(api_client):
     assert response.status_code == 403
 
 
+# =============================================================================
+# List View Tests (Task 1.6)
+# =============================================================================
+
+
 @pytest.mark.django_db
-def test_geostory_list_authenticated(api_client, user, geostory):
-    """Test that authenticated users can list geostories."""
+def test_geostory_list_published_only(api_client, user, geostory, draft_story):
+    """Test that non-staff users only see published stories."""
     api_client.force_authenticate(user=user)
     response = api_client.get("/api/v1/stories/")
     assert response.status_code == 200
-    assert len(response.data["results"]) >= 1
+    
+    results = response.data["results"]
+    titles = [r["title"] for r in results]
+    
+    # Published story should be visible
+    assert "Existing Story" in titles
+    # Draft story should NOT be visible to non-staff
+    assert "Draft Story" not in titles
+
+
+@pytest.mark.django_db
+def test_geostory_list_staff_sees_all(api_client, staff_user, geostory, draft_story):
+    """Test that staff users can see all stories including drafts."""
+    api_client.force_authenticate(user=staff_user)
+    response = api_client.get("/api/v1/stories/")
+    assert response.status_code == 200
+    
+    results = response.data["results"]
+    titles = [r["title"] for r in results]
+    
+    # Staff should see both
+    assert "Existing Story" in titles
+    assert "Draft Story" in titles
+
+
+@pytest.mark.django_db
+def test_geostory_list_payload_fields(api_client, user, geostory):
+    """Test that list response has slim payload (required fields only)."""
+    api_client.force_authenticate(user=user)
+    response = api_client.get("/api/v1/stories/")
+    assert response.status_code == 200
+    
+    story_data = response.data["results"][0]
+    
+    # Required fields in list
+    assert "id" in story_data
+    assert "title" in story_data
+    assert "summary" in story_data
+    assert "campaign" in story_data
+    assert "created_at" in story_data
+    
+    # These should NOT be in list (detail only)
+    assert "context" not in story_data
+    assert "layers" not in story_data
+    assert "feature_links" not in story_data
+
+
+@pytest.mark.django_db
+def test_geostory_filter_by_campaign(api_client, user, campaign):
+    """Test filtering geostories by campaign_id."""
+    # Create published stories in the campaign
+    GeoStory.objects.create(
+        title="Story 1", campaign=campaign, author=user, status=GeoStory.Status.PUBLISHED
+    )
+    GeoStory.objects.create(
+        title="Story 2", campaign=campaign, author=user, status=GeoStory.Status.PUBLISHED
+    )
+
+    # Create another campaign with a story
+    other_campaign = Campaign.objects.create(title="Other Campaign", created_by=user)
+    GeoStory.objects.create(
+        title="Other Story", campaign=other_campaign, author=user, status=GeoStory.Status.PUBLISHED
+    )
+
+    api_client.force_authenticate(user=user)
+    response = api_client.get(f"/api/v1/stories/?campaign_id={campaign.id}")
+    assert response.status_code == 200
+    assert len(response.data["results"]) == 2
+
+
+# =============================================================================
+# Detail View Tests (Task 1.6)
+# =============================================================================
+
+
+@pytest.mark.django_db
+def test_geostory_detail_has_nested_context(api_client, user, geostory):
+    """Test that detail view returns nested context object (not just UUID)."""
+    api_client.force_authenticate(user=user)
+    response = api_client.get(f"/api/v1/stories/{geostory.id}/")
+    assert response.status_code == 200
+    
+    context = response.data["context"]
+    assert context is not None
+    assert "content" in context
+    assert context["content"] == "This is the story content."
+    assert "content_type" in context
+    assert context["content_type"] == "simple"
+
+
+@pytest.mark.django_db
+def test_geostory_detail_has_layers(api_client, user, geostory, layer_ref):
+    """Test that detail view returns layers with display_order."""
+    # Add layer to story
+    GeoStoryLayer.objects.create(geostory=geostory, layer=layer_ref, display_order=1)
+    
+    api_client.force_authenticate(user=user)
+    response = api_client.get(f"/api/v1/stories/{geostory.id}/")
+    assert response.status_code == 200
+    
+    layers = response.data["layers"]
+    assert len(layers) == 1
+    assert layers[0]["layer_name"] == "workspace:test_layer"
+    assert layers[0]["display_order"] == 1
+
+
+@pytest.mark.django_db
+def test_geostory_detail_has_feature_links(api_client, user, geostory, campaign):
+    """Test that detail view returns outgoing feature links."""
+    # Create another story to link to
+    target_story = GeoStory.objects.create(
+        title="Target Story",
+        campaign=campaign,
+        author=user,
+        status=GeoStory.Status.PUBLISHED,
+    )
+    
+    # Create a feature link
+    FeatureLink.objects.create(
+        campaign=campaign,
+        source_object=geostory,
+        target_object=target_story,
+        link_type=FeatureLink.LinkType.READ_MORE,
+        created_by=user,
+    )
+    
+    api_client.force_authenticate(user=user)
+    response = api_client.get(f"/api/v1/stories/{geostory.id}/")
+    assert response.status_code == 200
+    
+    links = response.data["feature_links"]
+    assert len(links) == 1
+    assert links[0]["target_object_id"] == str(target_story.id)
+    assert links[0]["link_type"] == "read_more"
+    assert links[0]["target_type"] == "geostory"
+
+
+@pytest.mark.django_db
+def test_geostory_detail_full_payload(api_client, user, geostory):
+    """Test that detail response has all required fields."""
+    api_client.force_authenticate(user=user)
+    response = api_client.get(f"/api/v1/stories/{geostory.id}/")
+    assert response.status_code == 200
+    
+    data = response.data
+    
+    # All required fields
+    assert "id" in data
+    assert "title" in data
+    assert "summary" in data
+    assert "status" in data
+    assert "campaign" in data
+    assert "context" in data
+    assert "layers" in data
+    assert "feature_links" in data
+    assert "created_at" in data
+    assert "updated_at" in data
+
+
+# =============================================================================
+# Create/Update/Delete Tests (existing functionality)
+# =============================================================================
 
 
 @pytest.mark.django_db
@@ -74,33 +283,6 @@ def test_geostory_create_requires_title(api_client, user, campaign):
     response = api_client.post("/api/v1/stories/", data)
     assert response.status_code == 400
     assert "title" in response.data
-
-
-@pytest.mark.django_db
-def test_geostory_filter_by_campaign(api_client, user, campaign):
-    """Test filtering geostories by campaign_id."""
-    # Create stories in the campaign
-    GeoStory.objects.create(title="Story 1", campaign=campaign, author=user)
-    GeoStory.objects.create(title="Story 2", campaign=campaign, author=user)
-    
-    # Create another campaign with a story
-    other_campaign = Campaign.objects.create(title="Other Campaign", created_by=user)
-    GeoStory.objects.create(title="Other Story", campaign=other_campaign, author=user)
-    
-    api_client.force_authenticate(user=user)
-    response = api_client.get(f"/api/v1/stories/?campaign_id={campaign.id}")
-    assert response.status_code == 200
-    assert len(response.data["results"]) == 2
-
-
-@pytest.mark.django_db
-def test_geostory_retrieve(api_client, user, geostory):
-    """Test retrieving a specific geostory."""
-    api_client.force_authenticate(user=user)
-    response = api_client.get(f"/api/v1/stories/{geostory.id}/")
-    assert response.status_code == 200
-    assert response.data["id"] == str(geostory.id)
-    assert response.data["title"] == "Existing Story"
 
 
 @pytest.mark.django_db

--- a/tosca_api/apps/geostories/views.py
+++ b/tosca_api/apps/geostories/views.py
@@ -2,32 +2,78 @@ from rest_framework import permissions, viewsets
 from rest_framework.pagination import CursorPagination
 
 from .models import GeoStory
-from .serializers import GeoStorySerializer
+from .serializers import (
+    GeoStoryDetailSerializer,
+    GeoStoryListSerializer,
+    GeoStorySerializer,
+)
 
 
 class GeoStoryCursorPagination(CursorPagination):
     """Cursor pagination for GeoStory list."""
+
     page_size = 20
     ordering = "-created_at"
 
 
 class GeoStoryViewSet(viewsets.ModelViewSet):
     """
-    API endpoint for GeoStory CRUD operations.
-    
-    Supports filtering by campaign_id query parameter.
+    API endpoint for GeoStory operations.
+
+    - **List**: Returns published stories with slim payload.
+    - **Retrieve**: Returns full story with nested context, layers, links.
+    - **Create/Update/Delete**: Requires authentication.
+
+    Supports filtering by `campaign_id` query parameter.
     """
+
     queryset = GeoStory.objects.all()
-    serializer_class = GeoStorySerializer
     permission_classes = [permissions.IsAuthenticated]
     pagination_class = GeoStoryCursorPagination
 
+    def get_serializer_class(self):
+        """
+        Return appropriate serializer based on action.
+        - list: GeoStoryListSerializer (slim)
+        - retrieve: GeoStoryDetailSerializer (full nested)
+        - create/update/delete: GeoStorySerializer (write capable)
+        """
+        if self.action == "list":
+            return GeoStoryListSerializer
+        if self.action == "retrieve":
+            return GeoStoryDetailSerializer
+        return GeoStorySerializer
+
     def get_queryset(self):
-        """Filter by campaign_id if provided."""
+        """
+        Filter queryset based on action and parameters.
+
+        - List view: Only published stories (unless user is staff).
+        - Filter by campaign_id if provided.
+        - Optimize queries with select_related/prefetch_related.
+        """
         queryset = super().get_queryset()
+
+        # Apply status filter for list action (public consumption)
+        if self.action == "list":
+            # Staff users can see all, public users see only published
+            if not self.request.user.is_staff:
+                queryset = queryset.filter(status=GeoStory.Status.PUBLISHED)
+
+        # Filter by campaign_id if provided
         campaign_id = self.request.query_params.get("campaign_id")
         if campaign_id:
             queryset = queryset.filter(campaign_id=campaign_id)
+
+        # Optimize queries for detail view
+        if self.action == "retrieve":
+            queryset = queryset.select_related("context", "campaign", "author")
+            queryset = queryset.prefetch_related("geostorylayer_set__layer")
+
+        # Optimize queries for list view
+        if self.action == "list":
+            queryset = queryset.select_related("campaign")
+
         return queryset
 
     def perform_create(self, serializer):

--- a/tosca_api/settings/base.py
+++ b/tosca_api/settings/base.py
@@ -164,6 +164,21 @@ SPECTACULAR_SETTINGS = {
     "DESCRIPTION": "Backend API for TOSCA Geospatial Platform",
     "VERSION": "0.1.0",
     "SERVE_INCLUDE_SCHEMA": False,
+    # Add common error responses to all endpoints
+    "APPEND_COMPONENTS": {
+        "securitySchemes": {
+            "bearerAuth": {
+                "type": "http",
+                "scheme": "bearer",
+                "bearerFormat": "JWT",
+            }
+        }
+    },
+    "SECURITY": [{"bearerAuth": []}],
+    # Postprocessing hooks to add common responses
+    "POSTPROCESSING_HOOKS": [
+        "tosca_api.apps.core.schema.add_common_responses",
+    ],
 }
 
 AUTHENTICATION_BACKENDS = [


### PR DESCRIPTION
Implements Task 1.6: Enhanced GeoStory API with improved serializers and documentation.

- Add dual serializer strategy for GeoStory API:
  - [GeoStoryListSerializer](.../apps/geostories/serializers.py:71:0-86:33): Slim payload for list views.
  - [GeoStoryDetailSerializer](.../apps/geostories/serializers.py:89:0-132:59): Full nested payload for detail views.
- Implement nested serializers for:
  - [GeoContext](.../apps/geocontext/models.py:20:0-64:37): Exposing content and type.
  - [LayerRef](.../apps/layerrefs/models.py:18:0-41:37): Exposing layer name.
  - [FeatureLink](.../apps/featurelinks/models.py:21:0-152:37): Exposing outgoing links.
- Update [GeoStoryViewSet](.../apps/geostories/views.py:18:0-80:49) to enforce `status='published'` filtering for public access.
- Optimize API queries using `select_related` and `prefetch_related`.
- Add common API error responses (4xx/5xx) to OpenAPI schema via `drf-spectacular` hook.
- Fix `RelatedObjectDoesNotExist` bug in [FeatureLink](.../apps/featurelinks/models.py:21:0-152:37) admin validation.
- Add comprehensive API tests covering payloads, filtering, and nested data.

Closes #40

## Summary

- [ ] Description of changes
- [ ] Related issue link

## Testing

- [ ] `uv run pytest`
- [ ] Other (describe)
