### PR TITLE
feat(core): add Editor.js validation and normalization layer

### DIFF
--- a/tosca_api/apps/core/editorjs.py
+++ b/tosca_api/apps/core/editorjs.py
@@ -1,0 +1,225 @@
+"""
+Editor.js validation and normalization layer for GeoContext content.
+
+This module owns block-schema validation, deterministic normalization, and
+inline HTML sanitization for Editor.js documents stored in
+``GeoContext.content``. It is intentionally separate from the legacy HTML
+sanitizer in :mod:`tosca_api.apps.core.sanitization`, which serves freeform
+text fields on other models.
+
+Accepted input: either the canonical storage shape ``{"blocks": [...]}`` or
+a full Editor.js save envelope ``{"time", "version", "blocks"}``. The
+envelope fields and any per-block ``id`` are stripped on normalization so
+stored documents are deterministic and round-trip stable.
+
+MVP block set: ``paragraph``, ``header``, ``list``, ``quote``, ``delimiter``,
+``code``.
+
+MVP inline toolset: ``a``, ``strong``, ``em``, ``code``, ``br``. ``<b>`` and
+``<i>`` are rewritten to ``<strong>`` and ``<em>`` respectively. Unsafe URL
+schemes (anything outside ``http``, ``https``, ``mailto``) are rejected.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import nh3
+from django.core.exceptions import ValidationError
+
+_ALLOWED_BLOCK_TYPES = {
+    "paragraph",
+    "header",
+    "list",
+    "quote",
+    "delimiter",
+    "code",
+}
+
+_INLINE_TAGS = {"a", "strong", "em", "code", "br"}
+_INLINE_ATTRS = {"a": {"href", "title"}}
+_INLINE_URL_SCHEMES = {"http", "https", "mailto"}
+
+_HEADER_LEVELS = {1, 2, 3, 4}
+_LIST_STYLES = {"ordered", "unordered"}
+
+_B_OPEN = re.compile(r"<b(\s[^>]*)?>", re.IGNORECASE)
+_B_CLOSE = re.compile(r"</b\s*>", re.IGNORECASE)
+_I_OPEN = re.compile(r"<i(\s[^>]*)?>", re.IGNORECASE)
+_I_CLOSE = re.compile(r"</i\s*>", re.IGNORECASE)
+
+_UNSAFE_SCHEME = re.compile(r"""<a\b[^>]*\bhref\s*=\s*['"]?\s*([a-zA-Z][a-zA-Z0-9+.\-]*):""")
+
+
+def empty_document() -> dict:
+    """Return the canonical empty Editor.js document."""
+    return {"blocks": []}
+
+
+def validate_and_normalize(value: Any) -> dict:
+    """
+    Validate and normalize an Editor.js document.
+
+    Accepts ``None`` / ``{}`` / ``{"blocks": []}`` / full save envelope and
+    returns the canonical storage form ``{"blocks": [...]}`` with only
+    supported block types and inline formatting.
+
+    Raises:
+        ValidationError: if the document shape or any block is invalid.
+    """
+    if value in (None, "", {}, []):
+        return empty_document()
+
+    if not isinstance(value, dict):
+        raise ValidationError("GeoContext content must be a JSON object.")
+
+    if "blocks" not in value:
+        raise ValidationError("GeoContext content must contain a 'blocks' array.")
+
+    blocks = value["blocks"]
+    if not isinstance(blocks, list):
+        raise ValidationError("'blocks' must be an array.")
+
+    normalized_blocks = [_normalize_block(b, idx) for idx, b in enumerate(blocks)]
+    return {"blocks": normalized_blocks}
+
+
+def _normalize_block(block: Any, idx: int) -> dict:
+    if not isinstance(block, dict):
+        raise ValidationError(f"Block at index {idx} must be an object.")
+
+    block_type = block.get("type")
+    if block_type not in _ALLOWED_BLOCK_TYPES:
+        raise ValidationError(
+            f"Block at index {idx} has unsupported type '{block_type}'. "
+            f"Allowed types: {sorted(_ALLOWED_BLOCK_TYPES)}."
+        )
+
+    data = block.get("data")
+    if not isinstance(data, dict):
+        raise ValidationError(f"Block at index {idx} is missing a 'data' object.")
+
+    normalizer = _BLOCK_NORMALIZERS[block_type]
+    normalized_data = normalizer(data, idx)
+    return {"type": block_type, "data": normalized_data}
+
+
+def _normalize_paragraph(data: dict, idx: int) -> dict:
+    text = data.get("text", "")
+    if not isinstance(text, str):
+        raise ValidationError(f"paragraph block at {idx} requires a string 'text'.")
+    return {"text": _sanitize_inline(text, idx)}
+
+
+def _normalize_header(data: dict, idx: int) -> dict:
+    text = data.get("text", "")
+    level = data.get("level")
+    if not isinstance(text, str):
+        raise ValidationError(f"header block at {idx} requires a string 'text'.")
+    if level not in _HEADER_LEVELS:
+        raise ValidationError(
+            f"header block at {idx} requires 'level' in {sorted(_HEADER_LEVELS)}, got {level!r}."
+        )
+    return {"text": _sanitize_inline(text, idx), "level": level}
+
+
+def _normalize_list(data: dict, idx: int) -> dict:
+    style = data.get("style")
+    if style not in _LIST_STYLES:
+        raise ValidationError(
+            f"list block at {idx} requires 'style' in {sorted(_LIST_STYLES)}, got {style!r}."
+        )
+    items = data.get("items")
+    if not isinstance(items, list):
+        raise ValidationError(f"list block at {idx} requires an 'items' array.")
+    meta = data.get("meta", {})
+    if meta != {}:
+        raise ValidationError(
+            f"list block at {idx} must have 'meta' equal to {{}} (MVP); got {meta!r}."
+        )
+    normalized_items = [_normalize_list_item(item, idx, path=str(i)) for i, item in enumerate(items)]
+    return {"style": style, "items": normalized_items, "meta": {}}
+
+
+def _normalize_list_item(item: Any, block_idx: int, path: str) -> dict:
+    if isinstance(item, str):
+        return {"content": _sanitize_inline(item, block_idx), "items": []}
+    if isinstance(item, dict):
+        content = item.get("content", "")
+        if not isinstance(content, str):
+            raise ValidationError(
+                f"list item {path} in block {block_idx} requires a string 'content'."
+            )
+        nested = item.get("items", [])
+        if not isinstance(nested, list):
+            raise ValidationError(
+                f"list item {path} in block {block_idx} 'items' must be an array."
+            )
+        return {
+            "content": _sanitize_inline(content, block_idx),
+            "items": [
+                _normalize_list_item(child, block_idx, path=f"{path}.{i}")
+                for i, child in enumerate(nested)
+            ],
+        }
+    raise ValidationError(
+        f"list item {path} in block {block_idx} must be a string or object."
+    )
+
+
+def _normalize_quote(data: dict, idx: int) -> dict:
+    if "alignment" in data:
+        raise ValidationError(f"quote block at {idx} must not set 'alignment' (MVP).")
+    text = data.get("text", "")
+    caption = data.get("caption", "")
+    if not isinstance(text, str) or not isinstance(caption, str):
+        raise ValidationError(f"quote block at {idx} requires string 'text' and 'caption'.")
+    return {"text": _sanitize_inline(text, idx), "caption": _sanitize_inline(caption, idx)}
+
+
+def _normalize_delimiter(data: dict, idx: int) -> dict:
+    return {}
+
+
+def _normalize_code(data: dict, idx: int) -> dict:
+    code = data.get("code", "")
+    if not isinstance(code, str):
+        raise ValidationError(f"code block at {idx} requires a string 'code'.")
+    return {"code": code}
+
+
+_BLOCK_NORMALIZERS = {
+    "paragraph": _normalize_paragraph,
+    "header": _normalize_header,
+    "list": _normalize_list,
+    "quote": _normalize_quote,
+    "delimiter": _normalize_delimiter,
+    "code": _normalize_code,
+}
+
+
+def _sanitize_inline(text: str, block_idx: int) -> str:
+    """Normalize <b>/<i> to <strong>/<em>, strip disallowed tags, reject unsafe URLs."""
+    if not text:
+        return ""
+
+    rewritten = _B_OPEN.sub("<strong>", text)
+    rewritten = _B_CLOSE.sub("</strong>", rewritten)
+    rewritten = _I_OPEN.sub("<em>", rewritten)
+    rewritten = _I_CLOSE.sub("</em>", rewritten)
+
+    for match in _UNSAFE_SCHEME.finditer(rewritten):
+        scheme = match.group(1).lower()
+        if scheme not in _INLINE_URL_SCHEMES:
+            raise ValidationError(
+                f"block {block_idx} contains unsafe URL scheme '{scheme}:' in inline link."
+            )
+
+    return nh3.clean(
+        rewritten,
+        tags=_INLINE_TAGS,
+        attributes=_INLINE_ATTRS,
+        url_schemes=_INLINE_URL_SCHEMES,
+        link_rel=None,
+    )

--- a/tosca_api/apps/core/tests/test_editorjs.py
+++ b/tosca_api/apps/core/tests/test_editorjs.py
@@ -1,0 +1,204 @@
+"""
+Tests for the Editor.js validation and normalization layer.
+"""
+
+import pytest
+from django.core.exceptions import ValidationError
+
+from tosca_api.apps.core.editorjs import empty_document, validate_and_normalize
+
+
+def test_empty_inputs_return_canonical_empty_document():
+    for value in (None, "", {}, [], {"blocks": []}):
+        assert validate_and_normalize(value) == {"blocks": []}
+
+
+def test_non_dict_input_rejected():
+    with pytest.raises(ValidationError):
+        validate_and_normalize("hello")
+
+
+def test_missing_blocks_key_rejected():
+    with pytest.raises(ValidationError):
+        validate_and_normalize({"time": 1, "version": "2.28.0"})
+
+
+def test_accepts_supported_block_types():
+    doc = {
+        "blocks": [
+            {"type": "paragraph", "data": {"text": "Hello"}},
+            {"type": "header", "data": {"text": "T", "level": 2}},
+            {"type": "list", "data": {"style": "unordered", "items": ["a", "b"]}},
+            {"type": "quote", "data": {"text": "q", "caption": "c"}},
+            {"type": "delimiter", "data": {}},
+            {"type": "code", "data": {"code": "print(1)"}},
+        ]
+    }
+    out = validate_and_normalize(doc)
+    types = [b["type"] for b in out["blocks"]]
+    assert types == ["paragraph", "header", "list", "quote", "delimiter", "code"]
+
+
+def test_normalizes_save_envelope_strips_time_version_and_block_ids():
+    doc = {
+        "time": 1234567890,
+        "version": "2.28.0",
+        "blocks": [
+            {
+                "id": "abc123",
+                "type": "paragraph",
+                "data": {"text": "Hi"},
+                "tunes": {"ignored": True},
+            }
+        ],
+    }
+    out = validate_and_normalize(doc)
+    assert out == {"blocks": [{"type": "paragraph", "data": {"text": "Hi"}}]}
+    assert "time" not in out
+    assert "version" not in out
+    assert "id" not in out["blocks"][0]
+
+
+def test_normalizes_b_and_i_to_semantic_tags():
+    doc = {
+        "blocks": [
+            {"type": "paragraph", "data": {"text": "<b>bold</b> and <i>italic</i>"}},
+        ]
+    }
+    out = validate_and_normalize(doc)
+    text = out["blocks"][0]["data"]["text"]
+    assert "<strong>bold</strong>" in text
+    assert "<em>italic</em>" in text
+    assert "<b>" not in text and "<i>" not in text
+
+
+def test_strips_disallowed_tags_like_script_and_handlers():
+    doc = {
+        "blocks": [
+            {"type": "paragraph", "data": {"text": "safe<script>alert(1)</script>"}},
+        ]
+    }
+    out = validate_and_normalize(doc)
+    text = out["blocks"][0]["data"]["text"]
+    assert "<script" not in text
+    assert "alert" not in text
+    assert text.startswith("safe")
+
+
+def test_rejects_javascript_url_scheme_in_links():
+    doc = {
+        "blocks": [
+            {"type": "paragraph", "data": {"text": '<a href="javascript:alert(1)">x</a>'}},
+        ]
+    }
+    with pytest.raises(ValidationError):
+        validate_and_normalize(doc)
+
+
+def test_accepts_safe_url_schemes_in_links():
+    doc = {
+        "blocks": [
+            {"type": "paragraph", "data": {"text": '<a href="https://x.test">x</a>'}},
+        ]
+    }
+    out = validate_and_normalize(doc)
+    assert 'href="https://x.test"' in out["blocks"][0]["data"]["text"]
+
+
+def test_rejects_unsupported_block_type():
+    with pytest.raises(ValidationError):
+        validate_and_normalize({"blocks": [{"type": "image", "data": {"url": "x"}}]})
+
+
+def test_rejects_header_level_out_of_range():
+    for bad_level in (0, 5, "2", None):
+        with pytest.raises(ValidationError):
+            validate_and_normalize(
+                {"blocks": [{"type": "header", "data": {"text": "t", "level": bad_level}}]}
+            )
+
+
+def test_rejects_quote_alignment():
+    with pytest.raises(ValidationError):
+        validate_and_normalize(
+            {"blocks": [{"type": "quote", "data": {"text": "q", "caption": "c", "alignment": "left"}}]}
+        )
+
+
+def test_rejects_non_empty_list_meta():
+    with pytest.raises(ValidationError):
+        validate_and_normalize(
+            {
+                "blocks": [
+                    {
+                        "type": "list",
+                        "data": {
+                            "style": "ordered",
+                            "items": ["a"],
+                            "meta": {"start": 5},
+                        },
+                    }
+                ]
+            }
+        )
+
+
+def test_accepts_nested_list_items():
+    doc = {
+        "blocks": [
+            {
+                "type": "list",
+                "data": {
+                    "style": "unordered",
+                    "items": [
+                        {"content": "parent", "items": [{"content": "child", "items": []}]},
+                    ],
+                    "meta": {},
+                },
+            }
+        ]
+    }
+    out = validate_and_normalize(doc)
+    items = out["blocks"][0]["data"]["items"]
+    assert items[0]["content"] == "parent"
+    assert items[0]["items"][0]["content"] == "child"
+
+
+def test_list_string_items_are_upgraded_to_content_dicts():
+    doc = {
+        "blocks": [
+            {"type": "list", "data": {"style": "ordered", "items": ["a", "b"], "meta": {}}}
+        ]
+    }
+    out = validate_and_normalize(doc)
+    items = out["blocks"][0]["data"]["items"]
+    assert items == [
+        {"content": "a", "items": []},
+        {"content": "b", "items": []},
+    ]
+
+
+def test_invalid_block_shape_rejected():
+    with pytest.raises(ValidationError):
+        validate_and_normalize({"blocks": ["not-a-dict"]})
+    with pytest.raises(ValidationError):
+        validate_and_normalize({"blocks": [{"type": "paragraph"}]})
+
+
+def test_round_trip_is_byte_equal():
+    doc = {
+        "blocks": [
+            {"type": "paragraph", "data": {"text": "Hello <strong>world</strong>"}},
+            {"type": "header", "data": {"text": "Title", "level": 3}},
+            {"type": "list", "data": {"style": "ordered", "items": ["x"], "meta": {}}},
+            {"type": "delimiter", "data": {}},
+            {"type": "code", "data": {"code": "x=1"}},
+        ]
+    }
+    once = validate_and_normalize(doc)
+    twice = validate_and_normalize(once)
+    assert once == twice
+
+
+def test_empty_document_helper():
+    assert empty_document() == {"blocks": []}

--- a/tosca_api/apps/geocontext/models.py
+++ b/tosca_api/apps/geocontext/models.py
@@ -13,12 +13,13 @@ import uuid
 from django.conf import settings
 from django.db import models
 
+from tosca_api.apps.core.editorjs import empty_document, validate_and_normalize
 from tosca_api.apps.core.models import TimeStampedModel
 
 
 def empty_editorjs_document() -> dict:
     """Return the canonical empty Editor.js document."""
-    return {"blocks": []}
+    return empty_document()
 
 
 class GeoContext(TimeStampedModel):
@@ -57,7 +58,6 @@ class GeoContext(TimeStampedModel):
         return f"GeoContext: {len(blocks)} block(s)"
 
     def save(self, *args, **kwargs) -> None:
-        """Normalize missing/empty content to the canonical empty document."""
-        if self.content in (None, "", {}, []):
-            self.content = empty_editorjs_document()
+        """Validate and normalize Editor.js content before persistence."""
+        self.content = validate_and_normalize(self.content)
         super().save(*args, **kwargs)


### PR DESCRIPTION
Introduce a dedicated Editor.js validation layer in tosca_api/apps/core/editorjs.py and wire it into GeoContext.save() so every GeoContext write produces deterministic, canonical storage.

- New module exposes validate_and_normalize() and empty_document(). The validator accepts either the canonical storage shape {"blocks": [...]} or a full Editor.js save envelope with time/version/id/tunes, and returns a stripped canonical document.
- MVP block set enforced: paragraph, header, list, quote, delimiter, code. Unsupported block types raise django.core.exceptions.ValidationError.
- Inline sanitization (nh3) restricts text-bearing fields to a/strong/em/ code/br. <b>/<i> are rewritten to <strong>/<em> before sanitization. Link schemes restricted to http, https, mailto; javascript: raises.
- Schema rules: header.level must be in {1,2,3,4}, quote.alignment is rejected, list.meta is constrained to {} for MVP, list items accept either strings or {content, items} dicts (nested lists preserved).
- GeoContext.save() now delegates to validate_and_normalize, replacing the prior "normalize empty-only" shim. Round-trip is byte-equal.
- 18 unit tests added under tosca_api/apps/core/tests/test_editorjs.py; full 291-test run green (1 pre-existing unrelated failure in events/test_api.py::test_event_series_patch_skips_future_exception_occurrences_by_default, unchanged by this patch).

## Summary

- [ ] Description of changes
- [ ] Related issue link

## Testing

- [ ] `uv run pytest`
- [ ] Other (describe)
