### PR TITLE
refactor(events): add shared event filter layer for list and spatial …

### DIFF
--- a/tosca_api/apps/events/filters.py
+++ b/tosca_api/apps/events/filters.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from django.db.models import Q
+from django.utils import timezone
+
+from .models import Event
+
+
+def apply_event_filters(queryset, *, filters: dict):
+    """Apply the shared event filter contract to a queryset."""
+    status_value = filters.get("status", Event.Status.PUBLISHED)
+    queryset = queryset.filter(status=status_value)
+
+    campaign_id = filters.get("campaign_id")
+    if campaign_id:
+        queryset = queryset.filter(campaign_id=campaign_id)
+
+    visibility = filters.get("visibility")
+    if visibility:
+        queryset = queryset.filter(visibility=visibility)
+
+    include_past = filters.get("include_past", False)
+    if not include_past:
+        queryset = queryset.filter(start_datetime__gte=timezone.now())
+
+    start_after = filters.get("start_after")
+    if start_after:
+        queryset = queryset.filter(start_datetime__gte=start_after)
+
+    start_before = filters.get("start_before")
+    if start_before:
+        queryset = queryset.filter(start_datetime__lte=start_before)
+
+    term_id = filters.get("term_id")
+    if term_id:
+        queryset = queryset.filter(event_terms__term_id=term_id)
+
+    dimension_id = filters.get("dimension_id")
+    if dimension_id:
+        queryset = queryset.filter(event_terms__term__dimension_id=dimension_id)
+
+    spatial_geometry = filters.get("spatial_geometry")
+    if spatial_geometry is not None:
+        queryset = queryset.filter(
+            Q(
+                location_mode__in=[
+                    Event.LocationMode.PHYSICAL,
+                    Event.LocationMode.HYBRID,
+                ],
+                location__isnull=False,
+                location__within=spatial_geometry,
+            )
+            | Q(location_mode=Event.LocationMode.ONLINE)
+        )
+
+    if term_id or dimension_id:
+        queryset = queryset.distinct()
+
+    return queryset

--- a/tosca_api/apps/events/serializers.py
+++ b/tosca_api/apps/events/serializers.py
@@ -273,8 +273,22 @@ class EventWriteSerializer(serializers.ModelSerializer):
 
 
 class BBoxSerializer(serializers.Serializer):
-    """Validates and parses bbox query parameter."""
+    """Validates shared event filters plus bbox query parameter."""
 
+    campaign_id = serializers.UUIDField(required=False)
+    dimension_id = serializers.UUIDField(required=False)
+    term_id = serializers.UUIDField(required=False)
+    include_past = serializers.BooleanField(default=False)
+    start_after = serializers.DateTimeField(required=False)
+    start_before = serializers.DateTimeField(required=False)
+    status = serializers.ChoiceField(
+        choices=Event.Status.choices,
+        default=Event.Status.PUBLISHED,
+    )
+    visibility = serializers.ChoiceField(
+        choices=Event.Visibility.choices,
+        required=False,
+    )
     bbox = serializers.CharField(required=False, allow_blank=True)
 
     def validate_bbox(self, value):
@@ -322,6 +336,10 @@ class GeometryFilterSerializer(serializers.Serializer):
     status = serializers.ChoiceField(
         choices=Event.Status.choices,
         default=Event.Status.PUBLISHED,
+    )
+    visibility = serializers.ChoiceField(
+        choices=Event.Visibility.choices,
+        required=False,
     )
 
     def validate_geometry(self, value):

--- a/tosca_api/apps/events/tests/test_api.py
+++ b/tosca_api/apps/events/tests/test_api.py
@@ -231,17 +231,17 @@ def test_events_bbox_returns_geojson(api_client, user, future_event):
 
 
 @pytest.mark.django_db
-def test_events_bbox_excludes_events_without_location(
+def test_events_bbox_keeps_online_events_after_non_spatial_filtering(
     api_client, user, future_event, event_without_location
 ):
-    """Test that bbox filter excludes events without location."""
+    """Spatial filters should not drop eligible online events."""
     api_client.force_authenticate(user=user)
     response = api_client.get("/api/v1/events/?bbox=9.0,53.0,11.0,54.0")
     assert response.status_code == 200
 
     titles = [f["properties"]["title"] for f in response.data["features"]]
     assert "Future Event" in titles
-    assert "No Location Event" not in titles
+    assert "No Location Event" in titles
 
 
 @pytest.mark.django_db
@@ -336,6 +336,168 @@ def test_events_within_polygon(api_client, user, campaign):
     titles = [f["properties"]["title"] for f in response.data["features"]]
     assert "Inside Event" in titles
     assert "Outside Event" not in titles
+
+
+@pytest.mark.django_db
+def test_events_within_keeps_online_events_after_spatial_filtering(
+    api_client, user, future_event, event_without_location
+):
+    """Polygon filtering should still keep online events that match non-spatial filters."""
+    api_client.force_authenticate(user=user)
+    response = api_client.post(
+        "/api/v1/events/within/",
+        {
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [[9.0, 53.0], [11.0, 53.0], [11.0, 54.0], [9.0, 54.0], [9.0, 53.0]]
+                ],
+            }
+        },
+        format="json",
+    )
+
+    assert response.status_code == 200
+    titles = [feature["properties"]["title"] for feature in response.data["features"]]
+    assert "Future Event" in titles
+    assert "No Location Event" in titles
+
+
+@pytest.mark.django_db
+def test_events_within_excludes_past_events_by_default(api_client, user, campaign):
+    """The shared filter layer should exclude past events in within/ by default."""
+    Event.objects.create(
+        campaign=campaign,
+        title="Past Inside Event",
+        start_datetime=timezone.now() - timedelta(days=2),
+        end_datetime=timezone.now() - timedelta(days=2, hours=-1),
+        location=Point(10.0, 53.5, srid=4326),
+        organizer=user,
+        status=Event.Status.PUBLISHED,
+    )
+
+    api_client.force_authenticate(user=user)
+    response = api_client.post(
+        "/api/v1/events/within/",
+        {
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [[9.0, 53.0], [11.0, 53.0], [11.0, 54.0], [9.0, 54.0], [9.0, 53.0]]
+                ],
+            }
+        },
+        format="json",
+    )
+
+    assert response.status_code == 200
+    titles = [feature["properties"]["title"] for feature in response.data["features"]]
+    assert "Past Inside Event" not in titles
+
+
+@pytest.mark.django_db
+def test_events_shared_filters_match_between_list_and_within(api_client, user, campaign):
+    """List and within endpoints should apply the same non-spatial filter contract."""
+    dimension = TaxonomyDimension.objects.create(code="topic", label="Topic")
+    climate = TaxonomyTerm.objects.create(
+        dimension=dimension,
+        code="climate",
+        label="Climate",
+    )
+    matching_event = Event.objects.create(
+        campaign=campaign,
+        title="Matching Event",
+        start_datetime=timezone.now() + timedelta(days=2),
+        end_datetime=timezone.now() + timedelta(days=2, hours=1),
+        location=Point(10.0, 53.5, srid=4326),
+        organizer=user,
+        status=Event.Status.PUBLISHED,
+        visibility=Event.Visibility.PRIVATE,
+    )
+    filtered_out_online = Event.objects.create(
+        campaign=campaign,
+        title="Filtered Out Online Event",
+        start_datetime=timezone.now() + timedelta(days=2),
+        end_datetime=timezone.now() + timedelta(days=2, hours=1),
+        location_mode=Event.LocationMode.ONLINE,
+        online_url="https://example.org/live",
+        organizer=user,
+        status=Event.Status.PUBLISHED,
+        visibility=Event.Visibility.PUBLIC,
+    )
+    EventTerm.objects.create(event=matching_event, term=climate)
+    EventTerm.objects.create(event=filtered_out_online, term=climate)
+
+    start_after = (timezone.now() + timedelta(days=1)).isoformat()
+    start_before = (timezone.now() + timedelta(days=3)).isoformat()
+
+    api_client.force_authenticate(user=user)
+    list_response = api_client.get(
+        "/api/v1/events/",
+        {
+            "campaign_id": str(campaign.id),
+            "status": Event.Status.PUBLISHED,
+            "visibility": Event.Visibility.PRIVATE,
+            "term_id": str(climate.id),
+            "start_after": start_after,
+            "start_before": start_before,
+            "include_past": "false",
+        },
+    )
+    within_response = api_client.post(
+        "/api/v1/events/within/",
+        {
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [[9.0, 53.0], [11.0, 53.0], [11.0, 54.0], [9.0, 54.0], [9.0, 53.0]]
+                ],
+            },
+            "campaign_id": str(campaign.id),
+            "status": Event.Status.PUBLISHED,
+            "visibility": Event.Visibility.PRIVATE,
+            "term_id": str(climate.id),
+            "start_after": start_after,
+            "start_before": start_before,
+            "include_past": False,
+        },
+        format="json",
+    )
+
+    assert list_response.status_code == 200
+    assert within_response.status_code == 200
+
+    list_titles = [event["title"] for event in list_response.data["results"]]
+    within_titles = [feature["properties"]["title"] for feature in within_response.data["features"]]
+    assert list_titles == ["Matching Event"]
+    assert within_titles == ["Matching Event"]
+
+
+@pytest.mark.django_db
+def test_events_bbox_non_spatial_filters_remove_non_matching_online_events(
+    api_client, user, campaign
+):
+    """Online events should still be removed when they fail non-spatial filters."""
+    Event.objects.create(
+        campaign=campaign,
+        title="Private Online Event",
+        start_datetime=timezone.now() + timedelta(days=1),
+        end_datetime=timezone.now() + timedelta(days=1, hours=1),
+        location_mode=Event.LocationMode.ONLINE,
+        online_url="https://example.org/live",
+        organizer=user,
+        status=Event.Status.PUBLISHED,
+        visibility=Event.Visibility.PRIVATE,
+    )
+
+    api_client.force_authenticate(user=user)
+    response = api_client.get(
+        "/api/v1/events/?bbox=9.0,53.0,11.0,54.0&visibility=public"
+    )
+
+    assert response.status_code == 200
+    titles = [feature["properties"]["title"] for feature in response.data["features"]]
+    assert "Private Online Event" not in titles
 
 
 @pytest.mark.django_db

--- a/tosca_api/apps/events/views.py
+++ b/tosca_api/apps/events/views.py
@@ -1,9 +1,9 @@
-from django.utils import timezone
 from rest_framework import permissions, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.pagination import CursorPagination
 from rest_framework.response import Response
 
+from .filters import apply_event_filters
 from .models import Event
 from .serializers import (
     BBoxSerializer,
@@ -81,21 +81,6 @@ class EventViewSet(viewsets.ModelViewSet):
         """Check if request has bbox parameter."""
         return bool(self.request.query_params.get("bbox"))
 
-    def _apply_taxonomy_filters(self, queryset):
-        """Apply optional taxonomy term and dimension filters."""
-        term_id = self.request.query_params.get("term_id")
-        if term_id:
-            queryset = queryset.filter(event_terms__term_id=term_id)
-
-        dimension_id = self.request.query_params.get("dimension_id")
-        if dimension_id:
-            queryset = queryset.filter(event_terms__term__dimension_id=dimension_id)
-
-        if term_id or dimension_id:
-            queryset = queryset.distinct()
-
-        return queryset
-
     def get_queryset(self):
         """
         Filter queryset based on request parameters.
@@ -107,43 +92,13 @@ class EventViewSet(viewsets.ModelViewSet):
         """
         queryset = super().get_queryset()
 
-        # Status filter (default: published for list)
-        if self.action in ("list", "within"):
-            status_param = self.request.query_params.get("status", "published")
-            queryset = queryset.filter(status=status_param)
-
-        # Campaign filter
-        campaign_id = self.request.query_params.get("campaign_id")
-        if campaign_id:
-            queryset = queryset.filter(campaign_id=campaign_id)
-
-        queryset = self._apply_taxonomy_filters(queryset)
-
-        # Time filters
-        include_past = self.request.query_params.get("include_past", "").lower() == "true"
-        if not include_past and self.action == "list":
-            queryset = queryset.filter(start_datetime__gte=timezone.now())
-
-        start_after = self.request.query_params.get("start_after")
-        if start_after:
-            queryset = queryset.filter(start_datetime__gte=start_after)
-
-        start_before = self.request.query_params.get("start_before")
-        if start_before:
-            queryset = queryset.filter(start_datetime__lte=start_before)
-
-        # Spatial filter (bbox)
-        if self._is_spatial_request():
+        if self.action == "list":
             bbox_serializer = BBoxSerializer(data=self.request.query_params)
             bbox_serializer.is_valid(raise_exception=True)
-            bbox_geom = bbox_serializer.validated_data.get("bbox")
+            validated_filters = dict(bbox_serializer.validated_data)
+            validated_filters["spatial_geometry"] = validated_filters.pop("bbox", None)
 
-            if bbox_geom:
-                # Only events with location, within bbox
-                queryset = queryset.filter(
-                    location__isnull=False,
-                    location__within=bbox_geom,
-                )
+            queryset = apply_event_filters(queryset, filters=validated_filters)
 
         # Optimize queries
         if self.action == "retrieve":
@@ -170,7 +125,7 @@ class EventViewSet(viewsets.ModelViewSet):
         Non-spatial requests use standard paginated response.
         """
         if self._is_spatial_request():
-            queryset = self.filter_queryset(self.get_queryset())
+            queryset = self.filter_queryset(self.get_queryset()).order_by("start_datetime")
             serializer = self.get_serializer(queryset, many=True)
             return Response(serializer.data)
         return super().list(request, *args, **kwargs)
@@ -192,49 +147,17 @@ class EventViewSet(viewsets.ModelViewSet):
             "status": "published"
         }
         """
-        # Validate input
         filter_serializer = GeometryFilterSerializer(data=request.data)
         filter_serializer.is_valid(raise_exception=True)
-        data = filter_serializer.validated_data
+        data = dict(filter_serializer.validated_data)
+        data["spatial_geometry"] = data.pop("geometry")
 
-        # Build queryset
-        queryset = Event.objects.filter(
-            location__isnull=False,
-            location__within=data["geometry"],
-            status=data.get("status", Event.Status.PUBLISHED),
-        )
-
-        # Campaign filter
-        if data.get("campaign_id"):
-            queryset = queryset.filter(campaign_id=data["campaign_id"])
-
-        # Time filters
-        if not data.get("include_past", False):
-            queryset = queryset.filter(start_datetime__gte=timezone.now())
-
-        if data.get("start_after"):
-            queryset = queryset.filter(start_datetime__gte=data["start_after"])
-
-        if data.get("start_before"):
-            queryset = queryset.filter(start_datetime__lte=data["start_before"])
-
-        # Order by start_datetime
+        queryset = apply_event_filters(Event.objects.all(), filters=data)
         queryset = queryset.order_by("start_datetime").select_related(
             "campaign",
             "event_type",
             "series",
         )
-
-        if data.get("term_id"):
-            queryset = queryset.filter(event_terms__term_id=data["term_id"])
-
-        if data.get("dimension_id"):
-            queryset = queryset.filter(
-                event_terms__term__dimension_id=data["dimension_id"]
-            )
-
-        if data.get("term_id") or data.get("dimension_id"):
-            queryset = queryset.distinct()
 
         # Serialize as GeoJSON
         serializer = EventGeoSerializer(queryset, many=True)


### PR DESCRIPTION
…queries

Introduce a shared event filtering helper and move the common event filter contract out of the view-specific branches so list and spatial query paths use the same filtering rules.

Centralize parsing and validation for:
- campaign_id
- status
- visibility
- include_past
- start_after / start_before
- taxonomy term_id / dimension_id
- spatial bbox / polygon inputs

Apply the shared filtering semantics so that spatial predicates only affect physical and hybrid events, while online events remain eligible based on the non-spatial filters. In the current pre-2B.11 API shape, those online results are still returned through the existing GeoJSON responses with null geometry.

Add focused API coverage for:
- matching list vs map result sets under the same non-spatial filters
- include_past=false behavior across both query styles
- out-of-area spatial filtering for mapped events
- online event retention after spatial filtering
- online event removal when non-spatial filters do not match
- taxonomy filter consistency through the shared layer

## Summary

- [ ] Description of changes
- [ ] Related issue link

## Testing

- [ ] `uv run pytest`
- [ ] Other (describe)
