### PR TITLE
feat(events): add dedicated paginated list api for event v2

### DIFF
--- a/tosca_api/apps/events/tests/test_api.py
+++ b/tosca_api/apps/events/tests/test_api.py
@@ -207,6 +207,174 @@ def test_events_list_filter_by_campaign(api_client, user, campaign, future_event
 
 
 # =============================================================================
+# List API V2 Tests
+# =============================================================================
+
+
+@pytest.mark.django_db
+def test_events_list_v2_returns_mixed_modes_ordered_by_start_datetime(
+    api_client, user, campaign
+):
+    """The dedicated list endpoint should return a chronological mixed stream."""
+    Event.objects.create(
+        campaign=campaign,
+        title="Physical Event",
+        start_datetime=timezone.now() + timedelta(days=2),
+        end_datetime=timezone.now() + timedelta(days=2, hours=1),
+        location_mode=Event.LocationMode.PHYSICAL,
+        location=Point(10.0, 53.5, srid=4326),
+        organizer=user,
+        status=Event.Status.PUBLISHED,
+    )
+    Event.objects.create(
+        campaign=campaign,
+        title="Online Event",
+        start_datetime=timezone.now() + timedelta(days=1),
+        end_datetime=timezone.now() + timedelta(days=1, hours=1),
+        location_mode=Event.LocationMode.ONLINE,
+        online_url="https://example.org/live",
+        organizer=user,
+        status=Event.Status.PUBLISHED,
+    )
+    Event.objects.create(
+        campaign=campaign,
+        title="Hybrid Event",
+        start_datetime=timezone.now() + timedelta(days=3),
+        end_datetime=timezone.now() + timedelta(days=3, hours=1),
+        location_mode=Event.LocationMode.HYBRID,
+        location=Point(10.1, 53.6, srid=4326),
+        online_url="https://example.org/hybrid",
+        organizer=user,
+        status=Event.Status.PUBLISHED,
+    )
+
+    api_client.force_authenticate(user=user)
+    response = api_client.get("/api/v1/events/list/")
+
+    assert response.status_code == 200
+    titles = [event["title"] for event in response.data["results"]]
+    assert titles == ["Online Event", "Physical Event", "Hybrid Event"]
+    assert [event["location_mode"] for event in response.data["results"]] == [
+        "online",
+        "physical",
+        "hybrid",
+    ]
+
+
+@pytest.mark.django_db
+def test_events_list_v2_paginates_mixed_event_types(api_client, user, campaign):
+    """Cursor pagination should work for the dedicated list endpoint."""
+    for index in range(1, 22):
+        mode = [
+            Event.LocationMode.ONLINE,
+            Event.LocationMode.PHYSICAL,
+            Event.LocationMode.HYBRID,
+        ][(index - 1) % 3]
+        kwargs = {
+            "campaign": campaign,
+            "title": f"Event {index}",
+            "start_datetime": timezone.now() + timedelta(days=index),
+            "end_datetime": timezone.now() + timedelta(days=index, hours=1),
+            "location_mode": mode,
+            "organizer": user,
+            "status": Event.Status.PUBLISHED,
+        }
+        if mode == Event.LocationMode.ONLINE:
+            kwargs["online_url"] = "https://example.org/live"
+        else:
+            kwargs["location"] = Point(10.0 + index, 53.5 + index, srid=4326)
+            if mode == Event.LocationMode.HYBRID:
+                kwargs["online_url"] = "https://example.org/hybrid"
+        Event.objects.create(**kwargs)
+
+    api_client.force_authenticate(user=user)
+    response = api_client.get("/api/v1/events/list/")
+
+    assert response.status_code == 200
+    assert len(response.data["results"]) == 20
+    assert response.data["next"]
+
+
+@pytest.mark.django_db
+def test_events_list_v2_area_filter_keeps_eligible_online_events(
+    api_client, user, campaign
+):
+    """Area-filtered list results should include matching mapped events plus online events."""
+    Event.objects.create(
+        campaign=campaign,
+        title="Inside Physical Event",
+        start_datetime=timezone.now() + timedelta(days=1),
+        end_datetime=timezone.now() + timedelta(days=1, hours=1),
+        location=Point(10.0, 53.5, srid=4326),
+        organizer=user,
+        status=Event.Status.PUBLISHED,
+    )
+    Event.objects.create(
+        campaign=campaign,
+        title="Outside Physical Event",
+        start_datetime=timezone.now() + timedelta(days=2),
+        end_datetime=timezone.now() + timedelta(days=2, hours=1),
+        location=Point(13.4, 52.5, srid=4326),
+        organizer=user,
+        status=Event.Status.PUBLISHED,
+    )
+    Event.objects.create(
+        campaign=campaign,
+        title="Eligible Online Event",
+        start_datetime=timezone.now() + timedelta(days=3),
+        end_datetime=timezone.now() + timedelta(days=3, hours=1),
+        location_mode=Event.LocationMode.ONLINE,
+        online_url="https://example.org/live",
+        organizer=user,
+        status=Event.Status.PUBLISHED,
+    )
+
+    api_client.force_authenticate(user=user)
+    response = api_client.get("/api/v1/events/list/?bbox=9.5,53.0,10.5,54.0")
+
+    assert response.status_code == 200
+    titles = [event["title"] for event in response.data["results"]]
+    assert titles == ["Inside Physical Event", "Eligible Online Event"]
+
+
+@pytest.mark.django_db
+def test_events_list_v2_payload_remains_stable_when_no_online_events_match(
+    api_client, user, campaign
+):
+    """The dedicated list payload should remain a normal paginated list without online matches."""
+    Event.objects.create(
+        campaign=campaign,
+        title="Inside Physical Event",
+        start_datetime=timezone.now() + timedelta(days=1),
+        end_datetime=timezone.now() + timedelta(days=1, hours=1),
+        location=Point(10.0, 53.5, srid=4326),
+        organizer=user,
+        status=Event.Status.PUBLISHED,
+        visibility=Event.Visibility.PRIVATE,
+    )
+    Event.objects.create(
+        campaign=campaign,
+        title="Filtered Online Event",
+        start_datetime=timezone.now() + timedelta(days=2),
+        end_datetime=timezone.now() + timedelta(days=2, hours=1),
+        location_mode=Event.LocationMode.ONLINE,
+        online_url="https://example.org/live",
+        organizer=user,
+        status=Event.Status.PUBLISHED,
+        visibility=Event.Visibility.PUBLIC,
+    )
+
+    api_client.force_authenticate(user=user)
+    response = api_client.get(
+        "/api/v1/events/list/?bbox=9.5,53.0,10.5,54.0&visibility=private"
+    )
+
+    assert response.status_code == 200
+    assert "results" in response.data
+    assert response.data["results"][0]["title"] == "Inside Physical Event"
+
+
+# =============================================================================
 # Map View Tests (BBox)
 # =============================================================================
 

--- a/tosca_api/apps/events/views.py
+++ b/tosca_api/apps/events/views.py
@@ -71,6 +71,8 @@ class EventViewSet(viewsets.ModelViewSet):
             if self._is_spatial_request():
                 return EventGeoSerializer
             return EventListSerializer
+        if self.action == "list_v2":
+            return EventListSerializer
         if self.action == "retrieve":
             return EventDetailSerializer
         if self.action == "within":
@@ -92,7 +94,7 @@ class EventViewSet(viewsets.ModelViewSet):
         """
         queryset = super().get_queryset()
 
-        if self.action == "list":
+        if self.action in ("list", "list_v2"):
             bbox_serializer = BBoxSerializer(data=self.request.query_params)
             bbox_serializer.is_valid(raise_exception=True)
             validated_filters = dict(bbox_serializer.validated_data)
@@ -129,6 +131,24 @@ class EventViewSet(viewsets.ModelViewSet):
             serializer = self.get_serializer(queryset, many=True)
             return Response(serializer.data)
         return super().list(request, *args, **kwargs)
+
+    @action(detail=False, methods=["get"], url_path="list")
+    def list_v2(self, request):
+        """
+        Return a paginated chronological mixed stream of events.
+
+        This endpoint keeps list responses in JSON form even when spatial
+        filters are supplied, unlike the legacy `/events/` route which still
+        switches to GeoJSON for bbox requests.
+        """
+        queryset = self.filter_queryset(self.get_queryset()).order_by("start_datetime")
+        page = self.paginate_queryset(queryset)
+        if page is not None:
+            serializer = self.get_serializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+
+        serializer = self.get_serializer(queryset, many=True)
+        return Response(serializer.data)
 
     @action(detail=False, methods=["post"], url_path="within")
     def within(self, request):


### PR DESCRIPTION
Add the new `GET /api/v1/events/list/` endpoint as the canonical event list surface for v2.

Return one paginated chronological JSON stream that mixes physical, hybrid, and online events together and includes `location_mode` on every item. Reuse the shared event filter layer so the dedicated list endpoint supports the same filter contract introduced in 2B.9.

Keep the new list endpoint in JSON form even when spatial filters like `bbox` are supplied. This separates the v2 list behavior from the legacy `/api/v1/events/` route, which still switches to GeoJSON for bbox-based requests.

Add focused API coverage for:
- mixed-mode chronological ordering
- list item `location_mode` exposure
- cursor pagination across mixed event types
- area-filtered list results that keep eligible online events
- stable paginated payloads when no online events match

## Summary

- [ ] Description of changes
- [ ] Related issue link

## Testing

- [ ] `uv run pytest`
- [ ] Other (describe)
