### PR TITLE
feat(layers): enforce public + published layer assignment

### DIFF
--- a/tosca_api/apps/events/models.py
+++ b/tosca_api/apps/events/models.py
@@ -652,7 +652,9 @@ class Event(TimeStampedModel):
 class EventLayer(models.Model):
     """
     Through model for Event <-> geodata_providers.Layer.
-    Allows ordering of layers within an event.
+
+    Allows ordering of layers within an event. Layers must be public and
+    published — see ``clean()``.
     """
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
@@ -679,8 +681,18 @@ class EventLayer(models.Model):
     def __str__(self) -> str:
         return f"{self.event} - {self.layer} ({self.display_order})"
 
+    def clean(self) -> None:
+        """Reject non-public or non-published layer assignments."""
+        from tosca_api.apps.geodata_providers.validators import (
+            validate_layer_is_public_and_published,
+        )
+
+        super().clean()
+        if self.layer_id is not None:
+            validate_layer_is_public_and_published(self.layer)
+
     def save(self, *args, **kwargs) -> None:
-        """Auto-increment display_order if not specified."""
+        """Auto-increment display_order and enforce layer validation."""
         if self._state.adding and self.display_order == 0:
             max_order = (
                 EventLayer.objects.filter(event=self.event).aggregate(
@@ -689,6 +701,7 @@ class EventLayer(models.Model):
             )
             if max_order is not None:
                 self.display_order = max_order + 1
+        self.full_clean()
         super().save(*args, **kwargs)
 
 

--- a/tosca_api/apps/events/tests/test_models.py
+++ b/tosca_api/apps/events/tests/test_models.py
@@ -254,8 +254,9 @@ def test_event_layer_unique_together(user, campaign, layer_ref):
 
     EventLayer.objects.create(event=event, layer=layer_ref)
 
-    # Attempt to create duplicate
-    with pytest.raises(IntegrityError):
+    # Attempt to create duplicate — full_clean() now catches this before
+    # the DB-level constraint fires, so it surfaces as ValidationError.
+    with pytest.raises(ValidationError):
         EventLayer.objects.create(event=event, layer=layer_ref)
 
 
@@ -1345,3 +1346,63 @@ def test_multiple_select_dimension_allows_multiple_terms_for_same_event(user, ca
     EventTerm.objects.create(event=event, term=second_term)
 
     assert EventTerm.objects.filter(event=event).count() == 2
+
+
+# =============================================================================
+# EventLayer validation
+# =============================================================================
+
+
+@pytest.mark.django_db
+def test_event_layer_rejects_non_public_layer(user, campaign):
+    """Through-model clean() must reject is_public=False layers."""
+    now = timezone.now()
+    event = Event.objects.create(
+        campaign=campaign,
+        title="Event",
+        start_datetime=now,
+        end_datetime=now + timedelta(hours=1),
+        location=Point(10.0, 53.5, srid=4326),
+        organizer=user,
+    )
+    layer = make_layer("workspace:evt_private", user=user, is_public=False)
+
+    with pytest.raises(ValidationError):
+        EventLayer.objects.create(event=event, layer=layer)
+
+
+@pytest.mark.django_db
+def test_event_layer_rejects_unpublished_layer(user, campaign):
+    """Through-model clean() must reject non-PUBLISHED layers."""
+    now = timezone.now()
+    event = Event.objects.create(
+        campaign=campaign,
+        title="Event",
+        start_datetime=now,
+        end_datetime=now + timedelta(hours=1),
+        location=Point(10.0, 53.5, srid=4326),
+        organizer=user,
+    )
+    layer = make_layer(
+        "workspace:evt_draft", user=user, publishing_state="DRAFT"
+    )
+
+    with pytest.raises(ValidationError):
+        EventLayer.objects.create(event=event, layer=layer)
+
+
+@pytest.mark.django_db
+def test_event_layer_accepts_public_published(user, campaign):
+    """Through-model clean() accepts public + published layers."""
+    now = timezone.now()
+    event = Event.objects.create(
+        campaign=campaign,
+        title="Event",
+        start_datetime=now,
+        end_datetime=now + timedelta(hours=1),
+        location=Point(10.0, 53.5, srid=4326),
+        organizer=user,
+    )
+    layer = make_layer("workspace:evt_ok", user=user)
+    el = EventLayer.objects.create(event=event, layer=layer)
+    assert el.id is not None

--- a/tosca_api/apps/feedback/models.py
+++ b/tosca_api/apps/feedback/models.py
@@ -183,7 +183,9 @@ class GeoFeedback(TimeStampedModel):
 class FeedbackLayer(models.Model):
     """
     Through model for GeoFeedback <-> geodata_providers.Layer.
-    Allows ordering of layers within a feedback.
+
+    Allows ordering of layers within a feedback. Layers must be public and
+    published — see ``clean()``.
     """
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
@@ -205,8 +207,18 @@ class FeedbackLayer(models.Model):
     def __str__(self) -> str:
         return f"{self.feedback} - {self.layer} ({self.display_order})"
 
+    def clean(self) -> None:
+        """Reject non-public or non-published layer assignments."""
+        from tosca_api.apps.geodata_providers.validators import (
+            validate_layer_is_public_and_published,
+        )
+
+        super().clean()
+        if self.layer_id is not None:
+            validate_layer_is_public_and_published(self.layer)
+
     def save(self, *args, **kwargs) -> None:
-        """Auto-increment display_order if not specified."""
+        """Auto-increment display_order and enforce layer validation."""
         if self._state.adding and self.display_order == 0:
             max_order = (
                 FeedbackLayer.objects.filter(feedback=self.feedback).aggregate(
@@ -215,6 +227,7 @@ class FeedbackLayer(models.Model):
             )
             if max_order is not None:
                 self.display_order = max_order + 1
+        self.full_clean()
         super().save(*args, **kwargs)
 
 

--- a/tosca_api/apps/feedback/tests/test_models.py
+++ b/tosca_api/apps/feedback/tests/test_models.py
@@ -599,7 +599,9 @@ class TestFeedbackLayer:
             feedback=feedback_rating_only,
             layer=layer_ref,
         )
-        with pytest.raises(IntegrityError):
+        # full_clean() catches this before the DB-level constraint fires,
+        # so it surfaces as ValidationError.
+        with pytest.raises(ValidationError):
             FeedbackLayer.objects.create(
                 feedback=feedback_rating_only,
                 layer=layer_ref,
@@ -748,3 +750,33 @@ class TestGeoFeedbackRelationships:
             created_by=user,
         )
         assert custom_form.feedbacks.count() == 2
+
+
+@pytest.mark.django_db
+class TestFeedbackLayerValidation:
+    """Through-model clean() rejects non-public / non-published layers."""
+
+    def test_rejects_non_public_layer(self, feedback_rating_only, user):
+        layer = make_layer(
+            "workspace:fb_private", user=user, is_public=False
+        )
+        with pytest.raises(ValidationError):
+            FeedbackLayer.objects.create(
+                feedback=feedback_rating_only, layer=layer
+            )
+
+    def test_rejects_unpublished_layer(self, feedback_rating_only, user):
+        layer = make_layer(
+            "workspace:fb_draft", user=user, publishing_state="DRAFT"
+        )
+        with pytest.raises(ValidationError):
+            FeedbackLayer.objects.create(
+                feedback=feedback_rating_only, layer=layer
+            )
+
+    def test_accepts_public_published(self, feedback_rating_only, user):
+        layer = make_layer("workspace:fb_ok", user=user)
+        fl = FeedbackLayer.objects.create(
+            feedback=feedback_rating_only, layer=layer
+        )
+        assert fl.id is not None

--- a/tosca_api/apps/geodata_providers/validators.py
+++ b/tosca_api/apps/geodata_providers/validators.py
@@ -1,0 +1,36 @@
+"""Shared validators for layer-related cross-app integration."""
+
+from __future__ import annotations
+
+from django.core.exceptions import ValidationError
+
+from tosca_api.apps.geodata_providers.models import Layer
+
+
+def validate_layer_is_public_and_published(layer: Layer | None) -> None:
+    """
+    Reject any layer that is not both public and published.
+
+    Used by GeoStoryLayer / EventLayer / FeedbackLayer through-model `clean()`
+    so consumer apps (geostories, events, feedback) only attach layers that
+    are safe to render to public consumers and that are actually live in the
+    underlying engine (GeoServer / Martin / pg_tileserv).
+    """
+    if layer is None:
+        return
+
+    errors: dict[str, str] = {}
+    if not layer.is_public:
+        errors["layer"] = (
+            f"Layer '{layer}' is not public and cannot be attached to a "
+            "GeoStory, Event, or GeoFeedback."
+        )
+    elif layer.publishing_state != Layer.PublishingState.PUBLISHED:
+        errors["layer"] = (
+            f"Layer '{layer}' must be PUBLISHED to be attached to a "
+            f"GeoStory, Event, or GeoFeedback (current state: "
+            f"{layer.publishing_state})."
+        )
+
+    if errors:
+        raise ValidationError(errors)

--- a/tosca_api/apps/geostories/models.py
+++ b/tosca_api/apps/geostories/models.py
@@ -103,7 +103,9 @@ class GeoStory(TimeStampedModel):
 class GeoStoryLayer(models.Model):
     """
     Through model for GeoStory <-> geodata_providers.Layer.
-    Allows ordering of layers within a story.
+
+    Allows ordering of layers within a story. Layers must be public and
+    published — see ``clean()``.
     """
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
@@ -125,10 +127,20 @@ class GeoStoryLayer(models.Model):
     def __str__(self) -> str:
         return f"{self.geostory} - {self.layer} ({self.display_order})"
 
+    def clean(self) -> None:
+        """Reject non-public or non-published layer assignments."""
+        from tosca_api.apps.geodata_providers.validators import (
+            validate_layer_is_public_and_published,
+        )
+
+        super().clean()
+        if self.layer_id is not None:
+            validate_layer_is_public_and_published(self.layer)
+
     def save(self, *args, **kwargs) -> None:
         """
-        Override save to auto-increment display_order if not specified.
-        This fixes the issue where multiple layers added in Admin all get order 0.
+        Override save to auto-increment display_order if not specified
+        and to enforce public + published layer validation.
         """
         if self._state.adding and self.display_order == 0:
             # Find the current maximum order for this story
@@ -139,4 +151,5 @@ class GeoStoryLayer(models.Model):
             )
             if max_order is not None:
                 self.display_order = max_order + 1
+        self.full_clean()
         super().save(*args, **kwargs)

--- a/tosca_api/apps/geostories/tests/test_models.py
+++ b/tosca_api/apps/geostories/tests/test_models.py
@@ -116,3 +116,38 @@ def test_geostory_layer_auto_increment(user, campaign):
     assert gsl1.display_order == 0
     assert gsl2.display_order == 1
     assert gsl3.display_order == 2
+
+
+@pytest.mark.django_db
+def test_geostory_layer_rejects_non_public_layer(user, campaign):
+    """Through-model clean() must reject is_public=False layers."""
+    from django.core.exceptions import ValidationError
+
+    story = GeoStory.objects.create(title="S", campaign=campaign, author=user)
+    layer = make_layer("workspace:private_layer", user=user, is_public=False)
+
+    with pytest.raises(ValidationError):
+        GeoStoryLayer.objects.create(geostory=story, layer=layer)
+
+
+@pytest.mark.django_db
+def test_geostory_layer_rejects_unpublished_layer(user, campaign):
+    """Through-model clean() must reject non-PUBLISHED layers."""
+    from django.core.exceptions import ValidationError
+
+    story = GeoStory.objects.create(title="S", campaign=campaign, author=user)
+    layer = make_layer(
+        "workspace:draft_layer", user=user, publishing_state="DRAFT"
+    )
+
+    with pytest.raises(ValidationError):
+        GeoStoryLayer.objects.create(geostory=story, layer=layer)
+
+
+@pytest.mark.django_db
+def test_geostory_layer_accepts_public_published(user, campaign):
+    """Through-model clean() accepts public + published layers."""
+    story = GeoStory.objects.create(title="S", campaign=campaign, author=user)
+    layer = make_layer("workspace:ok_layer", user=user)
+    gsl = GeoStoryLayer.objects.create(geostory=story, layer=layer)
+    assert gsl.id is not None


### PR DESCRIPTION
Add a shared validate_layer_is_public_and_published helper in geodata_providers and call it from GeoStoryLayer.clean(), EventLayer.clean(), and FeedbackLayer.clean(). Each through-model save() now runs full_clean() so the rule fires consistently across ORM, admin inlines, and DRF write paths.

Reject layers where is_public=False or publishing_state != PUBLISHED with a clear field-keyed ValidationError. Cover the new behavior with reject/accept tests for all three consuming apps.

## Summary

- [ ] Description of changes
- [ ] Related issue link

## Testing

- [ ] `uv run pytest`
- [ ] Other (describe)
