### PR TITLE
feat(feedback): add REST API endpoints

### DIFF
--- a/tosca_api/apps/feedback/serializers.py
+++ b/tosca_api/apps/feedback/serializers.py
@@ -1,0 +1,141 @@
+from rest_framework import serializers
+from rest_framework_gis.fields import GeometryField
+from tosca_api.apps.geocontext.models import GeoContext
+
+from .models import FeedbackLayer, FeedbackSubmission, GeoFeedback
+
+
+class FeedbackGeoContextSerializer(serializers.ModelSerializer):
+    """Nested serializer for feedback's GeoContext."""
+
+    class Meta:
+        model = GeoContext
+        fields = ["id", "content", "content_type"]
+        read_only_fields = fields
+
+
+class FeedbackLayerSerializer(serializers.ModelSerializer):
+    """Serializer for FeedbackLayer through model."""
+
+    id = serializers.UUIDField(source="layer.id", read_only=True)
+    layer_name = serializers.CharField(source="layer.layer_name", read_only=True)
+
+    class Meta:
+        model = FeedbackLayer
+        fields = ["id", "layer_name", "display_order"]
+        read_only_fields = fields
+
+
+class GeoFeedbackListSerializer(serializers.ModelSerializer):
+    """Slim serializer for listing feedback campaigns."""
+
+    class Meta:
+        model = GeoFeedback
+        fields = [
+            "id",
+            "title",
+            "description",
+            "campaign",
+            "status",
+            "visibility",
+            "rating_enabled",
+            "form_enabled",
+            "allow_drawings",
+            "created_at",
+        ]
+
+
+class GeoFeedbackDetailSerializer(serializers.ModelSerializer):
+    """
+    Full serializer for reading feedback details.
+    Includes form references and layers.
+    """
+
+    context = FeedbackGeoContextSerializer(read_only=True)
+    layers = serializers.SerializerMethodField()
+    custom_form_slug = serializers.CharField(
+        source="custom_form.slug", read_only=True, allow_null=True
+    )
+
+    class Meta:
+        model = GeoFeedback
+        fields = [
+            "id",
+            "title",
+            "description",
+            "campaign",
+            "context",
+            "custom_form",
+            "custom_form_slug",
+            "rating_enabled",
+            "form_enabled",
+            "allow_drawings",
+            "status",
+            "visibility",
+            "created_by",
+            "layers",
+            "created_at",
+            "updated_at",
+        ]
+        read_only_fields = fields
+
+    def get_layers(self, obj) -> list:
+        """Return layers ordered by display_order."""
+        through_qs = FeedbackLayer.objects.filter(feedback=obj).select_related("layer")
+        return FeedbackLayerSerializer(through_qs, many=True).data
+
+
+class GeoFeedbackCreateUpdateSerializer(serializers.ModelSerializer):
+    """Write serializer for creating or updating GeoFeedback."""
+
+    class Meta:
+        model = GeoFeedback
+        fields = [
+            "id",
+            "title",
+            "description",
+            "campaign",
+            "context",
+            "custom_form",
+            "rating_enabled",
+            "form_enabled",
+            "allow_drawings",
+            "status",
+            "visibility",
+        ]
+        read_only_fields = ["id", "created_by"]
+
+    def validate(self, attrs):
+        # We manually trigger model clean inside ModelViewSet perform_create
+        # but DRF validate() can also do some basic validation here if we want
+        return super().validate(attrs)
+
+
+
+class FeedbackSubmissionSerializer(serializers.ModelSerializer):
+    """
+    Serializer for taking citizen submissions. 
+    It supports creating geometry via GeoJSON.
+    """
+
+    form_data = serializers.JSONField(required=False, allow_null=True)
+    geometry = GeometryField(required=False, allow_null=True)
+
+    class Meta:
+        model = FeedbackSubmission
+        fields = [
+            "id",
+            "feedback",
+            "submitted_by",
+            "rating",
+            "form_data",
+            "geometry",
+            "is_anonymized",
+            "created_at",
+        ]
+        read_only_fields = ["id", "feedback", "submitted_by", "created_at"]
+
+    def validate(self, attrs):
+        # Validation dependent on feedback is done in clean() or in the view.
+        # But we can also check it here if we inject self.context['feedback'] 
+        return super().validate(attrs)

--- a/tosca_api/apps/feedback/tests/test_api.py
+++ b/tosca_api/apps/feedback/tests/test_api.py
@@ -1,0 +1,240 @@
+import pytest
+from django.contrib.auth import get_user_model
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from formbuilder.models import CustomForm
+from tosca_api.apps.campaigns.models import Campaign
+from tosca_api.apps.feedback.models import GeoFeedback
+
+User = get_user_model()
+
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+
+@pytest.fixture
+def admin_user():
+    return User.objects.create_superuser(username="admin", password="password")
+
+
+@pytest.fixture
+def regular_user():
+    return User.objects.create_user(username="user", password="password")
+
+
+@pytest.fixture
+def admin_client(admin_user):
+    client = APIClient()
+    client.force_authenticate(user=admin_user)
+    return client
+
+
+@pytest.fixture
+def user_client(regular_user):
+    client = APIClient()
+    client.force_authenticate(user=regular_user)
+    return client
+
+
+@pytest.fixture
+def campaign(admin_user):
+    return Campaign.objects.create(title="Test Campaign", created_by=admin_user)
+
+
+@pytest.fixture
+def custom_form():
+    return CustomForm.objects.create(
+        name="Test Form",
+        slug="test-form",
+        status=CustomForm.FormStatus.PUBLISHED,
+    )
+
+
+@pytest.fixture
+def feedback(admin_user, campaign, custom_form):
+    """Fully enabled public/published feedback."""
+    return GeoFeedback.objects.create(
+        campaign=campaign,
+        title="Full Feedback",
+        created_by=admin_user,
+        custom_form=custom_form,
+        rating_enabled=True,
+        form_enabled=True,
+        allow_drawings=True,
+        status=GeoFeedback.Status.PUBLISHED,
+        visibility=GeoFeedback.Visibility.PUBLIC,
+    )
+
+
+@pytest.fixture
+def feedback_no_drawings(admin_user, campaign):
+    """Published but no drawings allowed."""
+    return GeoFeedback.objects.create(
+        campaign=campaign,
+        title="No Drawings Feedback",
+        created_by=admin_user,
+        rating_enabled=True,
+        form_enabled=False,
+        allow_drawings=False,
+        status=GeoFeedback.Status.PUBLISHED,
+        visibility=GeoFeedback.Visibility.PUBLIC,
+    )
+
+@pytest.fixture
+def feedback_draft_private(admin_user, campaign):
+    """Draft and private feedback."""
+    return GeoFeedback.objects.create(
+        campaign=campaign,
+        title="Draft Feedback",
+        created_by=admin_user,
+        rating_enabled=True,
+        form_enabled=False,
+        status=GeoFeedback.Status.DRAFT,
+        visibility=GeoFeedback.Visibility.PRIVATE,
+    )
+
+
+@pytest.mark.django_db
+class TestGeoFeedbackAPI:
+    """Test GeoFeedback list and retrieval."""
+
+    def test_list_feedbacks_public(self, api_client, feedback, feedback_draft_private):
+        """Anonymous users should only see published/public feedbacks."""
+        url = "/api/v1/feedback/"
+        resp = api_client.get(url)
+        assert resp.status_code == status.HTTP_200_OK
+        results = resp.data["results"]
+        # Standard cursor pagination returns 'results' list
+        assert len(results) == 1
+        assert results[0]["id"] == str(feedback.id)
+
+    def test_list_feedbacks_admin(self, admin_client, feedback, feedback_draft_private):
+        """Admins should see all feedbacks."""
+        url = "/api/v1/feedback/"
+        resp = admin_client.get(url)
+        assert resp.status_code == status.HTTP_200_OK
+        assert len(resp.data["results"]) == 2
+
+    def test_retrieve_feedback_includes_slug(self, api_client, feedback):
+        """Wait, detail read should return custom_form_slug."""
+        url = f"/api/v1/feedback/{feedback.id}/"
+        resp = api_client.get(url)
+        assert resp.status_code == status.HTTP_200_OK
+        assert resp.data["custom_form_slug"] == "test-form"
+        assert resp.data["rating_enabled"] is True
+
+    def test_anonymous_create_fails(self, api_client, campaign):
+        """Anonymous user cannot create feedback."""
+        url = "/api/v1/feedback/"
+        data = {
+            "title": "New Feedback",
+            "campaign": str(campaign.id),
+            "rating_enabled": True,
+        }
+        resp = api_client.post(url, data)
+        assert resp.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_admin_create_feedback(self, admin_client, campaign):
+        """Admin user can create feedback."""
+        url = "/api/v1/feedback/"
+        data = {
+            "title": "New Feedback",
+            "campaign": str(campaign.id),
+            "rating_enabled": True,
+            "form_enabled": False,
+        }
+        resp = admin_client.post(url, data)
+        assert resp.status_code == status.HTTP_201_CREATED
+        assert resp.data["title"] == "New Feedback"
+
+
+@pytest.mark.django_db
+class TestFeedbackSubmissionAPI:
+    """Test POST /api/v1/feedback/{id}/submit/ action."""
+
+    def test_submit_feedback_with_rating_and_form(self, api_client, feedback):
+        """Anonymous submit with both rating and form matches criteria."""
+        url = f"/api/v1/feedback/{feedback.id}/submit/"
+        resp = api_client.post(
+            url,
+            {
+                "rating": 5,
+                "form_data": {"test_field": "test_answer"}
+            },
+            format="json"
+        )
+        assert resp.status_code == status.HTTP_201_CREATED
+        assert resp.data["rating"] == 5
+        assert resp.data["form_data"]["test_field"] == "test_answer"
+        assert resp.data["submitted_by"] is None
+
+    def test_submit_fails_when_missing_required_rating(self, api_client, feedback):
+        """Should fail if rating_enabled=True but rating is missing."""
+        url = f"/api/v1/feedback/{feedback.id}/submit/"
+        resp = api_client.post(
+            url,
+            {"form_data": {"comment": "Hi"}},
+            format="json"
+        )
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+        assert "rating" in resp.data
+
+    def test_submit_fails_when_missing_required_form(self, api_client, feedback):
+        """Should fail if form_enabled=True but form_data is missing."""
+        url = f"/api/v1/feedback/{feedback.id}/submit/"
+        resp = api_client.post(
+            url,
+            {"rating": 3},
+            format="json"
+        )
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+        assert "form_data" in resp.data
+
+    def test_submit_authenticated_user(self, user_client, regular_user, feedback):
+        """Authenticated user's ID should be saved as submitted_by."""
+        url = f"/api/v1/feedback/{feedback.id}/submit/"
+        resp = user_client.post(
+            url,
+            {"rating": 4, "form_data": {"q": "a"}},
+            format="json"
+        )
+        assert resp.status_code == status.HTTP_201_CREATED
+        assert resp.data["submitted_by"] == regular_user.id
+
+    def test_submit_with_geometry(self, api_client, feedback):
+        """Should parse GeoJSON if allow_drawings=True."""
+        url = f"/api/v1/feedback/{feedback.id}/submit/"
+        resp = api_client.post(
+            url,
+            {
+                "rating": 5,
+                "form_data": {"any": "val"},
+                "geometry": {
+                    "type": "Point",
+                    "coordinates": [10.0, 53.5]
+                }
+            },
+            format="json"
+        )
+        assert resp.status_code == status.HTTP_201_CREATED
+        assert "geometry" in resp.data
+
+    def test_submit_geometry_rejected_if_disabled(self, api_client, feedback_no_drawings):
+        """If allow_drawings is False, geometry should be rejected."""
+        url = f"/api/v1/feedback/{feedback_no_drawings.id}/submit/"
+        resp = api_client.post(
+            url,
+            {
+                "rating": 4,
+                "geometry": {
+                    "type": "Point",
+                    "coordinates": [10.0, 53.5]
+                }
+            },
+            format="json"
+        )
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+        assert "geometry" in resp.data

--- a/tosca_api/apps/feedback/urls.py
+++ b/tosca_api/apps/feedback/urls.py
@@ -1,0 +1,8 @@
+from rest_framework.routers import DefaultRouter
+
+from .views import GeoFeedbackViewSet
+
+router = DefaultRouter()
+router.register(r"feedback", GeoFeedbackViewSet, basename="feedback")
+
+urlpatterns = router.urls

--- a/tosca_api/apps/feedback/views.py
+++ b/tosca_api/apps/feedback/views.py
@@ -1,0 +1,154 @@
+from django.core.exceptions import ValidationError as DjangoValidationError
+from rest_framework import permissions, status, viewsets
+from rest_framework.decorators import action
+from rest_framework.exceptions import ValidationError
+from rest_framework.pagination import CursorPagination
+from rest_framework.response import Response
+
+from .models import FeedbackSubmission, GeoFeedback
+from .serializers import (
+    FeedbackSubmissionSerializer,
+    GeoFeedbackCreateUpdateSerializer,
+    GeoFeedbackDetailSerializer,
+    GeoFeedbackListSerializer,
+)
+
+
+class FeedbackCursorPagination(CursorPagination):
+    """Cursor pagination for feedback, ordered by created_at descending."""
+
+    page_size = 20
+    ordering = "-created_at"
+
+
+class IsAdminOrReadOnly(permissions.BasePermission):
+    """
+    Custom permission to only allow admins to edit/create it.
+    Read-only permissions are allowed for any request.
+    """
+
+    def has_permission(self, request, view):
+        if request.method in permissions.SAFE_METHODS:
+            return True
+        return bool(request.user and request.user.is_staff)
+
+
+class GeoFeedbackViewSet(viewsets.ModelViewSet):
+    """
+    API endpoint for GeoFeedback operations.
+
+    - GET /api/v1/feedback/ : List all published feedback campaigns
+    - GET /api/v1/feedback/{id}/ : Get details
+    - POST /api/v1/feedback/ : Create (Admin only)
+    - PATCH/PUT /api/v1/feedback/{id}/ : Update (Admin only)
+    - DELETE /api/v1/feedback/{id}/ : Delete (Admin only)
+    
+    Submissions:
+    - POST /api/v1/feedback/{id}/submit/ : Submit citizen feedback
+    """
+
+    queryset = GeoFeedback.objects.all()
+    # Admins can do anything, others can only read.
+    # Note: submission has its own permission logic in the submit action.
+    permission_classes = [IsAdminOrReadOnly]
+    pagination_class = FeedbackCursorPagination
+
+    def get_serializer_class(self):
+        if self.action == "list":
+            return GeoFeedbackListSerializer
+        if self.action == "retrieve":
+            return GeoFeedbackDetailSerializer
+        if self.action == "submit":
+            return FeedbackSubmissionSerializer
+        return GeoFeedbackCreateUpdateSerializer
+
+    def get_queryset(self):
+        """
+        Filter queryset:
+        - Regular users only see PUBLISHED and PUBLIC feedbacks.
+        - Staff see everything.
+        - Filter by campaign_id query param if provided.
+        """
+        qs = super().get_queryset()
+
+        if self.action == "retrieve":
+            qs = qs.select_related("context", "campaign", "created_by", "custom_form")
+            qs = qs.prefetch_related("feedbacklayer_set__layer")
+
+        user = self.request.user
+        if not (user and user.is_staff):
+            qs = qs.filter(
+                status=GeoFeedback.Status.PUBLISHED,
+                visibility=GeoFeedback.Visibility.PUBLIC,
+            )
+
+        campaign_id = self.request.query_params.get("campaign_id")
+        if campaign_id:
+            qs = qs.filter(campaign_id=campaign_id)
+
+        return qs
+
+    def perform_create(self, serializer):
+        """Set the creator to the current user."""
+        serializer.save(created_by=self.request.user)
+
+    @action(detail=True, methods=["post"], permission_classes=[permissions.AllowAny])
+    def submit(self, request, pk=None):
+        """
+        Submit feedback to this campaign.
+        Anonymous users are allowed.
+
+        JSON body:
+        {
+            "rating": 5, (optional/required based on config)
+            "form_data": {...}, (optional/required based on config)
+            "geometry": {... GeoJSON ...} (optional/allowed based on config)
+        }
+        """
+        feedback = self.get_object()
+
+        # Parse request data
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        data = serializer.validated_data
+        rating = data.get("rating")
+        form_data = data.get("form_data")
+        geometry = data.get("geometry")
+
+        # Config Validation
+        errors = {}
+        if feedback.rating_enabled and rating is None:
+            errors["rating"] = "Rating is required for this feedback campaign."
+        
+        if feedback.form_enabled and not form_data:
+            errors["form_data"] = "Form data is required for this feedback campaign."
+
+        if geometry and not feedback.allow_drawings:
+            errors["geometry"] = "Drawings are not allowed for this feedback campaign."
+
+        if errors:
+            raise ValidationError(errors)
+
+        # Create submission
+        user = request.user if request.user.is_authenticated else None
+        
+        try:
+            submission = FeedbackSubmission(
+                feedback=feedback,
+                submitted_by=user,
+                rating=rating,
+                form_data=form_data,
+                geometry=geometry,
+                # Simple logic for anonymization parameter if provided, otherwise default False
+                is_anonymized=request.data.get("is_anonymized", False)
+            )
+            submission.full_clean()  # Model-level bounds checking
+            submission.save()
+            return Response(
+                FeedbackSubmissionSerializer(submission).data,
+                status=status.HTTP_201_CREATED,
+            )
+        except DjangoValidationError as e:
+            # Catch model-level ValidationError (e.g., rating out of bounds)
+            raise ValidationError(e.message_dict)

--- a/tosca_api/urls.py
+++ b/tosca_api/urls.py
@@ -35,5 +35,6 @@ urlpatterns = [
     path('api/v1/', include('tosca_api.apps.campaigns.urls')),
     path('api/v1/', include('tosca_api.apps.geostories.urls')),
     path('api/v1/', include('tosca_api.apps.events.urls')),
+    path("api/v1/", include("tosca_api.apps.feedback.urls")),
     path('admin/', admin.site.urls),
 ]


### PR DESCRIPTION
Implement GeoFeedback API:
- GET/POST /api/v1/feedback/ (Admin CRUD, Public Read)
- POST /api/v1/feedback/{id}/submit/

Supports anonymous submissions, strict feedback config enforcement, and geometry.
- Performance: Use CursorPagination
- Forms: Include custom_form_slug in detail views

closes #53

## Summary

- [ ] Description of changes
- [ ] Related issue link

## Testing

- [ ] `uv run pytest`
- [ ] Other (describe)
