### PR TITLE
feat(events): add REST API endpoints with spatial filtering

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "python-json-logger>=4.0.0",
     "nh3>=0.3.2",
     "drf-spectacular>=0.29.0",
+    "djangorestframework-gis>=1.2.0",
 ]
 
 [project.optional-dependencies]

--- a/tosca_api/apps/events/serializers.py
+++ b/tosca_api/apps/events/serializers.py
@@ -1,0 +1,218 @@
+from django.contrib.gis.geos import GEOSGeometry, Polygon
+from django.utils import timezone
+from rest_framework import serializers
+from rest_framework_gis.serializers import GeoFeatureModelSerializer
+
+from tosca_api.apps.geocontext.models import GeoContext
+
+from .models import CalendarEvent, EventLayer
+
+
+# =============================================================================
+# Nested Serializers
+# =============================================================================
+
+
+class EventGeoContextSerializer(serializers.ModelSerializer):
+    """Nested serializer for event's GeoContext."""
+
+    class Meta:
+        model = GeoContext
+        fields = ["id", "content", "content_type"]
+        read_only_fields = fields
+
+
+class EventLayerSerializer(serializers.ModelSerializer):
+    """Serializer for EventLayer through model."""
+
+    id = serializers.UUIDField(source="layer.id", read_only=True)
+    layer_name = serializers.CharField(source="layer.layer_name", read_only=True)
+
+    class Meta:
+        model = EventLayer
+        fields = ["id", "layer_name", "display_order"]
+        read_only_fields = fields
+
+
+# =============================================================================
+# CalendarEvent Serializers
+# =============================================================================
+
+
+class CalendarEventListSerializer(serializers.ModelSerializer):
+    """
+    Slim serializer for calendar view (list).
+    Used when no spatial filtering is applied.
+    """
+
+    class Meta:
+        model = CalendarEvent
+        fields = [
+            "id",
+            "title",
+            "description",
+            "campaign",
+            "start_datetime",
+            "end_datetime",
+            "status",
+            "visibility",
+            "created_at",
+        ]
+        read_only_fields = fields
+
+
+class CalendarEventDetailSerializer(serializers.ModelSerializer):
+    """
+    Full serializer for event detail view.
+    Includes nested context and layers.
+    """
+
+    context = EventGeoContextSerializer(read_only=True)
+    layers = serializers.SerializerMethodField()
+
+    class Meta:
+        model = CalendarEvent
+        fields = [
+            "id",
+            "title",
+            "description",
+            "campaign",
+            "start_datetime",
+            "end_datetime",
+            "location",
+            "status",
+            "visibility",
+            "organizer",
+            "context",
+            "layers",
+            "created_at",
+            "updated_at",
+        ]
+        read_only_fields = fields
+
+    def get_layers(self, obj) -> list:
+        """Return layers ordered by display_order."""
+        through_qs = EventLayer.objects.filter(event=obj).select_related("layer")
+        return EventLayerSerializer(through_qs, many=True).data
+
+
+class CalendarEventGeoSerializer(GeoFeatureModelSerializer):
+    """
+    GeoJSON serializer for map view.
+    Returns events as GeoJSON FeatureCollection.
+    """
+
+    class Meta:
+        model = CalendarEvent
+        geo_field = "location"
+        fields = [
+            "id",
+            "title",
+            "description",
+            "campaign",
+            "start_datetime",
+            "end_datetime",
+            "status",
+            "visibility",
+        ]
+        read_only_fields = fields
+
+
+class CalendarEventCreateSerializer(serializers.ModelSerializer):
+    """Serializer for creating/updating events."""
+
+    class Meta:
+        model = CalendarEvent
+        fields = [
+            "id",
+            "title",
+            "description",
+            "campaign",
+            "start_datetime",
+            "end_datetime",
+            "location",
+            "status",
+            "visibility",
+            "organizer",
+            "context",
+        ]
+        read_only_fields = ["id", "organizer"]
+
+
+# =============================================================================
+# Spatial Filter Serializers
+# =============================================================================
+
+
+class BBoxSerializer(serializers.Serializer):
+    """Validates and parses bbox query parameter."""
+
+    bbox = serializers.CharField(required=False, allow_blank=True)
+
+    def validate_bbox(self, value):
+        """Parse bbox string into Polygon geometry."""
+        if not value:
+            return None
+
+        try:
+            parts = [float(x) for x in value.split(",")]
+            if len(parts) != 4:
+                raise ValueError("Must have 4 values")
+
+            min_lon, min_lat, max_lon, max_lat = parts
+
+            # Validate ranges
+            if not (-180 <= min_lon <= 180 and -180 <= max_lon <= 180):
+                raise ValueError("Longitude must be between -180 and 180")
+            if not (-90 <= min_lat <= 90 and -90 <= max_lat <= 90):
+                raise ValueError("Latitude must be between -90 and 90")
+            if min_lon >= max_lon or min_lat >= max_lat:
+                raise ValueError("Min must be less than max")
+
+            # Create polygon from bbox
+            return Polygon.from_bbox((min_lon, min_lat, max_lon, max_lat))
+
+        except (ValueError, TypeError) as e:
+            raise serializers.ValidationError(
+                f"Invalid bbox format. Expected: min_lon,min_lat,max_lon,max_lat. Error: {e}"
+            )
+
+
+class GeometryFilterSerializer(serializers.Serializer):
+    """
+    Validates geometry filter for POST /events/within/ endpoint.
+    Accepts GeoJSON geometry.
+    """
+
+    geometry = serializers.JSONField(required=True)
+    campaign_id = serializers.UUIDField(required=False)
+    include_past = serializers.BooleanField(default=False)
+    start_after = serializers.DateTimeField(required=False)
+    start_before = serializers.DateTimeField(required=False)
+    status = serializers.ChoiceField(
+        choices=CalendarEvent.Status.choices,
+        default=CalendarEvent.Status.PUBLISHED,
+    )
+
+    def validate_geometry(self, value):
+        """Parse GeoJSON into GEOS geometry."""
+        try:
+            import json
+
+            geojson_str = json.dumps(value)
+            geom = GEOSGeometry(geojson_str)
+
+            # Only allow Polygon or MultiPolygon
+            if geom.geom_type not in ("Polygon", "MultiPolygon"):
+                raise serializers.ValidationError(
+                    f"Geometry must be Polygon or MultiPolygon, got {geom.geom_type}"
+                )
+
+            # Ensure SRID is set
+            if geom.srid is None:
+                geom.srid = 4326
+
+            return geom
+
+        except Exception as e:
+            raise serializers.ValidationError(f"Invalid GeoJSON geometry: {e}")

--- a/tosca_api/apps/events/tests/test_api.py
+++ b/tosca_api/apps/events/tests/test_api.py
@@ -1,0 +1,395 @@
+from datetime import timedelta
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.contrib.gis.geos import Point
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from tosca_api.apps.campaigns.models import Campaign
+from tosca_api.apps.events.models import CalendarEvent
+
+User = get_user_model()
+
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+
+@pytest.fixture
+def user():
+    return User.objects.create_user(username="eventapiuser", password="password")
+
+
+@pytest.fixture
+def staff_user():
+    return User.objects.create_user(
+        username="staffuser", password="password", is_staff=True
+    )
+
+
+@pytest.fixture
+def campaign(user):
+    return Campaign.objects.create(title="API Test Campaign", created_by=user)
+
+
+@pytest.fixture
+def future_event(user, campaign):
+    """Create a future published event with location."""
+    return CalendarEvent.objects.create(
+        campaign=campaign,
+        title="Future Event",
+        start_datetime=timezone.now() + timedelta(days=1),
+        end_datetime=timezone.now() + timedelta(days=1, hours=2),
+        location=Point(10.0, 53.5, srid=4326),
+        organizer=user,
+        status=CalendarEvent.Status.PUBLISHED,
+    )
+
+
+@pytest.fixture
+def past_event(user, campaign):
+    """Create a past published event."""
+    return CalendarEvent.objects.create(
+        campaign=campaign,
+        title="Past Event",
+        start_datetime=timezone.now() - timedelta(days=2),
+        end_datetime=timezone.now() - timedelta(days=2, hours=-2),
+        location=Point(10.0, 53.5, srid=4326),
+        organizer=user,
+        status=CalendarEvent.Status.PUBLISHED,
+    )
+
+
+@pytest.fixture
+def event_without_location(user, campaign):
+    """Create an event without location."""
+    return CalendarEvent.objects.create(
+        campaign=campaign,
+        title="No Location Event",
+        start_datetime=timezone.now() + timedelta(days=3),
+        end_datetime=timezone.now() + timedelta(days=3, hours=1),
+        location=None,
+        organizer=user,
+        status=CalendarEvent.Status.PUBLISHED,
+    )
+
+
+@pytest.fixture
+def draft_event(user, campaign):
+    """Create a draft event."""
+    return CalendarEvent.objects.create(
+        campaign=campaign,
+        title="Draft Event",
+        start_datetime=timezone.now() + timedelta(days=5),
+        end_datetime=timezone.now() + timedelta(days=5, hours=1),
+        organizer=user,
+        status=CalendarEvent.Status.DRAFT,
+    )
+
+
+# =============================================================================
+# Authentication Tests
+# =============================================================================
+
+
+@pytest.mark.django_db
+def test_events_list_unauthenticated(api_client):
+    """Test that unauthenticated users cannot list events."""
+    response = api_client.get("/api/v1/events/")
+    assert response.status_code == 403
+
+
+# =============================================================================
+# Calendar View Tests (List)
+# =============================================================================
+
+
+@pytest.mark.django_db
+def test_events_list_returns_future_only_by_default(
+    api_client, user, future_event, past_event
+):
+    """Test that list returns only future events by default."""
+    api_client.force_authenticate(user=user)
+    response = api_client.get("/api/v1/events/")
+    assert response.status_code == 200
+
+    titles = [e["title"] for e in response.data["results"]]
+    assert "Future Event" in titles
+    assert "Past Event" not in titles
+
+
+@pytest.mark.django_db
+def test_events_list_include_past(api_client, user, future_event, past_event):
+    """Test that include_past=true returns past events."""
+    api_client.force_authenticate(user=user)
+    response = api_client.get("/api/v1/events/?include_past=true")
+    assert response.status_code == 200
+
+    titles = [e["title"] for e in response.data["results"]]
+    assert "Future Event" in titles
+    assert "Past Event" in titles
+
+
+@pytest.mark.django_db
+def test_events_list_includes_events_without_location(
+    api_client, user, future_event, event_without_location
+):
+    """Test that calendar view includes events without location."""
+    api_client.force_authenticate(user=user)
+    response = api_client.get("/api/v1/events/")
+    assert response.status_code == 200
+
+    titles = [e["title"] for e in response.data["results"]]
+    assert "Future Event" in titles
+    assert "No Location Event" in titles
+
+
+@pytest.mark.django_db
+def test_events_list_filters_by_published_status(
+    api_client, user, future_event, draft_event
+):
+    """Test that list returns only published events by default."""
+    api_client.force_authenticate(user=user)
+    response = api_client.get("/api/v1/events/")
+    assert response.status_code == 200
+
+    titles = [e["title"] for e in response.data["results"]]
+    assert "Future Event" in titles
+    assert "Draft Event" not in titles
+
+
+@pytest.mark.django_db
+def test_events_list_filter_by_campaign(api_client, user, campaign, future_event):
+    """Test filtering by campaign_id."""
+    # Create another campaign with event
+    other_campaign = Campaign.objects.create(title="Other Campaign", created_by=user)
+    CalendarEvent.objects.create(
+        campaign=other_campaign,
+        title="Other Event",
+        start_datetime=timezone.now() + timedelta(days=1),
+        end_datetime=timezone.now() + timedelta(days=1, hours=1),
+        organizer=user,
+        status=CalendarEvent.Status.PUBLISHED,
+    )
+
+    api_client.force_authenticate(user=user)
+    response = api_client.get(f"/api/v1/events/?campaign_id={campaign.id}")
+    assert response.status_code == 200
+
+    titles = [e["title"] for e in response.data["results"]]
+    assert "Future Event" in titles
+    assert "Other Event" not in titles
+
+
+# =============================================================================
+# Map View Tests (BBox)
+# =============================================================================
+
+
+@pytest.mark.django_db
+def test_events_bbox_returns_geojson(api_client, user, future_event):
+    """Test that bbox filter returns GeoJSON format."""
+    api_client.force_authenticate(user=user)
+    response = api_client.get("/api/v1/events/?bbox=9.0,53.0,11.0,54.0")
+    assert response.status_code == 200
+
+    # GeoJSON FeatureCollection structure
+    assert response.data["type"] == "FeatureCollection"
+    assert "features" in response.data
+    assert len(response.data["features"]) >= 1
+
+    feature = response.data["features"][0]
+    assert feature["type"] == "Feature"
+    assert "geometry" in feature
+    assert "properties" in feature
+    assert feature["properties"]["title"] == "Future Event"
+
+
+@pytest.mark.django_db
+def test_events_bbox_excludes_events_without_location(
+    api_client, user, future_event, event_without_location
+):
+    """Test that bbox filter excludes events without location."""
+    api_client.force_authenticate(user=user)
+    response = api_client.get("/api/v1/events/?bbox=9.0,53.0,11.0,54.0")
+    assert response.status_code == 200
+
+    titles = [f["properties"]["title"] for f in response.data["features"]]
+    assert "Future Event" in titles
+    assert "No Location Event" not in titles
+
+
+@pytest.mark.django_db
+def test_events_bbox_excludes_events_outside_bbox(api_client, user, campaign):
+    """Test that bbox filter excludes events outside the bounding box."""
+    # Create event in Hamburg
+    CalendarEvent.objects.create(
+        campaign=campaign,
+        title="Hamburg Event",
+        start_datetime=timezone.now() + timedelta(days=1),
+        end_datetime=timezone.now() + timedelta(days=1, hours=1),
+        location=Point(10.0, 53.5, srid=4326),
+        organizer=user,
+        status=CalendarEvent.Status.PUBLISHED,
+    )
+
+    # Create event in Berlin (outside Hamburg bbox)
+    CalendarEvent.objects.create(
+        campaign=campaign,
+        title="Berlin Event",
+        start_datetime=timezone.now() + timedelta(days=1),
+        end_datetime=timezone.now() + timedelta(days=1, hours=1),
+        location=Point(13.4, 52.5, srid=4326),  # Berlin
+        organizer=user,
+        status=CalendarEvent.Status.PUBLISHED,
+    )
+
+    api_client.force_authenticate(user=user)
+    # Hamburg area bbox
+    response = api_client.get("/api/v1/events/?bbox=9.5,53.0,10.5,54.0")
+    assert response.status_code == 200
+
+    titles = [f["properties"]["title"] for f in response.data["features"]]
+    assert "Hamburg Event" in titles
+    assert "Berlin Event" not in titles
+
+
+@pytest.mark.django_db
+def test_events_bbox_invalid_format(api_client, user):
+    """Test that invalid bbox returns 400."""
+    api_client.force_authenticate(user=user)
+    response = api_client.get("/api/v1/events/?bbox=invalid")
+    assert response.status_code == 400
+
+
+# =============================================================================
+# Map View Tests (Polygon - POST /within/)
+# =============================================================================
+
+
+@pytest.mark.django_db
+def test_events_within_polygon(api_client, user, campaign):
+    """Test POST /events/within/ with polygon filter."""
+    # Create event inside polygon
+    CalendarEvent.objects.create(
+        campaign=campaign,
+        title="Inside Event",
+        start_datetime=timezone.now() + timedelta(days=1),
+        end_datetime=timezone.now() + timedelta(days=1, hours=1),
+        location=Point(10.0, 53.5, srid=4326),
+        organizer=user,
+        status=CalendarEvent.Status.PUBLISHED,
+    )
+
+    # Create event outside polygon
+    CalendarEvent.objects.create(
+        campaign=campaign,
+        title="Outside Event",
+        start_datetime=timezone.now() + timedelta(days=1),
+        end_datetime=timezone.now() + timedelta(days=1, hours=1),
+        location=Point(5.0, 50.0, srid=4326),
+        organizer=user,
+        status=CalendarEvent.Status.PUBLISHED,
+    )
+
+    api_client.force_authenticate(user=user)
+    response = api_client.post(
+        "/api/v1/events/within/",
+        {
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [[9.0, 53.0], [11.0, 53.0], [11.0, 54.0], [9.0, 54.0], [9.0, 53.0]]
+                ],
+            }
+        },
+        format="json",
+    )
+    assert response.status_code == 200
+    assert response.data["type"] == "FeatureCollection"
+
+    titles = [f["properties"]["title"] for f in response.data["features"]]
+    assert "Inside Event" in titles
+    assert "Outside Event" not in titles
+
+
+@pytest.mark.django_db
+def test_events_within_rejects_non_polygon(api_client, user):
+    """Test that within/ rejects Point geometry."""
+    api_client.force_authenticate(user=user)
+    response = api_client.post(
+        "/api/v1/events/within/",
+        {
+            "geometry": {
+                "type": "Point",
+                "coordinates": [10.0, 53.5],
+            }
+        },
+        format="json",
+    )
+    assert response.status_code == 400
+    assert "Polygon" in str(response.data)
+
+
+@pytest.mark.django_db
+def test_events_within_invalid_geojson(api_client, user):
+    """Test that invalid GeoJSON returns 400."""
+    api_client.force_authenticate(user=user)
+    response = api_client.post(
+        "/api/v1/events/within/",
+        {"geometry": {"type": "invalid", "coordinates": []}},
+        format="json",
+    )
+    assert response.status_code == 400
+
+
+# =============================================================================
+# Detail View Tests
+# =============================================================================
+
+
+@pytest.mark.django_db
+def test_events_retrieve_detail(api_client, user, future_event):
+    """Test retrieving a single event returns full details."""
+    api_client.force_authenticate(user=user)
+    response = api_client.get(f"/api/v1/events/{future_event.id}/")
+    assert response.status_code == 200
+
+    assert response.data["id"] == str(future_event.id)
+    assert response.data["title"] == "Future Event"
+    assert "layers" in response.data
+    assert "context" in response.data
+
+
+# =============================================================================
+# Create/Update/Delete Tests
+# =============================================================================
+
+
+@pytest.mark.django_db
+def test_events_create(api_client, user, campaign):
+    """Test creating a new event."""
+    api_client.force_authenticate(user=user)
+    data = {
+        "title": "New Event",
+        "description": "Test description",
+        "campaign": str(campaign.id),
+        "start_datetime": (timezone.now() + timedelta(days=1)).isoformat(),
+        "end_datetime": (timezone.now() + timedelta(days=1, hours=2)).isoformat(),
+        "status": "draft",
+    }
+    response = api_client.post("/api/v1/events/", data, format="json")
+    assert response.status_code == 201
+    assert response.data["title"] == "New Event"
+    assert response.data["organizer"] == user.id
+
+
+@pytest.mark.django_db
+def test_events_delete(api_client, user, future_event):
+    """Test deleting an event."""
+    api_client.force_authenticate(user=user)
+    response = api_client.delete(f"/api/v1/events/{future_event.id}/")
+    assert response.status_code == 204
+    assert not CalendarEvent.objects.filter(id=future_event.id).exists()

--- a/tosca_api/apps/events/urls.py
+++ b/tosca_api/apps/events/urls.py
@@ -1,0 +1,11 @@
+from django.urls import include, path
+from rest_framework.routers import DefaultRouter
+
+from .views import CalendarEventViewSet
+
+router = DefaultRouter()
+router.register(r"events", CalendarEventViewSet, basename="event")
+
+urlpatterns = [
+    path("", include(router.urls)),
+]

--- a/tosca_api/apps/events/views.py
+++ b/tosca_api/apps/events/views.py
@@ -1,0 +1,203 @@
+from django.utils import timezone
+from rest_framework import permissions, status, viewsets
+from rest_framework.decorators import action
+from rest_framework.pagination import CursorPagination
+from rest_framework.response import Response
+
+from .models import CalendarEvent
+from .serializers import (
+    BBoxSerializer,
+    CalendarEventCreateSerializer,
+    CalendarEventDetailSerializer,
+    CalendarEventGeoSerializer,
+    CalendarEventListSerializer,
+    GeometryFilterSerializer,
+)
+
+
+class EventCursorPagination(CursorPagination):
+    """Cursor pagination for events, ordered by start_datetime."""
+
+    page_size = 20
+    ordering = "start_datetime"
+
+
+class CalendarEventViewSet(viewsets.ModelViewSet):
+    """
+    API endpoint for CalendarEvent operations.
+
+    ## List Endpoints
+
+    ### Calendar View (default)
+    ```
+    GET /api/v1/events/
+    ```
+    Returns all events (with or without location) as JSON.
+    By default, only future events are returned.
+
+    **Query Parameters:**
+    - `campaign_id`: Filter by campaign UUID
+    - `include_past`: Set to `true` to include past events (default: false)
+    - `start_after`: Filter events starting after this datetime
+    - `start_before`: Filter events starting before this datetime
+    - `status`: Filter by status (default: published)
+
+    ### Map View (bbox)
+    ```
+    GET /api/v1/events/?bbox=min_lon,min_lat,max_lon,max_lat
+    ```
+    Returns events WITH location inside bounding box as GeoJSON FeatureCollection.
+
+    ### Map View (polygon) - POST
+    ```
+    POST /api/v1/events/within/
+    {
+        "geometry": {GeoJSON Polygon/MultiPolygon},
+        "campaign_id": "uuid",
+        "include_past": false
+    }
+    ```
+    Returns events WITH location inside geometry as GeoJSON FeatureCollection.
+    """
+
+    queryset = CalendarEvent.objects.all()
+    permission_classes = [permissions.IsAuthenticated]
+    pagination_class = EventCursorPagination
+
+    def get_serializer_class(self):
+        """Return appropriate serializer based on action and request."""
+        if self.action == "list":
+            # Check if spatial filter is applied
+            if self._is_spatial_request():
+                return CalendarEventGeoSerializer
+            return CalendarEventListSerializer
+        if self.action == "retrieve":
+            return CalendarEventDetailSerializer
+        if self.action == "within":
+            return CalendarEventGeoSerializer
+        return CalendarEventCreateSerializer
+
+    def _is_spatial_request(self) -> bool:
+        """Check if request has bbox parameter."""
+        return bool(self.request.query_params.get("bbox"))
+
+    def get_queryset(self):
+        """
+        Filter queryset based on request parameters.
+
+        - Default: Only upcoming events (start_datetime >= now)
+        - Spatial requests (bbox): Only events with location
+        - Status filtering
+        - Campaign filtering
+        """
+        queryset = super().get_queryset()
+
+        # Status filter (default: published for list)
+        if self.action in ("list", "within"):
+            status_param = self.request.query_params.get("status", "published")
+            queryset = queryset.filter(status=status_param)
+
+        # Campaign filter
+        campaign_id = self.request.query_params.get("campaign_id")
+        if campaign_id:
+            queryset = queryset.filter(campaign_id=campaign_id)
+
+        # Time filters
+        include_past = self.request.query_params.get("include_past", "").lower() == "true"
+        if not include_past and self.action == "list":
+            queryset = queryset.filter(start_datetime__gte=timezone.now())
+
+        start_after = self.request.query_params.get("start_after")
+        if start_after:
+            queryset = queryset.filter(start_datetime__gte=start_after)
+
+        start_before = self.request.query_params.get("start_before")
+        if start_before:
+            queryset = queryset.filter(start_datetime__lte=start_before)
+
+        # Spatial filter (bbox)
+        if self._is_spatial_request():
+            bbox_serializer = BBoxSerializer(data=self.request.query_params)
+            bbox_serializer.is_valid(raise_exception=True)
+            bbox_geom = bbox_serializer.validated_data.get("bbox")
+
+            if bbox_geom:
+                # Only events with location, within bbox
+                queryset = queryset.filter(
+                    location__isnull=False,
+                    location__within=bbox_geom,
+                )
+
+        # Optimize queries
+        if self.action == "retrieve":
+            queryset = queryset.select_related("context", "campaign", "organizer")
+            queryset = queryset.prefetch_related("eventlayer_set__layer")
+        else:
+            queryset = queryset.select_related("campaign")
+
+        return queryset
+
+    def perform_create(self, serializer):
+        """Set the organizer to the current user."""
+        serializer.save(organizer=self.request.user)
+
+    def list(self, request, *args, **kwargs):
+        """
+        Override list to return GeoJSON FeatureCollection for spatial requests.
+        Non-spatial requests use standard paginated response.
+        """
+        if self._is_spatial_request():
+            queryset = self.filter_queryset(self.get_queryset())
+            serializer = self.get_serializer(queryset, many=True)
+            return Response(serializer.data)
+        return super().list(request, *args, **kwargs)
+
+    @action(detail=False, methods=["post"], url_path="within")
+    def within(self, request):
+        """
+        Filter events within a given geometry (Polygon/MultiPolygon).
+
+        Returns GeoJSON FeatureCollection of events with location inside the geometry.
+
+        Request body:
+        {
+            "geometry": {GeoJSON Polygon or MultiPolygon},
+            "campaign_id": "uuid (optional)",
+            "include_past": false,
+            "start_after": "datetime (optional)",
+            "start_before": "datetime (optional)",
+            "status": "published"
+        }
+        """
+        # Validate input
+        filter_serializer = GeometryFilterSerializer(data=request.data)
+        filter_serializer.is_valid(raise_exception=True)
+        data = filter_serializer.validated_data
+
+        # Build queryset
+        queryset = CalendarEvent.objects.filter(
+            location__isnull=False,
+            location__within=data["geometry"],
+            status=data.get("status", CalendarEvent.Status.PUBLISHED),
+        )
+
+        # Campaign filter
+        if data.get("campaign_id"):
+            queryset = queryset.filter(campaign_id=data["campaign_id"])
+
+        # Time filters
+        if not data.get("include_past", False):
+            queryset = queryset.filter(start_datetime__gte=timezone.now())
+
+        if data.get("start_after"):
+            queryset = queryset.filter(start_datetime__gte=data["start_after"])
+
+        if data.get("start_before"):
+            queryset = queryset.filter(start_datetime__lte=data["start_before"])
+
+        # Order by start_datetime
+        queryset = queryset.order_by("start_datetime").select_related("campaign")
+
+        # Serialize as GeoJSON
+        serializer = CalendarEventGeoSerializer(queryset, many=True)
+        return Response(serializer.data)

--- a/tosca_api/settings/base.py
+++ b/tosca_api/settings/base.py
@@ -55,6 +55,7 @@ INSTALLED_APPS = [
     "tosca_api.apps.authentication",  # Override allauth templates
     # Third-party
     "rest_framework",
+    "rest_framework_gis",
     "drf_spectacular",
     "rest_framework.authtoken",
     "allauth",

--- a/tosca_api/urls.py
+++ b/tosca_api/urls.py
@@ -34,5 +34,6 @@ urlpatterns = [
     path('', include('tosca_api.apps.authentication.urls')),  # ← Include authentication app URLs
     path('api/v1/', include('tosca_api.apps.campaigns.urls')),
     path('api/v1/', include('tosca_api.apps.geostories.urls')),
+    path('api/v1/', include('tosca_api.apps.events.urls')),
     path('admin/', admin.site.urls),
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -298,6 +298,18 @@ wheels = [
 ]
 
 [[package]]
+name = "django-filter"
+version = "25.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/40/c702a6fe8cccac9bf426b55724ebdf57d10a132bae80a17691d0cf0b9bac/django_filter-25.1.tar.gz", hash = "sha256:1ec9eef48fa8da1c0ac9b411744b16c3f4c31176c867886e4c48da369c407153", size = 143021, upload-time = "2025-02-14T16:30:53.238Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/a6/70dcd68537c434ba7cb9277d403c5c829caf04f35baf5eb9458be251e382/django_filter-25.1-py3-none-any.whl", hash = "sha256:4fa48677cf5857b9b1347fed23e355ea792464e0fe07244d1fdfb8a806215b80", size = 94114, upload-time = "2025-02-14T16:30:50.435Z" },
+]
+
+[[package]]
 name = "djangorestframework"
 version = "3.16.1"
 source = { registry = "https://pypi.org/simple" }
@@ -307,6 +319,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8a/95/5376fe618646fde6899b3cdc85fd959716bb67542e273a76a80d9f326f27/djangorestframework-3.16.1.tar.gz", hash = "sha256:166809528b1aced0a17dc66c24492af18049f2c9420dbd0be29422029cfc3ff7", size = 1089735, upload-time = "2025-08-06T17:50:53.251Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/ce/bf8b9d3f415be4ac5588545b5fcdbbb841977db1c1d923f7568eeabe1689/djangorestframework-3.16.1-py3-none-any.whl", hash = "sha256:33a59f47fb9c85ede792cbf88bde71893bcda0667bc573f784649521f1102cec", size = 1080442, upload-time = "2025-08-06T17:50:50.667Z" },
+]
+
+[[package]]
+name = "djangorestframework-gis"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+    { name = "django-filter" },
+    { name = "djangorestframework" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/fb/36b4f5d9d0fccdb17ae620c580d4b340a7b3643830e49b8cc5d8fc1eb1ee/djangorestframework_gis-1.2.0.tar.gz", hash = "sha256:702ba9ad44173b7cc70e48c6c84da48c28f6f82612cc901a77fdb54c5c57c971", size = 50983, upload-time = "2025-06-02T19:22:41.411Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/86/b7e85e372ecc97dc1344785f82dc0c51c2b2c8b1d2b8660d3d8752fd1b3c/djangorestframework_gis-1.2.0-py2.py3-none-any.whl", hash = "sha256:3924651b2f6dcb5a64b30df9692577af548a04725b0c2c36cbc385f7c50fc80a", size = 22254, upload-time = "2025-06-02T19:22:39.214Z" },
 ]
 
 [[package]]
@@ -942,6 +968,7 @@ dependencies = [
     { name = "django-allauth" },
     { name = "django-environ" },
     { name = "djangorestframework" },
+    { name = "djangorestframework-gis" },
     { name = "drf-spectacular" },
     { name = "nh3" },
     { name = "psycopg", extra = ["binary"] },
@@ -973,6 +1000,7 @@ requires-dist = [
     { name = "django-allauth", specifier = ">=65.13.1" },
     { name = "django-environ", specifier = ">=0.11.0" },
     { name = "djangorestframework", specifier = ">=3.15.0" },
+    { name = "djangorestframework-gis", specifier = ">=1.2.0" },
     { name = "drf-spectacular", specifier = ">=0.29.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11.0" },
     { name = "nh3", specifier = ">=0.3.2" },


### PR DESCRIPTION
Implement CalendarEvent API endpoints:
- GET /api/v1/events/ - Calendar view (paginated JSON)
- GET /api/v1/events/?bbox=... - Map view (GeoJSON FeatureCollection)
- POST /api/v1/events/within/ - Polygon filter (GeoJSON)
- GET/PATCH/DELETE /api/v1/events/{id}/ - Detail/Update/Delete

Features:
- Default: future events only (include_past=false)
- Time filters: start_after, start_before, include_past
- Spatial filters: bbox (GET query param), polygon (POST body)
- Map views return only events WITH location
- Calendar view includes all events (with or without location)
- GeoJSON FeatureCollection output for spatial queries

Dependencies:
- Added djangorestframework-gis for GeoJSON serialization
- Added rest_framework_gis to INSTALLED_APPS

16 API tests passing.

Closes #44

## Summary

- [x] Description of changes
- [x] Related issue link

## Testing

- [x] `uv run pytest`
- [x] Other (describe)
