### PR TITLE
feat(events): add series generation preview and exception-aware sync

### DIFF
--- a/tosca_api/apps/events/models.py
+++ b/tosca_api/apps/events/models.py
@@ -276,6 +276,15 @@ class EventSeries(TimeStampedModel):
                 errors["recurrence_type"] = "Recurring series require a recurrence type."
             if bool(self.end_date) == bool(self.occurrence_count):
                 errors["end_date"] = "Use either end_date or occurrence_count."
+            if (
+                self.start_time is not None
+                and self.end_time is not None
+                and self.end_time <= self.start_time
+            ):
+                errors["end_time"] = (
+                    "Recurring generation currently requires same-day end times "
+                    "after start_time."
+                )
 
             invalid_weekdays = set(self.by_weekday) - VALID_WEEKDAYS
             if invalid_weekdays:

--- a/tosca_api/apps/events/serializers.py
+++ b/tosca_api/apps/events/serializers.py
@@ -1,4 +1,5 @@
 from collections import Counter
+from zoneinfo import ZoneInfoNotFoundError
 
 from django.contrib.gis.geos import GEOSGeometry, Polygon
 from django.db import transaction
@@ -7,7 +8,80 @@ from rest_framework_gis.serializers import GeoFeatureModelSerializer
 
 from tosca_api.apps.geocontext.models import GeoContext
 
-from .models import Event, EventLayer, EventTerm, TaxonomyDimension, TaxonomyTerm
+from .models import (
+    Event,
+    EventLayer,
+    EventSeries,
+    EventSeriesDate,
+    EventTerm,
+    TaxonomyDimension,
+    TaxonomyTerm,
+    EventType,
+    VALID_WEEKDAYS,
+)
+from .services import (
+    KEEP_EXISTING_TERMS,
+    build_occurrence_specs,
+    create_occurrence_events,
+    serialize_occurrence_events,
+    sync_occurrence_events,
+)
+
+EVENT_SERIES_FIELDS = {
+    "campaign",
+    "event_type",
+    "name",
+    "default_context",
+    "series_mode",
+    "recurrence_type",
+    "start_date",
+    "end_date",
+    "occurrence_count",
+    "interval",
+    "start_time",
+    "end_time",
+    "timezone",
+    "monthly_rule_type",
+    "day_of_month",
+    "week_of_month",
+    "weekday_of_month",
+    "by_weekday",
+    "notes",
+}
+
+EVENT_TEMPLATE_FIELDS = {
+    "title",
+    "description",
+    "location_mode",
+    "location",
+    "online_url",
+    "online_platform",
+    "access_notes",
+    "provider_name",
+    "provider_url",
+    "provider_contact",
+    "status",
+    "visibility",
+    "context",
+}
+
+EXCEPTION_TRIGGER_FIELDS = {
+    "title",
+    "description",
+    "start_datetime",
+    "end_datetime",
+    "location_mode",
+    "location",
+    "online_url",
+    "online_platform",
+    "access_notes",
+    "provider_name",
+    "provider_url",
+    "provider_contact",
+    "status",
+    "visibility",
+    "context",
+}
 
 
 # =============================================================================
@@ -165,61 +239,8 @@ class EventMapOnlineSerializer(serializers.ModelSerializer):
         read_only_fields = fields
 
 
-class EventWriteSerializer(serializers.ModelSerializer):
-    """Serializer for creating/updating events."""
-
-    taxonomy_term_ids = serializers.ListField(
-        child=serializers.UUIDField(),
-        required=False,
-        allow_empty=True,
-        write_only=True,
-    )
-
-    class Meta:
-        model = Event
-        fields = [
-            "id",
-            "title",
-            "description",
-            "campaign",
-            "event_type",
-            "start_datetime",
-            "end_datetime",
-            "location_mode",
-            "location",
-            "online_url",
-            "online_platform",
-            "access_notes",
-            "provider_name",
-            "provider_url",
-            "provider_contact",
-            "series",
-            "occurrence_index",
-            "is_exception",
-            "original_start_datetime",
-            "status",
-            "visibility",
-            "organizer",
-            "context",
-            "taxonomy_term_ids",
-        ]
-        read_only_fields = ["id", "organizer"]
-
-    def validate(self, attrs):
-        """Invoke model clean() to ensure DB constraints surface as API 400s."""
-        taxonomy_term_ids = attrs.pop("taxonomy_term_ids", serializers.empty)
-        if taxonomy_term_ids is not serializers.empty:
-            attrs["_taxonomy_terms"] = self._resolve_taxonomy_terms(taxonomy_term_ids)
-
-        instance = self.instance or Event()
-        for attr, value in attrs.items():
-            if attr.startswith("_"):
-                continue
-            setattr(instance, attr, value)
-
-        # Event.clean() enforces start_datetime <= end_datetime
-        instance.clean()
-        return attrs
+class TaxonomyTermResolutionMixin:
+    """Shared taxonomy term validation and replacement helpers."""
 
     def _resolve_taxonomy_terms(self, taxonomy_term_ids):
         duplicate_ids = [
@@ -274,6 +295,70 @@ class EventWriteSerializer(serializers.ModelSerializer):
             for term in taxonomy_terms:
                 EventTerm.objects.create(event=event, term=term)
 
+
+class EventWriteSerializer(TaxonomyTermResolutionMixin, serializers.ModelSerializer):
+    """Serializer for creating/updating events."""
+
+    taxonomy_term_ids = serializers.ListField(
+        child=serializers.UUIDField(),
+        required=False,
+        allow_empty=True,
+        write_only=True,
+    )
+
+    class Meta:
+        model = Event
+        fields = [
+            "id",
+            "title",
+            "description",
+            "campaign",
+            "event_type",
+            "start_datetime",
+            "end_datetime",
+            "location_mode",
+            "location",
+            "online_url",
+            "online_platform",
+            "access_notes",
+            "provider_name",
+            "provider_url",
+            "provider_contact",
+            "series",
+            "occurrence_index",
+            "is_exception",
+            "original_start_datetime",
+            "status",
+            "visibility",
+            "organizer",
+            "context",
+            "taxonomy_term_ids",
+        ]
+        read_only_fields = ["id", "organizer"]
+
+    def validate(self, attrs):
+        """Invoke model clean() to ensure DB constraints surface as API 400s."""
+        taxonomy_term_ids = attrs.pop("taxonomy_term_ids", serializers.empty)
+        if taxonomy_term_ids is not serializers.empty:
+            attrs["_taxonomy_terms"] = self._resolve_taxonomy_terms(taxonomy_term_ids)
+
+        instance = Event()
+        if self.instance is not None:
+            for field in self.Meta.fields:
+                if field in {"id", "taxonomy_term_ids"}:
+                    continue
+                setattr(instance, field, getattr(self.instance, field))
+            instance.pk = self.instance.pk
+
+        for attr, value in attrs.items():
+            if attr.startswith("_"):
+                continue
+            setattr(instance, attr, value)
+
+        # Event.clean() enforces start_datetime <= end_datetime
+        instance.clean()
+        return attrs
+
     def create(self, validated_data):
         taxonomy_terms = validated_data.pop("_taxonomy_terms", serializers.empty)
         event = super().create(validated_data)
@@ -283,10 +368,418 @@ class EventWriteSerializer(serializers.ModelSerializer):
 
     def update(self, instance, validated_data):
         taxonomy_terms = validated_data.pop("_taxonomy_terms", serializers.empty)
+        should_mark_exception = self._should_mark_exception(
+            instance=instance,
+            validated_data=validated_data,
+            taxonomy_terms=taxonomy_terms,
+        )
+        if should_mark_exception:
+            validated_data["is_exception"] = True
+            if (
+                ("start_datetime" in validated_data or "end_datetime" in validated_data)
+                and instance.original_start_datetime is None
+            ):
+                validated_data["original_start_datetime"] = instance.start_datetime
+
         event = super().update(instance, validated_data)
         if taxonomy_terms is not serializers.empty:
             self._replace_event_terms(event, taxonomy_terms)
         return event
+
+    def _should_mark_exception(self, instance, validated_data, taxonomy_terms) -> bool:
+        if not instance.series_id:
+            return False
+
+        for field in EXCEPTION_TRIGGER_FIELDS:
+            if field in validated_data and validated_data[field] != getattr(instance, field):
+                return True
+
+        if taxonomy_terms is not serializers.empty:
+            current_term_ids = set(
+                EventTerm.objects.filter(event=instance).values_list("term_id", flat=True)
+            )
+            incoming_term_ids = {term.id for term in taxonomy_terms}
+            if current_term_ids != incoming_term_ids:
+                return True
+
+        return False
+
+
+class EventSeriesOccurrenceSerializer(serializers.Serializer):
+    """Occurrence payload used by preview and write responses."""
+
+    id = serializers.UUIDField(required=False)
+    occurrence_index = serializers.IntegerField()
+    occurrence_date = serializers.DateField(required=False)
+    is_exception = serializers.BooleanField(required=False)
+    start_datetime = serializers.DateTimeField()
+    end_datetime = serializers.DateTimeField()
+    original_start_datetime = serializers.DateTimeField()
+    title = serializers.CharField(required=False)
+
+
+class EventSeriesResponseSerializer(serializers.ModelSerializer):
+    """Response serializer for event-series create and update operations."""
+
+    occurrences = serializers.SerializerMethodField()
+
+    class Meta:
+        model = EventSeries
+        fields = [
+            "id",
+            "campaign",
+            "event_type",
+            "name",
+            "series_mode",
+            "recurrence_type",
+            "start_date",
+            "end_date",
+            "occurrence_count",
+            "interval",
+            "start_time",
+            "end_time",
+            "timezone",
+            "occurrences",
+        ]
+        read_only_fields = fields
+
+    def get_occurrences(self, obj):
+        occurrences = getattr(obj, "_response_occurrences", [])
+        return EventSeriesOccurrenceSerializer(occurrences, many=True).data
+
+
+class EventSeriesWriteSerializer(TaxonomyTermResolutionMixin, serializers.Serializer):
+    """Validate preview/create/update payloads for event series generation."""
+
+    taxonomy_term_ids = serializers.ListField(
+        child=serializers.UUIDField(),
+        required=False,
+        allow_empty=True,
+        write_only=True,
+    )
+
+    campaign = serializers.PrimaryKeyRelatedField(
+        queryset=EventSeries._meta.get_field("campaign").remote_field.model.objects.all(),
+        required=False,
+    )
+    event_type = serializers.PrimaryKeyRelatedField(
+        queryset=EventType.objects.all(),
+        required=False,
+    )
+    name = serializers.CharField(required=False, allow_blank=True, allow_null=False)
+    default_context = serializers.PrimaryKeyRelatedField(
+        queryset=GeoContext.objects.all(),
+        required=False,
+        allow_null=True,
+    )
+    series_mode = serializers.ChoiceField(
+        choices=EventSeries.SeriesMode.choices,
+        required=False,
+    )
+    recurrence_type = serializers.ChoiceField(
+        choices=EventSeries.RecurrenceType.choices,
+        required=False,
+        allow_blank=True,
+    )
+    start_date = serializers.DateField(required=False)
+    end_date = serializers.DateField(required=False, allow_null=True)
+    occurrence_count = serializers.IntegerField(required=False, allow_null=True, min_value=1)
+    interval = serializers.IntegerField(required=False, min_value=1)
+    start_time = serializers.TimeField(required=False)
+    end_time = serializers.TimeField(required=False)
+    timezone = serializers.CharField(required=False, allow_blank=False)
+    monthly_rule_type = serializers.ChoiceField(
+        choices=EventSeries.MonthlyRuleType.choices,
+        required=False,
+        allow_blank=True,
+    )
+    day_of_month = serializers.IntegerField(required=False, allow_null=True, min_value=1, max_value=31)
+    week_of_month = serializers.IntegerField(required=False, allow_null=True, min_value=1, max_value=5)
+    weekday_of_month = serializers.CharField(required=False, allow_blank=True)
+    by_weekday = serializers.ListField(
+        child=serializers.ChoiceField(choices=sorted(VALID_WEEKDAYS)),
+        required=False,
+        allow_empty=True,
+    )
+    notes = serializers.CharField(required=False, allow_blank=True)
+    explicit_dates = serializers.ListField(
+        child=serializers.DateField(),
+        required=False,
+        allow_empty=True,
+        write_only=True,
+    )
+
+    title = serializers.CharField(required=False, max_length=255)
+    description = serializers.CharField(required=False, allow_blank=True)
+    location_mode = serializers.ChoiceField(
+        choices=Event.LocationMode.choices,
+        required=False,
+    )
+    location = serializers.JSONField(required=False, allow_null=True)
+    online_url = serializers.URLField(required=False, allow_blank=True)
+    online_platform = serializers.CharField(required=False, allow_blank=True)
+    access_notes = serializers.CharField(required=False, allow_blank=True)
+    provider_name = serializers.CharField(required=False, allow_blank=True)
+    provider_url = serializers.URLField(required=False, allow_blank=True)
+    provider_contact = serializers.CharField(required=False, allow_blank=True)
+    status = serializers.ChoiceField(choices=Event.Status.choices, required=False)
+    visibility = serializers.ChoiceField(choices=Event.Visibility.choices, required=False)
+    context = serializers.PrimaryKeyRelatedField(
+        queryset=GeoContext.objects.all(),
+        required=False,
+        allow_null=True,
+    )
+
+    def validate(self, attrs):
+        taxonomy_term_ids = attrs.pop("taxonomy_term_ids", serializers.empty)
+        if taxonomy_term_ids is not serializers.empty:
+            attrs["_taxonomy_terms"] = self._resolve_taxonomy_terms(taxonomy_term_ids)
+
+        series_attrs = self._merged_series_attrs(attrs)
+        explicit_dates = self._resolved_explicit_dates(attrs)
+        series_candidate = EventSeries(
+            **series_attrs,
+            created_by=self.context["request"].user,
+        )
+        series_candidate.clean()
+
+        if self.instance and (
+            "campaign" in series_attrs
+            and series_attrs["campaign"] != self.instance.campaign
+            and self.instance.events.exists()
+        ):
+            raise serializers.ValidationError(
+                {"campaign": "Series campaign cannot be changed after occurrences exist."}
+            )
+
+        if self.instance and (
+            "event_type" in series_attrs
+            and series_attrs["event_type"] != self.instance.event_type
+            and self.instance.events.exists()
+        ):
+            raise serializers.ValidationError(
+                {"event_type": "Series event type cannot be changed after occurrences exist."}
+            )
+
+        try:
+            occurrences = build_occurrence_specs(
+                series_candidate,
+                explicit_dates=explicit_dates,
+            )
+        except ZoneInfoNotFoundError as exc:
+            raise serializers.ValidationError(
+                {"timezone": f"Unknown timezone: {exc}"}
+            ) from exc
+        if not occurrences:
+            raise serializers.ValidationError(
+                {"explicit_dates": "This series definition produces no occurrences."}
+            )
+
+        event_template = self._merged_event_template(attrs)
+        exemplar_event = self._template_event_instance(
+            series=series_candidate,
+            occurrence=occurrences[0],
+            event_template=event_template,
+        )
+        exemplar_event.clean()
+
+        attrs["_series_attrs"] = series_attrs
+        attrs["_explicit_dates"] = explicit_dates
+        attrs["_event_template"] = event_template
+        attrs["_occurrences"] = occurrences
+        attrs["_template_event"] = self._base_template_event()
+        return attrs
+
+    def create(self, validated_data):
+        taxonomy_terms = validated_data.pop("_taxonomy_terms", [])
+        series_attrs = validated_data.pop("_series_attrs")
+        explicit_dates = validated_data.pop("_explicit_dates")
+        event_template = validated_data.pop("_event_template")
+        occurrences = validated_data.pop("_occurrences")
+
+        with transaction.atomic():
+            series = EventSeries.objects.create(
+                **series_attrs,
+                created_by=self.context["request"].user,
+            )
+            self._persist_explicit_dates(series, explicit_dates)
+            created_events = create_occurrence_events(
+                series=series,
+                occurrences=occurrences,
+                event_template=event_template,
+                organizer=self.context["request"].user,
+                taxonomy_terms=taxonomy_terms,
+            )
+
+        series._response_occurrences = serialize_occurrence_events(created_events)
+        return series
+
+    def update(self, instance, validated_data):
+        taxonomy_terms = validated_data.pop("_taxonomy_terms", KEEP_EXISTING_TERMS)
+        series_attrs = validated_data.pop("_series_attrs")
+        explicit_dates = validated_data.pop("_explicit_dates")
+        event_template = validated_data.pop("_event_template")
+        occurrences = validated_data.pop("_occurrences")
+        template_event = self._base_template_event()
+
+        for field, value in series_attrs.items():
+            setattr(instance, field, value)
+
+        with transaction.atomic():
+            instance.save()
+            self._persist_explicit_dates(instance, explicit_dates)
+            sync_result = sync_occurrence_events(
+                series=instance,
+                occurrences=occurrences,
+                event_template=event_template,
+                template_event=template_event,
+                organizer=self.context["request"].user,
+                taxonomy_terms=taxonomy_terms,
+            )
+
+        instance._response_occurrences = serialize_occurrence_events(sync_result.events)
+        instance._sync_result = sync_result
+        return instance
+
+    def _merged_series_attrs(self, attrs):
+        source = {}
+        if self.instance:
+            for field in EVENT_SERIES_FIELDS:
+                source[field] = getattr(self.instance, field)
+
+        for field in EVENT_SERIES_FIELDS:
+            if field in attrs:
+                source[field] = attrs[field]
+
+        required_fields = {
+            "campaign",
+            "event_type",
+            "start_date",
+            "start_time",
+            "end_time",
+            "timezone",
+            "series_mode",
+        }
+        missing = [
+            field
+            for field in required_fields
+            if source.get(field) in (None, "")
+        ]
+        if missing:
+            raise serializers.ValidationError(
+                {field: "This field is required." for field in missing}
+            )
+        return source
+
+    def _resolved_explicit_dates(self, attrs):
+        explicit_dates = attrs.get("explicit_dates", serializers.empty)
+        series_mode = attrs.get(
+            "series_mode",
+            self.instance.series_mode if self.instance else None,
+        )
+        if series_mode == EventSeries.SeriesMode.MANUAL_BATCH:
+            if explicit_dates is serializers.empty:
+                if self.instance:
+                    explicit_dates = list(
+                        self.instance.dates.order_by("display_order", "occurrence_date").values_list(
+                            "occurrence_date",
+                            flat=True,
+                        )
+                    )
+                else:
+                    explicit_dates = []
+            if not explicit_dates:
+                raise serializers.ValidationError(
+                    {"explicit_dates": "Manual batch series require at least one explicit date."}
+                )
+            duplicates = [
+                str(item)
+                for item, count in Counter(explicit_dates).items()
+                if count > 1
+            ]
+            if duplicates:
+                raise serializers.ValidationError(
+                    {"explicit_dates": f"Duplicate explicit dates are not allowed: {', '.join(duplicates)}"}
+                )
+            return explicit_dates
+
+        if explicit_dates is not serializers.empty:
+            raise serializers.ValidationError(
+                {"explicit_dates": "Explicit dates are only valid for manual batch series."}
+            )
+
+        return []
+
+    def _merged_event_template(self, attrs):
+        source = {}
+        base_event = self._base_template_event()
+        if base_event is not None:
+            for field in EVENT_TEMPLATE_FIELDS:
+                source[field] = getattr(base_event, field)
+
+        for field in EVENT_TEMPLATE_FIELDS:
+            if field in attrs:
+                source[field] = attrs[field]
+
+        required_fields = {"title", "location_mode"}
+        missing = [
+            field
+            for field in required_fields
+            if source.get(field) in (None, "")
+        ]
+        if missing:
+            raise serializers.ValidationError(
+                {field: "This field is required." for field in missing}
+            )
+        return source
+
+    def _template_event_instance(self, *, series, occurrence, event_template):
+        return Event(
+            campaign=series.campaign,
+            event_type=series.event_type,
+            organizer=self.context["request"].user,
+            series=series if self.instance else None,
+            occurrence_index=occurrence.occurrence_index,
+            original_start_datetime=occurrence.original_start_datetime,
+            start_datetime=occurrence.start_datetime,
+            end_datetime=occurrence.end_datetime,
+            **event_template,
+        )
+
+    def _base_template_event(self):
+        if self.instance is None:
+            return None
+        base_event = (
+            self.instance.events.filter(is_exception=False)
+            .order_by("occurrence_index", "start_datetime")
+            .prefetch_related("event_terms__term")
+            .first()
+        )
+        if base_event is not None:
+            return base_event
+        return (
+            self.instance.events.order_by("occurrence_index", "start_datetime")
+            .prefetch_related("event_terms__term")
+            .first()
+        )
+
+    def _persist_explicit_dates(self, series, explicit_dates):
+        if series.series_mode != EventSeries.SeriesMode.MANUAL_BATCH:
+            if series.pk:
+                series.dates.all().delete()
+            return
+
+        series.dates.all().delete()
+        EventSeriesDate.objects.bulk_create(
+            [
+                EventSeriesDate(
+                    series=series,
+                    occurrence_date=occurrence_date,
+                    display_order=index,
+                )
+                for index, occurrence_date in enumerate(explicit_dates, start=1)
+            ]
+        )
 
 
 # =============================================================================

--- a/tosca_api/apps/events/services.py
+++ b/tosca_api/apps/events/services.py
@@ -1,0 +1,370 @@
+from __future__ import annotations
+
+from calendar import monthrange
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta
+from typing import Any
+from zoneinfo import ZoneInfo
+
+from django.db import transaction
+from django.utils import timezone
+
+from .models import Event, EventSeries, EventTerm, TaxonomyTerm
+
+KEEP_EXISTING_TERMS = object()
+
+WEEKDAY_TO_INDEX = {
+    "monday": 0,
+    "tuesday": 1,
+    "wednesday": 2,
+    "thursday": 3,
+    "friday": 4,
+    "saturday": 5,
+    "sunday": 6,
+}
+
+
+@dataclass(frozen=True, slots=True)
+class OccurrenceSpec:
+    occurrence_index: int
+    occurrence_date: date
+    start_datetime: datetime
+    end_datetime: datetime
+    original_start_datetime: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class SyncResult:
+    created_count: int
+    updated_count: int
+    deleted_count: int
+    skipped_exception_count: int
+    events: list[Event]
+
+
+def build_occurrence_specs(
+    series: EventSeries,
+    *,
+    explicit_dates: list[date] | None = None,
+) -> list[OccurrenceSpec]:
+    tz = ZoneInfo(series.timezone)
+    duration = _build_occurrence_duration(series, tz)
+    occurrence_dates = _generate_occurrence_dates(series, explicit_dates=explicit_dates)
+
+    occurrences: list[OccurrenceSpec] = []
+    for index, occurrence_date in enumerate(occurrence_dates, start=1):
+        start_datetime = _localize(series, occurrence_date, tz)
+        occurrences.append(
+            OccurrenceSpec(
+                occurrence_index=index,
+                occurrence_date=occurrence_date,
+                start_datetime=start_datetime,
+                end_datetime=start_datetime + duration,
+                original_start_datetime=start_datetime,
+            )
+        )
+    return occurrences
+
+
+def create_occurrence_events(
+    *,
+    series: EventSeries,
+    occurrences: list[OccurrenceSpec],
+    event_template: dict[str, Any],
+    organizer,
+    taxonomy_terms: list[TaxonomyTerm],
+) -> list[Event]:
+    created_events: list[Event] = []
+    with transaction.atomic():
+        for occurrence in occurrences:
+            event = Event(
+                campaign=series.campaign,
+                event_type=series.event_type,
+                organizer=organizer,
+            )
+            _apply_occurrence_to_event(
+                event,
+                occurrence=occurrence,
+                template_data=event_template,
+                series=series,
+            )
+            event.save()
+            _set_event_terms(event, taxonomy_terms)
+            created_events.append(event)
+
+    return created_events
+
+
+def sync_occurrence_events(
+    *,
+    series: EventSeries,
+    occurrences: list[OccurrenceSpec],
+    event_template: dict[str, Any],
+    template_event: Event,
+    organizer,
+    taxonomy_terms: list[TaxonomyTerm] | object = KEEP_EXISTING_TERMS,
+    reference_time: datetime | None = None,
+) -> SyncResult:
+    now = reference_time or timezone.now()
+    existing_events = {
+        event.occurrence_index: event
+        for event in series.events.all().order_by("occurrence_index", "start_datetime")
+        if event.occurrence_index is not None
+    }
+    target_indexes = {occurrence.occurrence_index for occurrence in occurrences}
+    created_count = 0
+    updated_count = 0
+    deleted_count = 0
+    skipped_exception_count = 0
+    synced_events: list[Event] = []
+
+    with transaction.atomic():
+        for occurrence in occurrences:
+            event = existing_events.get(occurrence.occurrence_index)
+            if event is None:
+                if occurrence.start_datetime < now:
+                    continue
+                event = Event(
+                    campaign=series.campaign,
+                    event_type=series.event_type,
+                    organizer=organizer,
+                )
+                _apply_occurrence_to_event(
+                    event,
+                    occurrence=occurrence,
+                    template_data=event_template,
+                    series=series,
+                )
+                event.save()
+                if taxonomy_terms is KEEP_EXISTING_TERMS:
+                    _copy_event_terms(source_event=template_event, target_event=event)
+                else:
+                    _set_event_terms(event, taxonomy_terms)
+                created_count += 1
+                synced_events.append(event)
+                continue
+
+            if event.start_datetime < now:
+                synced_events.append(event)
+                continue
+
+            if event.is_exception:
+                skipped_exception_count += 1
+                synced_events.append(event)
+                continue
+
+            _apply_occurrence_to_event(
+                event,
+                occurrence=occurrence,
+                template_data=event_template,
+                series=series,
+            )
+            event.organizer = organizer
+            event.save()
+            if taxonomy_terms is not KEEP_EXISTING_TERMS:
+                _set_event_terms(event, taxonomy_terms)
+            updated_count += 1
+            synced_events.append(event)
+
+        removable_events = (
+            series.events.filter(start_datetime__gte=now, is_exception=False)
+            .exclude(occurrence_index__in=target_indexes)
+            .order_by("occurrence_index", "start_datetime")
+        )
+        deleted_count = removable_events.count()
+        removable_events.delete()
+
+    current_events = list(series.events.order_by("occurrence_index", "start_datetime"))
+    return SyncResult(
+        created_count=created_count,
+        updated_count=updated_count,
+        deleted_count=deleted_count,
+        skipped_exception_count=skipped_exception_count,
+        events=current_events,
+    )
+
+
+def serialize_occurrence_specs(
+    occurrences: list[OccurrenceSpec],
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "occurrence_index": occurrence.occurrence_index,
+            "occurrence_date": occurrence.occurrence_date,
+            "start_datetime": occurrence.start_datetime,
+            "end_datetime": occurrence.end_datetime,
+            "original_start_datetime": occurrence.original_start_datetime,
+        }
+        for occurrence in occurrences
+    ]
+
+
+def serialize_occurrence_events(events: list[Event]) -> list[dict[str, Any]]:
+    return [
+        {
+            "id": event.id,
+            "occurrence_index": event.occurrence_index,
+            "is_exception": event.is_exception,
+            "start_datetime": event.start_datetime,
+            "end_datetime": event.end_datetime,
+            "original_start_datetime": event.original_start_datetime,
+            "title": event.title,
+        }
+        for event in events
+    ]
+
+
+def _apply_occurrence_to_event(
+    event: Event,
+    *,
+    occurrence: OccurrenceSpec,
+    template_data: dict[str, Any],
+    series: EventSeries,
+) -> None:
+    for field, value in template_data.items():
+        setattr(event, field, value)
+
+    event.campaign = series.campaign
+    event.event_type = series.event_type
+    event.series = series
+    event.occurrence_index = occurrence.occurrence_index
+    event.start_datetime = occurrence.start_datetime
+    event.end_datetime = occurrence.end_datetime
+    event.original_start_datetime = occurrence.original_start_datetime
+    event.is_exception = False
+
+
+def _set_event_terms(event: Event, taxonomy_terms: list[TaxonomyTerm]) -> None:
+    EventTerm.objects.filter(event=event).delete()
+    for term in taxonomy_terms:
+        EventTerm.objects.create(event=event, term=term)
+
+
+def _copy_event_terms(source_event: Event, target_event: Event) -> None:
+    source_terms = list(
+        TaxonomyTerm.objects.filter(event_terms__event=source_event).distinct()
+    )
+    _set_event_terms(target_event, source_terms)
+
+
+def _build_occurrence_duration(series: EventSeries, tz: ZoneInfo) -> timedelta:
+    start_datetime = datetime.combine(series.start_date, series.start_time, tzinfo=tz)
+    end_datetime = datetime.combine(series.start_date, series.end_time, tzinfo=tz)
+    return end_datetime - start_datetime
+
+
+def _localize(series: EventSeries, occurrence_date: date, tz: ZoneInfo) -> datetime:
+    return datetime.combine(occurrence_date, series.start_time, tzinfo=tz)
+
+
+def _generate_occurrence_dates(
+    series: EventSeries,
+    *,
+    explicit_dates: list[date] | None = None,
+) -> list[date]:
+    if series.series_mode == EventSeries.SeriesMode.MANUAL_BATCH:
+        if explicit_dates is not None:
+            return explicit_dates
+        return list(
+            series.dates.order_by("display_order", "occurrence_date").values_list(
+                "occurrence_date",
+                flat=True,
+            )
+        )
+
+    if series.recurrence_type == EventSeries.RecurrenceType.DAILY:
+        return _generate_daily_dates(series)
+    if series.recurrence_type == EventSeries.RecurrenceType.WEEKLY:
+        return _generate_weekly_dates(series)
+    if series.recurrence_type == EventSeries.RecurrenceType.MONTHLY:
+        return _generate_monthly_dates(series)
+    return []
+
+
+def _generate_daily_dates(series: EventSeries) -> list[date]:
+    dates: list[date] = []
+    current_date = series.start_date
+    while _can_continue(dates, current_date, series):
+        dates.append(current_date)
+        current_date += timedelta(days=series.interval)
+    return dates
+
+
+def _generate_weekly_dates(series: EventSeries) -> list[date]:
+    dates: list[date] = []
+    anchor_week_start = series.start_date - timedelta(days=series.start_date.weekday())
+    weekday_indexes = sorted({WEEKDAY_TO_INDEX[weekday] for weekday in series.by_weekday})
+    week_offset = 0
+
+    while True:
+        week_start = anchor_week_start + timedelta(weeks=week_offset)
+        candidates = [
+            week_start + timedelta(days=weekday_index)
+            for weekday_index in weekday_indexes
+        ]
+        candidates = [candidate for candidate in candidates if candidate >= series.start_date]
+
+        if series.end_date and candidates and min(candidates) > series.end_date:
+            break
+
+        for candidate in candidates:
+            if not _can_continue(dates, candidate, series):
+                return dates
+            dates.append(candidate)
+
+        week_offset += series.interval
+
+    return dates
+
+
+def _generate_monthly_dates(series: EventSeries) -> list[date]:
+    dates: list[date] = []
+    month_offset = 0
+
+    while True:
+        year, month = _add_months(series.start_date.year, series.start_date.month, month_offset)
+        candidate = _monthly_candidate(series, year, month)
+        if candidate and candidate >= series.start_date:
+            if not _can_continue(dates, candidate, series):
+                return dates
+            dates.append(candidate)
+
+        if series.end_date:
+            last_of_month = date(year, month, monthrange(year, month)[1])
+            if last_of_month >= series.end_date and (
+                candidate is None or candidate > series.end_date
+            ):
+                break
+
+        month_offset += series.interval
+
+    return dates
+
+
+def _monthly_candidate(series: EventSeries, year: int, month: int) -> date | None:
+    if series.monthly_rule_type == EventSeries.MonthlyRuleType.DAY_OF_MONTH:
+        days_in_month = monthrange(year, month)[1]
+        if series.day_of_month > days_in_month:
+            return None
+        return date(year, month, series.day_of_month)
+
+    weekday_index = WEEKDAY_TO_INDEX[series.weekday_of_month]
+    first_weekday, days_in_month = monthrange(year, month)
+    first_target_day = 1 + ((weekday_index - first_weekday) % 7)
+    day = first_target_day + ((series.week_of_month - 1) * 7)
+    if day > days_in_month:
+        return None
+    return date(year, month, day)
+
+
+def _add_months(year: int, month: int, month_offset: int) -> tuple[int, int]:
+    zero_based_month = month - 1 + month_offset
+    return year + (zero_based_month // 12), (zero_based_month % 12) + 1
+
+
+def _can_continue(existing_dates: list[date], candidate: date, series: EventSeries) -> bool:
+    if series.end_date and candidate > series.end_date:
+        return False
+    if series.occurrence_count and len(existing_dates) >= series.occurrence_count:
+        return False
+    return True

--- a/tosca_api/apps/events/tests/test_api.py
+++ b/tosca_api/apps/events/tests/test_api.py
@@ -1,4 +1,5 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
 
 import pytest
 from django.contrib.auth import get_user_model
@@ -38,6 +39,10 @@ def build_series_kwargs(user, campaign, event_type, **overrides):
     }
     kwargs.update(overrides)
     return kwargs
+
+
+def parse_api_datetime(value):
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
 
 
 @pytest.fixture
@@ -931,6 +936,231 @@ def test_events_retrieve_detail_uses_series_default_context(
 # =============================================================================
 # Create/Update/Delete Tests
 # =============================================================================
+
+
+@pytest.mark.django_db
+def test_event_series_preview_manual_batch_returns_one_occurrence_per_explicit_date(
+    api_client, user, campaign, event_type
+):
+    """Manual batch preview should return one preview occurrence per explicit date."""
+    api_client.force_authenticate(user=user)
+    response = api_client.post(
+        "/api/v1/event-series/preview/",
+        {
+            "campaign": str(campaign.id),
+            "event_type": str(event_type.id),
+            "name": "Manual Batch",
+            "series_mode": "manual_batch",
+            "start_date": "2026-04-01",
+            "start_time": "09:00:00",
+            "end_time": "10:30:00",
+            "timezone": "Europe/Berlin",
+            "explicit_dates": ["2026-04-03", "2026-04-10", "2026-04-17"],
+            "title": "Manual Event",
+            "location_mode": "online",
+            "online_url": "https://example.org/live",
+            "status": "draft",
+        },
+        format="json",
+    )
+
+    assert response.status_code == 200
+    assert [item["occurrence_index"] for item in response.data["occurrences"]] == [1, 2, 3]
+    assert [item["occurrence_date"] for item in response.data["occurrences"]] == [
+        "2026-04-03",
+        "2026-04-10",
+        "2026-04-17",
+    ]
+
+
+@pytest.mark.django_db
+def test_event_series_create_weekly_generates_occurrences_with_series_metadata(
+    api_client, user, campaign, event_type
+):
+    """Recurring series creation should persist generated events with series metadata."""
+    api_client.force_authenticate(user=user)
+    response = api_client.post(
+        "/api/v1/event-series/",
+        {
+            "campaign": str(campaign.id),
+            "event_type": str(event_type.id),
+            "name": "Weekly Series",
+            "series_mode": "recurring",
+            "recurrence_type": "weekly",
+            "start_date": "2026-04-06",
+            "occurrence_count": 3,
+            "interval": 1,
+            "start_time": "18:00:00",
+            "end_time": "19:30:00",
+            "timezone": "Europe/Berlin",
+            "by_weekday": ["monday"],
+            "title": "Recurring Event",
+            "location_mode": "online",
+            "online_url": "https://example.org/live",
+            "status": "draft",
+        },
+        format="json",
+    )
+
+    assert response.status_code == 201
+
+    series = EventSeries.objects.get(id=response.data["id"])
+    events = list(series.events.order_by("occurrence_index"))
+
+    assert [event.occurrence_index for event in events] == [1, 2, 3]
+    assert all(event.series_id == series.id for event in events)
+    assert all(event.original_start_datetime == event.start_datetime for event in events)
+    assert [event.start_datetime.astimezone(ZoneInfo("Europe/Berlin")).date().isoformat() for event in events] == [
+        "2026-04-06",
+        "2026-04-13",
+        "2026-04-20",
+    ]
+
+
+@pytest.mark.django_db
+def test_event_series_preview_weekly_preserves_wall_time_across_dst(
+    api_client, user, campaign, event_type
+):
+    """Weekly previews should preserve the same local clock time across DST changes."""
+    api_client.force_authenticate(user=user)
+    response = api_client.post(
+        "/api/v1/event-series/preview/",
+        {
+            "campaign": str(campaign.id),
+            "event_type": str(event_type.id),
+            "name": "DST Weekly Series",
+            "series_mode": "recurring",
+            "recurrence_type": "weekly",
+            "start_date": "2026-03-23",
+            "occurrence_count": 3,
+            "interval": 1,
+            "start_time": "09:00:00",
+            "end_time": "10:00:00",
+            "timezone": "Europe/Berlin",
+            "by_weekday": ["monday"],
+            "title": "DST Event",
+            "location_mode": "online",
+            "online_url": "https://example.org/live",
+            "status": "draft",
+        },
+        format="json",
+    )
+
+    assert response.status_code == 200
+
+    berlin = ZoneInfo("Europe/Berlin")
+    local_starts = [
+        parse_api_datetime(item["start_datetime"]).astimezone(berlin)
+        for item in response.data["occurrences"]
+    ]
+    assert [start.hour for start in local_starts] == [9, 9, 9]
+    assert [start.utcoffset() for start in local_starts] == [
+        timedelta(hours=1),
+        timedelta(hours=2),
+        timedelta(hours=2),
+    ]
+
+
+@pytest.mark.django_db
+def test_events_patch_marks_generated_occurrence_as_exception(
+    api_client, user, campaign, event_type
+):
+    """Editing a generated occurrence directly should mark it as an exception."""
+    api_client.force_authenticate(user=user)
+    create_response = api_client.post(
+        "/api/v1/event-series/",
+        {
+            "campaign": str(campaign.id),
+            "event_type": str(event_type.id),
+            "name": "Exception Series",
+            "series_mode": "recurring",
+            "recurrence_type": "weekly",
+            "start_date": "2026-04-06",
+            "occurrence_count": 2,
+            "interval": 1,
+            "start_time": "18:00:00",
+            "end_time": "19:00:00",
+            "timezone": "Europe/Berlin",
+            "by_weekday": ["monday"],
+            "title": "Generated Event",
+            "location_mode": "online",
+            "online_url": "https://example.org/live",
+            "status": "draft",
+        },
+        format="json",
+    )
+    series = EventSeries.objects.get(id=create_response.data["id"])
+    event = series.events.order_by("occurrence_index").first()
+    original_start = event.start_datetime
+
+    new_start = original_start + timedelta(hours=2)
+    response = api_client.patch(
+        f"/api/v1/events/{event.id}/",
+        {
+            "start_datetime": new_start.isoformat(),
+            "end_datetime": (new_start + timedelta(hours=1)).isoformat(),
+        },
+        format="json",
+    )
+
+    assert response.status_code == 200
+    event.refresh_from_db()
+    assert event.is_exception is True
+    assert event.original_start_datetime == original_start
+    assert event.start_datetime == new_start
+
+
+@pytest.mark.django_db
+def test_event_series_patch_skips_future_exception_occurrences_by_default(
+    api_client, user, campaign, event_type
+):
+    """Future bulk updates should leave exception occurrences untouched by default."""
+    api_client.force_authenticate(user=user)
+    create_response = api_client.post(
+        "/api/v1/event-series/",
+        {
+            "campaign": str(campaign.id),
+            "event_type": str(event_type.id),
+            "name": "Bulk Update Series",
+            "series_mode": "recurring",
+            "recurrence_type": "weekly",
+            "start_date": "2026-04-06",
+            "occurrence_count": 3,
+            "interval": 1,
+            "start_time": "18:00:00",
+            "end_time": "19:00:00",
+            "timezone": "Europe/Berlin",
+            "by_weekday": ["monday"],
+            "title": "Original Series Title",
+            "location_mode": "online",
+            "online_url": "https://example.org/live",
+            "status": "draft",
+        },
+        format="json",
+    )
+    series = EventSeries.objects.get(id=create_response.data["id"])
+    events = list(series.events.order_by("occurrence_index"))
+
+    exception_response = api_client.patch(
+        f"/api/v1/events/{events[1].id}/",
+        {"title": "Exception Title"},
+        format="json",
+    )
+    assert exception_response.status_code == 200
+
+    response = api_client.patch(
+        f"/api/v1/event-series/{series.id}/",
+        {"title": "Updated Series Title"},
+        format="json",
+    )
+
+    assert response.status_code == 200
+    series.refresh_from_db()
+    events = list(series.events.order_by("occurrence_index"))
+    assert events[0].title == "Updated Series Title"
+    assert events[1].title == "Exception Title"
+    assert events[1].is_exception is True
+    assert events[2].title == "Updated Series Title"
 
 
 @pytest.mark.django_db

--- a/tosca_api/apps/events/tests/test_models.py
+++ b/tosca_api/apps/events/tests/test_models.py
@@ -1,4 +1,4 @@
-from datetime import timedelta
+from datetime import time, timedelta
 
 import pytest
 from django.contrib.auth import get_user_model
@@ -1068,6 +1068,27 @@ def test_recurring_series_rejects_invalid_end_date_occurrence_count_combinations
         )
 
     assert "end_date" in exc.value.message_dict
+
+
+@pytest.mark.django_db
+def test_recurring_series_requires_same_day_end_time(user, campaign, event_type):
+    """Recurring generation currently only supports same-day occurrence durations."""
+    with pytest.raises(ValidationError) as exc:
+        EventSeries.objects.create(
+            **build_series_kwargs(
+                user,
+                campaign,
+                event_type,
+                series_mode=EventSeries.SeriesMode.RECURRING,
+                recurrence_type=EventSeries.RecurrenceType.WEEKLY,
+                start_time=time(18, 0),
+                by_weekday=["monday"],
+                end_date=timezone.now().date() + timedelta(days=14),
+                end_time=time(17, 0),
+            )
+        )
+
+    assert "end_time" in exc.value.message_dict
 
     with pytest.raises(ValidationError) as exc:
         EventSeries.objects.create(

--- a/tosca_api/apps/events/urls.py
+++ b/tosca_api/apps/events/urls.py
@@ -1,10 +1,11 @@
 from django.urls import include, path
 from rest_framework.routers import DefaultRouter
 
-from .views import EventViewSet
+from .views import EventSeriesViewSet, EventViewSet
 
 router = DefaultRouter()
 router.register(r"events", EventViewSet, basename="event")
+router.register(r"event-series", EventSeriesViewSet, basename="event-series")
 
 urlpatterns = [
     path("", include(router.urls)),

--- a/tosca_api/apps/events/views.py
+++ b/tosca_api/apps/events/views.py
@@ -1,10 +1,11 @@
 from rest_framework import permissions, status, viewsets
 from rest_framework.decorators import action
+from rest_framework.mixins import CreateModelMixin, RetrieveModelMixin, UpdateModelMixin
 from rest_framework.pagination import CursorPagination
 from rest_framework.response import Response
 
 from .filters import apply_event_filters
-from .models import Event
+from .models import Event, EventSeries
 from .serializers import (
     BBoxSerializer,
     EventWriteSerializer,
@@ -12,8 +13,12 @@ from .serializers import (
     EventGeoSerializer,
     EventListSerializer,
     EventMapOnlineSerializer,
+    EventSeriesOccurrenceSerializer,
+    EventSeriesResponseSerializer,
+    EventSeriesWriteSerializer,
     GeometryFilterSerializer,
 )
+from .services import serialize_occurrence_specs
 
 
 class EventCursorPagination(CursorPagination):
@@ -215,3 +220,48 @@ class EventViewSet(viewsets.ModelViewSet):
         # Serialize as GeoJSON
         serializer = EventGeoSerializer(queryset, many=True)
         return Response(serializer.data)
+
+
+class EventSeriesViewSet(
+    CreateModelMixin,
+    UpdateModelMixin,
+    RetrieveModelMixin,
+    viewsets.GenericViewSet,
+):
+    """Preview, create, and update event series with generated occurrences."""
+
+    queryset = EventSeries.objects.all().select_related(
+        "campaign",
+        "event_type",
+        "default_context",
+        "created_by",
+    )
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get_serializer_class(self):
+        if self.action == "retrieve":
+            return EventSeriesResponseSerializer
+        return EventSeriesWriteSerializer
+
+    def create(self, request, *args, **kwargs):
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        series = serializer.save()
+        response_serializer = EventSeriesResponseSerializer(series)
+        return Response(response_serializer.data, status=status.HTTP_201_CREATED)
+
+    def partial_update(self, request, *args, **kwargs):
+        series = self.get_object()
+        serializer = self.get_serializer(series, data=request.data, partial=True)
+        serializer.is_valid(raise_exception=True)
+        series = serializer.save()
+        response_serializer = EventSeriesResponseSerializer(series)
+        return Response(response_serializer.data)
+
+    @action(detail=False, methods=["post"], url_path="preview")
+    def preview(self, request):
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        occurrences = serialize_occurrence_specs(serializer.validated_data["_occurrences"])
+        response_serializer = EventSeriesOccurrenceSerializer(occurrences, many=True)
+        return Response({"occurrences": response_serializer.data})


### PR DESCRIPTION
Add the dedicated event-series recurrence authoring surface with:
- POST /api/v1/event-series/preview/
- POST /api/v1/event-series/
- PATCH /api/v1/event-series/{id}/

Introduce a shared recurrence generation service for manual batches and recurring series so preview, create, and update flows use one source of truth for occurrence calculation.

Persist generated occurrences with:
- series_id
- occurrence_index
- original_start_datetime

Generate occurrences in the EventSeries timezone and preserve weekly local wall-clock time across DST transitions.

Add exception behavior for generated events:
- direct edits to generated occurrences through /api/v1/events/{id}/ now mark the row as is_exception=true when schedule, content, location, or taxonomy data diverges
- bulk series updates skip future exception occurrences by default
- future non-exception occurrences are updated, created, or deleted based on the regenerated schedule

Tighten recurring validation to the currently supported generation model by requiring same-day end times for recurring occurrences. Document this explicitly because EventSeries.end_date is already being used as the recurrence termination boundary, so multi-day recurring occurrence duration would need explicit schema support later.

Add focused coverage for:
- manual batch preview output
- weekly recurring preview/create generation
- generated occurrence metadata persistence
- exception marking on direct occurrence edits
- exception-safe future bulk updates
- weekly DST wall-time preservation

## Summary

- [ ] Description of changes
- [ ] Related issue link

## Testing

- [ ] `uv run pytest`
- [ ] Other (describe)
