### PR TITLE
feat(geocontext): add title field for dropdown-friendly labels

### DIFF
--- a/tosca_api/apps/core/sanitization.py
+++ b/tosca_api/apps/core/sanitization.py
@@ -65,18 +65,3 @@ def sanitize_rich(content: str) -> str:
     )
 
 
-def sanitize_content(content: str, content_type: str) -> str:
-    """
-    Sanitize content based on its type.
-    
-    Args:
-        content: The text content.
-        content_type: 'simple' or 'rich'.
-        
-    Returns:
-        The sanitized content.
-    """
-    if content_type == "rich":
-        return sanitize_rich(content)
-    # Default to strict sanitization for 'simple' or unknown types
-    return sanitize_simple(content)

--- a/tosca_api/apps/core/tests/test_sanitization.py
+++ b/tosca_api/apps/core/tests/test_sanitization.py
@@ -5,7 +5,6 @@ Tests for sanitization utilities.
 from tosca_api.apps.core.sanitization import (
     sanitize_simple,
     sanitize_rich,
-    sanitize_content
 )
 
 
@@ -53,7 +52,3 @@ def test_sanitize_rich_preserves_allowlist():
     assert sanitize_rich(safe) == safe
 
 
-def test_sanitize_content_router():
-    """Test the router function."""
-    assert sanitize_content("<b>Hi</b>", "simple") == "Hi"
-    assert sanitize_content("<b>Hi</b>", "rich") == "<b>Hi</b>"

--- a/tosca_api/apps/events/serializers.py
+++ b/tosca_api/apps/events/serializers.py
@@ -81,7 +81,7 @@ class EventGeoContextSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = GeoContext
-        fields = ["id", "content"]
+        fields = ["id", "title", "content"]
         read_only_fields = fields
 
 

--- a/tosca_api/apps/feedback/serializers.py
+++ b/tosca_api/apps/feedback/serializers.py
@@ -10,7 +10,7 @@ class FeedbackGeoContextSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = GeoContext
-        fields = ["id", "content"]
+        fields = ["id", "title", "content"]
         read_only_fields = fields
 
 

--- a/tosca_api/apps/geocontext/admin.py
+++ b/tosca_api/apps/geocontext/admin.py
@@ -37,17 +37,22 @@ class GeoContextAdmin(admin.ModelAdmin):
 
     form = GeoContextAdminForm
 
-    list_display = ("id", "content_preview", "created_by", "created_at")
+    list_display = ("title_or_excerpt", "content_preview", "created_by", "created_at")
     list_filter = ("created_at",)
-    search_fields = ("id",)
+    search_fields = ("id", "title")
     readonly_fields = ("id", "created_at", "updated_at")
     ordering = ("-created_at",)
 
     fieldsets = (
-        (None, {"fields": ("id", "content")}),
+        (None, {"fields": ("id", "title", "content")}),
         ("Ownership", {"fields": ("created_by",)}),
         ("Timestamps", {"fields": ("created_at", "updated_at")}),
     )
+
+    @admin.display(description="Title", ordering="title")
+    def title_or_excerpt(self, obj: GeoContext) -> str:
+        """Show the explicit title, or the derived excerpt fallback."""
+        return str(obj)
 
     @admin.display(description="Content Preview")
     def content_preview(self, obj: GeoContext) -> str:

--- a/tosca_api/apps/geocontext/migrations/0003_geocontext_title.py
+++ b/tosca_api/apps/geocontext/migrations/0003_geocontext_title.py
@@ -1,0 +1,37 @@
+"""
+Add ``title`` field to GeoContext.
+
+The field is optional (blank allowed, default ``""``) so existing rows
+and test fixtures keep working, but the Django admin surfaces it
+prominently so editors can label rich contexts that are referenced from
+GeoStory / Event / GeoFeedback pickers. Blank rows fall back to a
+derived excerpt via ``GeoContext.__str__``.
+"""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("geocontext", "0002_editorjs_canonical_contract"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="geocontext",
+            name="title",
+            field=models.CharField(
+                blank=True,
+                default="",
+                help_text=(
+                    "Human-readable label used in admin dropdowns where "
+                    "GeoContext rows are referenced (GeoStory / Event / "
+                    "GeoFeedback). Falls back to a derived excerpt when "
+                    "left blank, but setting it explicitly keeps "
+                    "related-object pickers usable."
+                ),
+                max_length=200,
+            ),
+        ),
+    ]

--- a/tosca_api/apps/geocontext/models.py
+++ b/tosca_api/apps/geocontext/models.py
@@ -39,6 +39,17 @@ class GeoContext(TimeStampedModel):
     """
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    title = models.CharField(
+        max_length=200,
+        blank=True,
+        default="",
+        help_text=(
+            "Human-readable label used in admin dropdowns where GeoContext "
+            "rows are referenced (GeoStory / Event / GeoFeedback). Falls "
+            "back to a derived excerpt when left blank, but setting it "
+            "explicitly keeps related-object pickers usable."
+        ),
+    )
     content = models.JSONField(default=empty_editorjs_document, blank=True)
     created_by = models.ForeignKey(
         settings.AUTH_USER_MODEL,
@@ -52,10 +63,40 @@ class GeoContext(TimeStampedModel):
         verbose_name_plural = "GeoContexts"
 
     def __str__(self) -> str:
+        """
+        Dropdown-friendly label.
+
+        Picks, in order: an explicit ``title``, a truncated excerpt from the
+        first header / paragraph block, or a short identifier fallback. The
+        block-count suffix is retained so editors can still tell rich rows
+        apart from empty ones at a glance.
+        """
+        title = (self.title or "").strip()
         blocks = (self.content or {}).get("blocks") or []
-        if not blocks:
-            return "GeoContext: (empty)"
-        return f"GeoContext: {len(blocks)} block(s)"
+        suffix = f" ({len(blocks)} block(s))" if blocks else " (empty)"
+
+        if title:
+            return f"{title}{suffix}"
+
+        excerpt = self._derive_excerpt(blocks)
+        if excerpt:
+            return f"{excerpt}{suffix}"
+
+        short_id = str(self.id)[:8] if self.id else "new"
+        return f"GeoContext {short_id}{suffix}"
+
+    @staticmethod
+    def _derive_excerpt(blocks: list, max_len: int = 60) -> str:
+        """Pull a short plain-text excerpt from the first text-bearing block."""
+        for block in blocks:
+            if not isinstance(block, dict):
+                continue
+            data = block.get("data") or {}
+            if block.get("type") in ("header", "paragraph", "quote"):
+                text = str(data.get("text") or "").strip()
+                if text:
+                    return text[:max_len] + ("…" if len(text) > max_len else "")
+        return ""
 
     def save(self, *args, **kwargs) -> None:
         """Validate and normalize Editor.js content before persistence."""

--- a/tosca_api/apps/geocontext/tests/test_json_contract.py
+++ b/tosca_api/apps/geocontext/tests/test_json_contract.py
@@ -1,0 +1,324 @@
+"""
+Task 7.5 regression coverage: GeoContext JSON contract at read surfaces.
+
+The original Phase 7 migration plan was to (1) add a parallel ``content_json``
+field, (2) switch reads/writes to it while retaining legacy columns for
+rollback, then (3) drop the legacy columns. Task 7.1 was executed
+destructively instead — ``content_type`` and the legacy text field were
+dropped outright and ``GeoContext.content`` is already the canonical
+Editor.js JSON column. See ``docs/features-to-add/decisions.md`` §[7.5].
+
+These tests therefore act as the final regression guard that every
+application read surface which embeds GeoContext emits the canonical
+``{"blocks": [...]}`` contract — and that no remaining code path depends
+on the retired ``content_type`` discriminator.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.contrib.gis.geos import Point
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from tosca_api.apps.campaigns.models import Campaign
+from tosca_api.apps.events.models import Event
+from tosca_api.apps.feedback.models import GeoFeedback
+from tosca_api.apps.geocontext.models import GeoContext
+from tosca_api.apps.geostories.models import GeoStory
+
+User = get_user_model()
+
+
+# ----------------------------------------------------------------------
+# Fixtures
+# ----------------------------------------------------------------------
+
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+
+@pytest.fixture
+def user(db):
+    return User.objects.create_user(username="json_contract_user", password="pw")
+
+
+@pytest.fixture
+def admin_user(db):
+    return User.objects.create_superuser(
+        username="json_contract_admin", password="pw", email="a@a.test"
+    )
+
+
+@pytest.fixture
+def campaign(user):
+    return Campaign.objects.create(title="JSON Contract", created_by=user)
+
+
+@pytest.fixture
+def rich_context(user):
+    return GeoContext.objects.create(
+        title="Rich Context Title",
+        content={
+            "blocks": [
+                {"type": "header", "data": {"text": "Intro", "level": 2}},
+                {"type": "paragraph", "data": {"text": "Hello"}},
+            ]
+        },
+        created_by=user,
+    )
+
+
+@pytest.fixture
+def empty_context(user):
+    return GeoContext.objects.create(content={"blocks": []}, created_by=user)
+
+
+# ----------------------------------------------------------------------
+# Geostory detail
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_geostory_detail_reads_context_as_json_blocks(
+    api_client, user, campaign, rich_context
+):
+    story = GeoStory.objects.create(
+        title="Story",
+        status=GeoStory.Status.PUBLISHED,
+        campaign=campaign,
+        author=user,
+        context=rich_context,
+    )
+    api_client.force_authenticate(user=user)
+    response = api_client.get(f"/api/v1/stories/{story.id}/")
+    assert response.status_code == 200
+
+    ctx = response.data["context"]
+    assert isinstance(ctx["content"], dict)
+    assert "blocks" in ctx["content"]
+    assert ctx["content"]["blocks"][0]["type"] == "header"
+    # The retired legacy discriminator must not leak into the contract.
+    assert "content_type" not in ctx
+
+
+@pytest.mark.django_db
+def test_geostory_detail_empty_context_serializes_as_empty_blocks(
+    api_client, user, campaign, empty_context
+):
+    story = GeoStory.objects.create(
+        title="Empty",
+        status=GeoStory.Status.PUBLISHED,
+        campaign=campaign,
+        author=user,
+        context=empty_context,
+    )
+    api_client.force_authenticate(user=user)
+    response = api_client.get(f"/api/v1/stories/{story.id}/")
+    assert response.status_code == 200
+    assert response.data["context"]["content"] == {"blocks": []}
+
+
+# ----------------------------------------------------------------------
+# Event detail
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_event_detail_reads_context_as_json_blocks(
+    api_client, user, campaign, rich_context
+):
+    event = Event.objects.create(
+        campaign=campaign,
+        title="Event",
+        start_datetime=timezone.now() + timedelta(days=1),
+        end_datetime=timezone.now() + timedelta(days=1, hours=1),
+        location=Point(10.0, 53.5, srid=4326),
+        organizer=user,
+        status=Event.Status.PUBLISHED,
+        context=rich_context,
+    )
+    api_client.force_authenticate(user=user)
+    response = api_client.get(f"/api/v1/events/{event.id}/")
+    assert response.status_code == 200
+
+    ctx = response.data["context"]
+    assert isinstance(ctx["content"], dict)
+    assert ctx["content"]["blocks"][1]["data"]["text"] == "Hello"
+    assert "content_type" not in ctx
+
+
+@pytest.mark.django_db
+def test_event_detail_without_context_returns_none(
+    api_client, user, campaign
+):
+    event = Event.objects.create(
+        campaign=campaign,
+        title="No Context",
+        start_datetime=timezone.now() + timedelta(days=1),
+        end_datetime=timezone.now() + timedelta(days=1, hours=1),
+        location=Point(10.0, 53.5, srid=4326),
+        organizer=user,
+        status=Event.Status.PUBLISHED,
+    )
+    api_client.force_authenticate(user=user)
+    response = api_client.get(f"/api/v1/events/{event.id}/")
+    assert response.status_code == 200
+    assert response.data["context"] is None
+
+
+# ----------------------------------------------------------------------
+# Feedback detail
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_feedback_detail_reads_context_as_json_blocks(
+    api_client, admin_user, campaign, rich_context
+):
+    feedback = GeoFeedback.objects.create(
+        campaign=campaign,
+        title="FB",
+        created_by=admin_user,
+        context=rich_context,
+        status=GeoFeedback.Status.PUBLISHED,
+        visibility=GeoFeedback.Visibility.PUBLIC,
+    )
+    response = api_client.get(f"/api/v1/feedback/{feedback.id}/")
+    assert response.status_code == 200
+
+    ctx = response.data["context"]
+    assert isinstance(ctx["content"], dict)
+    assert ctx["content"]["blocks"][0]["type"] == "header"
+    assert "content_type" not in ctx
+
+
+@pytest.mark.django_db
+def test_feedback_detail_empty_context_serializes_as_empty_blocks(
+    api_client, admin_user, campaign, empty_context
+):
+    feedback = GeoFeedback.objects.create(
+        campaign=campaign,
+        title="FB Empty",
+        created_by=admin_user,
+        context=empty_context,
+        status=GeoFeedback.Status.PUBLISHED,
+        visibility=GeoFeedback.Visibility.PUBLIC,
+    )
+    response = api_client.get(f"/api/v1/feedback/{feedback.id}/")
+    assert response.status_code == 200
+    assert response.data["context"]["content"] == {"blocks": []}
+
+
+# ----------------------------------------------------------------------
+# Admin writes go through the canonical JSON path
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_admin_edit_updates_context_as_json_blocks(client, admin_user):
+    """An admin save persists the canonical JSON contract end-to-end."""
+    from django.urls import reverse
+
+    client.force_login(admin_user)
+    url = reverse("admin:geocontext_geocontext_add")
+    payload = {
+        "content": (
+            '{"blocks": [{"type": "paragraph", "data": {"text": "Admin wrote"}}]}'
+        ),
+        "created_by": str(admin_user.id),
+        "_save": "Save",
+    }
+    response = client.post(url, payload, follow=True)
+    assert response.status_code == 200
+    ctx = GeoContext.objects.get(created_by=admin_user)
+    assert ctx.content == {
+        "blocks": [{"type": "paragraph", "data": {"text": "Admin wrote"}}]
+    }
+
+
+# ----------------------------------------------------------------------
+# Regression: retired content_type discriminator has no active callers
+# ----------------------------------------------------------------------
+
+
+def test_no_module_imports_sanitize_content():
+    """
+    ``sanitize_content(content, content_type)`` was the Task 7.1 relic
+    that dispatched on the retired discriminator. The helper has been
+    removed; this test fails loud if anything re-adds a caller.
+    """
+    from tosca_api.apps.core import sanitization
+
+    assert not hasattr(sanitization, "sanitize_content")
+
+
+def test_geocontext_model_has_no_content_type_field():
+    field_names = {f.name for f in GeoContext._meta.get_fields()}
+    assert "content_type" not in field_names
+    assert "content" in field_names
+    assert "title" in field_names
+
+
+# ----------------------------------------------------------------------
+# Title propagation to nested read surfaces
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_geostory_detail_exposes_context_title(
+    api_client, user, campaign, rich_context
+):
+    story = GeoStory.objects.create(
+        title="Story",
+        status=GeoStory.Status.PUBLISHED,
+        campaign=campaign,
+        author=user,
+        context=rich_context,
+    )
+    api_client.force_authenticate(user=user)
+    response = api_client.get(f"/api/v1/stories/{story.id}/")
+    assert response.status_code == 200
+    assert response.data["context"]["title"] == "Rich Context Title"
+
+
+@pytest.mark.django_db
+def test_event_detail_exposes_context_title(
+    api_client, user, campaign, rich_context
+):
+    event = Event.objects.create(
+        campaign=campaign,
+        title="Event",
+        start_datetime=timezone.now() + timedelta(days=1),
+        end_datetime=timezone.now() + timedelta(days=1, hours=1),
+        location=Point(10.0, 53.5, srid=4326),
+        organizer=user,
+        status=Event.Status.PUBLISHED,
+        context=rich_context,
+    )
+    api_client.force_authenticate(user=user)
+    response = api_client.get(f"/api/v1/events/{event.id}/")
+    assert response.status_code == 200
+    assert response.data["context"]["title"] == "Rich Context Title"
+
+
+@pytest.mark.django_db
+def test_feedback_detail_exposes_context_title(
+    api_client, admin_user, campaign, rich_context
+):
+    feedback = GeoFeedback.objects.create(
+        campaign=campaign,
+        title="FB",
+        created_by=admin_user,
+        context=rich_context,
+        status=GeoFeedback.Status.PUBLISHED,
+        visibility=GeoFeedback.Visibility.PUBLIC,
+    )
+    response = api_client.get(f"/api/v1/feedback/{feedback.id}/")
+    assert response.status_code == 200
+    assert response.data["context"]["title"] == "Rich Context Title"

--- a/tosca_api/apps/geocontext/tests/test_models.py
+++ b/tosca_api/apps/geocontext/tests/test_models.py
@@ -64,13 +64,49 @@ def test_geocontext_has_no_content_type_field():
 
 
 @pytest.mark.django_db
-def test_geocontext_str_representation(test_user):
-    """String representation reflects block count, not raw text."""
+def test_geocontext_str_prefers_explicit_title(test_user):
+    """An explicit title wins over derived excerpt in __str__."""
+    ctx = GeoContext.objects.create(
+        title="Smart City Logistics",
+        content={"blocks": [{"type": "paragraph", "data": {"text": "body"}}]},
+        created_by=test_user,
+    )
+    label = str(ctx)
+    assert label.startswith("Smart City Logistics")
+    assert "1 block" in label
+
+
+@pytest.mark.django_db
+def test_geocontext_str_falls_back_to_first_block_excerpt(test_user):
+    """Without a title, __str__ derives a short excerpt from the first block."""
+    ctx = GeoContext.objects.create(
+        content={
+            "blocks": [
+                {"type": "header", "data": {"text": "Quantum AI Overview", "level": 2}},
+                {"type": "paragraph", "data": {"text": "body"}},
+            ]
+        },
+        created_by=test_user,
+    )
+    label = str(ctx)
+    assert "Quantum AI Overview" in label
+    assert "2 block" in label
+
+
+@pytest.mark.django_db
+def test_geocontext_str_empty_document_is_labeled(test_user):
+    """Empty docs still produce a dropdown-friendly label."""
     empty = GeoContext.objects.create(created_by=test_user)
     assert "(empty)" in str(empty)
 
-    populated = GeoContext.objects.create(
-        content={"blocks": [{"type": "paragraph", "data": {"text": "Hi"}}]},
+
+@pytest.mark.django_db
+def test_geocontext_str_no_title_no_text_falls_back_to_short_id(test_user):
+    """A rich document with no text-bearing block still gets a stable label."""
+    ctx = GeoContext.objects.create(
+        content={"blocks": [{"type": "delimiter", "data": {}}]},
         created_by=test_user,
     )
-    assert "1 block" in str(populated)
+    label = str(ctx)
+    assert "GeoContext " in label
+    assert "1 block" in label

--- a/tosca_api/apps/geostories/serializers.py
+++ b/tosca_api/apps/geostories/serializers.py
@@ -18,7 +18,7 @@ class GeoContextSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = GeoContext
-        fields = ["id", "content"]
+        fields = ["id", "title", "content"]
         read_only_fields = fields
 
 


### PR DESCRIPTION
The Django admin related-object picker for GeoStory / Event / GeoFeedback rendered every GeoContext as "GeoContext: 4 block(s)", making it effectively impossible to pick the right context when authoring parent rows. Fix by adding a human-readable title.

- Add GeoContext.title (CharField, max_length=200, blank=True default=""). Optional to avoid a disruptive data migration and keep existing fixtures working.
- Migration geocontext.0003_geocontext_title ships the column with default "".
- Rewrite GeoContext.__str__ with a dropdown-friendly fallback chain:
    1. explicit title          -> "Title (N block(s))"
    2. first header/paragraph/ -> "Excerpt… (N block(s))" quote excerpt (<=60ch)
    3. short uuid              -> "GeoContext ab12cd34 (N block(s))"
  Empty documents are still labeled "(empty)".
- Admin: lead list_display with title_or_excerpt, add title to search_fields, and surface title at the top of the change-form fieldset so editors are nudged to set it.
- Nested serializers for GeoStory, Event, and GeoFeedback detail endpoints now expose {id, title, content} instead of {id, content so frontends can render the label alongside block JSON.

Tests:
- 4 new __str__ cases in tosca_api/apps/geocontext/tests/test_models.py pinning the explicit-title, excerpt-fallback, empty-doc, and no-text-block fallback branches.
- 3 new cases in tosca_api/apps/geocontext/tests/test_json_contract.py pinning context.title exposure on geostory/event/feedback detail responses. Updated the rich_context fixture to carry a title so the existing JSON-contract tests also cover the enriched payload shape.

Full suite: 394 pass, one pre-existing unrelated event-series PATCH failure unchanged by this commit.

## Summary

- [ ] Description of changes
- [ ] Related issue link

## Testing

- [ ] `uv run pytest`
- [ ] Other (describe)
