### PR TITLE
feat(events): add dedicated bucketed map api for event v2

### DIFF
--- a/tosca_api/apps/events/serializers.py
+++ b/tosca_api/apps/events/serializers.py
@@ -143,6 +143,28 @@ class EventGeoSerializer(GeoFeatureModelSerializer):
         read_only_fields = fields
 
 
+class EventMapOnlineSerializer(serializers.ModelSerializer):
+    """Serializer for online events returned in the dedicated map endpoint."""
+
+    class Meta:
+        model = Event
+        fields = [
+            "id",
+            "title",
+            "description",
+            "campaign",
+            "event_type",
+            "start_datetime",
+            "end_datetime",
+            "location_mode",
+            "online_url",
+            "online_platform",
+            "status",
+            "visibility",
+        ]
+        read_only_fields = fields
+
+
 class EventWriteSerializer(serializers.ModelSerializer):
     """Serializer for creating/updating events."""
 

--- a/tosca_api/apps/events/tests/test_api.py
+++ b/tosca_api/apps/events/tests/test_api.py
@@ -375,6 +375,164 @@ def test_events_list_v2_payload_remains_stable_when_no_online_events_match(
 
 
 # =============================================================================
+# Map API V2 Tests
+# =============================================================================
+
+
+@pytest.mark.django_db
+def test_events_map_v2_returns_geojson_and_online_buckets(api_client, user, campaign):
+    """The dedicated map endpoint should split spatial and online results."""
+    Event.objects.create(
+        campaign=campaign,
+        title="Physical Event",
+        start_datetime=timezone.now() + timedelta(days=1),
+        end_datetime=timezone.now() + timedelta(days=1, hours=1),
+        location=Point(10.0, 53.5, srid=4326),
+        organizer=user,
+        status=Event.Status.PUBLISHED,
+    )
+    Event.objects.create(
+        campaign=campaign,
+        title="Online Event",
+        start_datetime=timezone.now() + timedelta(days=2),
+        end_datetime=timezone.now() + timedelta(days=2, hours=1),
+        location_mode=Event.LocationMode.ONLINE,
+        online_url="https://example.org/live",
+        organizer=user,
+        status=Event.Status.PUBLISHED,
+    )
+
+    api_client.force_authenticate(user=user)
+    response = api_client.get("/api/v1/events/map/")
+
+    assert response.status_code == 200
+    assert response.data["spatial_events"]["type"] == "FeatureCollection"
+    assert "features" in response.data["spatial_events"]
+    assert response.data["online_events"][0]["title"] == "Online Event"
+
+
+@pytest.mark.django_db
+def test_events_map_v2_spatial_bucket_contains_only_mapped_physical_or_hybrid_events(
+    api_client, user, campaign
+):
+    """The spatial bucket should contain only physical and hybrid events with geometry."""
+    Event.objects.create(
+        campaign=campaign,
+        title="Physical Event",
+        start_datetime=timezone.now() + timedelta(days=1),
+        end_datetime=timezone.now() + timedelta(days=1, hours=1),
+        location_mode=Event.LocationMode.PHYSICAL,
+        location=Point(10.0, 53.5, srid=4326),
+        organizer=user,
+        status=Event.Status.PUBLISHED,
+    )
+    Event.objects.create(
+        campaign=campaign,
+        title="Hybrid Event",
+        start_datetime=timezone.now() + timedelta(days=2),
+        end_datetime=timezone.now() + timedelta(days=2, hours=1),
+        location_mode=Event.LocationMode.HYBRID,
+        location=Point(10.1, 53.6, srid=4326),
+        online_url="https://example.org/hybrid",
+        organizer=user,
+        status=Event.Status.PUBLISHED,
+    )
+    Event.objects.create(
+        campaign=campaign,
+        title="Online Event",
+        start_datetime=timezone.now() + timedelta(days=3),
+        end_datetime=timezone.now() + timedelta(days=3, hours=1),
+        location_mode=Event.LocationMode.ONLINE,
+        online_url="https://example.org/live",
+        organizer=user,
+        status=Event.Status.PUBLISHED,
+    )
+
+    api_client.force_authenticate(user=user)
+    response = api_client.get("/api/v1/events/map/")
+
+    assert response.status_code == 200
+    spatial_titles = [
+        feature["properties"]["title"]
+        for feature in response.data["spatial_events"]["features"]
+    ]
+    assert spatial_titles == ["Physical Event", "Hybrid Event"]
+    assert response.data["online_events"][0]["title"] == "Online Event"
+
+
+@pytest.mark.django_db
+def test_events_map_v2_area_filter_keeps_eligible_online_events_separately(
+    api_client, user, campaign
+):
+    """Map filtering should keep online events in the separate online bucket."""
+    Event.objects.create(
+        campaign=campaign,
+        title="Inside Physical Event",
+        start_datetime=timezone.now() + timedelta(days=1),
+        end_datetime=timezone.now() + timedelta(days=1, hours=1),
+        location=Point(10.0, 53.5, srid=4326),
+        organizer=user,
+        status=Event.Status.PUBLISHED,
+    )
+    Event.objects.create(
+        campaign=campaign,
+        title="Outside Physical Event",
+        start_datetime=timezone.now() + timedelta(days=2),
+        end_datetime=timezone.now() + timedelta(days=2, hours=1),
+        location=Point(13.4, 52.5, srid=4326),
+        organizer=user,
+        status=Event.Status.PUBLISHED,
+    )
+    Event.objects.create(
+        campaign=campaign,
+        title="Eligible Online Event",
+        start_datetime=timezone.now() + timedelta(days=3),
+        end_datetime=timezone.now() + timedelta(days=3, hours=1),
+        location_mode=Event.LocationMode.ONLINE,
+        online_url="https://example.org/live",
+        organizer=user,
+        status=Event.Status.PUBLISHED,
+    )
+
+    api_client.force_authenticate(user=user)
+    response = api_client.get("/api/v1/events/map/?bbox=9.5,53.0,10.5,54.0")
+
+    assert response.status_code == 200
+    spatial_titles = [
+        feature["properties"]["title"]
+        for feature in response.data["spatial_events"]["features"]
+    ]
+    online_titles = [event["title"] for event in response.data["online_events"]]
+    assert spatial_titles == ["Inside Physical Event"]
+    assert online_titles == ["Eligible Online Event"]
+
+
+@pytest.mark.django_db
+def test_events_map_v2_empty_spatial_bucket_still_returns_feature_collection(
+    api_client, user, campaign
+):
+    """An empty spatial bucket should still return valid GeoJSON structure."""
+    Event.objects.create(
+        campaign=campaign,
+        title="Online Event",
+        start_datetime=timezone.now() + timedelta(days=1),
+        end_datetime=timezone.now() + timedelta(days=1, hours=1),
+        location_mode=Event.LocationMode.ONLINE,
+        online_url="https://example.org/live",
+        organizer=user,
+        status=Event.Status.PUBLISHED,
+    )
+
+    api_client.force_authenticate(user=user)
+    response = api_client.get("/api/v1/events/map/?bbox=9.5,53.0,10.5,54.0")
+
+    assert response.status_code == 200
+    assert response.data["spatial_events"]["type"] == "FeatureCollection"
+    assert response.data["spatial_events"]["features"] == []
+    assert response.data["online_events"][0]["title"] == "Online Event"
+
+
+# =============================================================================
 # Map View Tests (BBox)
 # =============================================================================
 

--- a/tosca_api/apps/events/views.py
+++ b/tosca_api/apps/events/views.py
@@ -11,6 +11,7 @@ from .serializers import (
     EventDetailSerializer,
     EventGeoSerializer,
     EventListSerializer,
+    EventMapOnlineSerializer,
     GeometryFilterSerializer,
 )
 
@@ -73,6 +74,8 @@ class EventViewSet(viewsets.ModelViewSet):
             return EventListSerializer
         if self.action == "list_v2":
             return EventListSerializer
+        if self.action == "map_v2":
+            return EventMapOnlineSerializer
         if self.action == "retrieve":
             return EventDetailSerializer
         if self.action == "within":
@@ -149,6 +152,36 @@ class EventViewSet(viewsets.ModelViewSet):
 
         serializer = self.get_serializer(queryset, many=True)
         return Response(serializer.data)
+
+    @action(detail=False, methods=["get"], url_path="map")
+    def map_v2(self, request):
+        """
+        Return the dedicated map response with separate spatial and online buckets.
+        """
+        bbox_serializer = BBoxSerializer(data=request.query_params)
+        bbox_serializer.is_valid(raise_exception=True)
+        filters = dict(bbox_serializer.validated_data)
+        filters["spatial_geometry"] = filters.pop("bbox", None)
+
+        queryset = apply_event_filters(
+            Event.objects.all().select_related("campaign", "event_type", "series"),
+            filters=filters,
+        ).order_by("start_datetime")
+
+        spatial_queryset = queryset.filter(
+            location_mode__in=[Event.LocationMode.PHYSICAL, Event.LocationMode.HYBRID],
+            location__isnull=False,
+        )
+        online_queryset = queryset.filter(location_mode=Event.LocationMode.ONLINE)
+
+        spatial_events = EventGeoSerializer(spatial_queryset, many=True).data
+        online_events = EventMapOnlineSerializer(online_queryset, many=True).data
+        return Response(
+            {
+                "spatial_events": spatial_events,
+                "online_events": online_events,
+            }
+        )
 
     @action(detail=False, methods=["post"], url_path="within")
     def within(self, request):


### PR DESCRIPTION
Add the new `GET /api/v1/events/map/` endpoint as the canonical v2 map surface for events.

Return the response in two buckets:
- `spatial_events` as GeoJSON FeatureCollection for mapped physical and hybrid events
- `online_events` as a separate JSON array for eligible online events

Reuse the shared event filter layer so the dedicated map endpoint honors the same filter contract as the v2 list endpoint, including campaign, status, visibility, include_past, start range, taxonomy, and bbox-based spatial filtering.

Keep the legacy `/api/v1/events/` bbox behavior in place for backward compatibility while moving the new bucketed map response contract onto `/api/v1/events/map/`.

Add focused API coverage for:
- valid GeoJSON structure in `spatial_events`
- separate `online_events` output
- spatial bucket containing only mapped physical/hybrid events
- area-filtered responses that keep eligible online events separately
- valid empty GeoJSON structure when no spatial matches exist

## Summary

- [ ] Description of changes
- [ ] Related issue link

## Testing

- [ ] `uv run pytest`
- [ ] Other (describe)
