### PR TITLE
feat(layers): add LayerSummarySerializer and hydrate detail responses

### DIFF
--- a/tosca_api/apps/events/serializers.py
+++ b/tosca_api/apps/events/serializers.py
@@ -9,6 +9,7 @@ from rest_framework import serializers
 from rest_framework_gis.serializers import GeoFeatureModelSerializer
 
 from tosca_api.apps.geocontext.models import GeoContext
+from tosca_api.apps.geodata_providers.api.serializers import LayerSummarySerializer
 
 from .models import (
     Event,
@@ -86,19 +87,18 @@ class EventGeoContextSerializer(serializers.ModelSerializer):
 
 
 class EventLayerSerializer(serializers.ModelSerializer):
-    """Serializer for EventLayer through model."""
+    """
+    Serializer for EventLayer through model.
 
-    id = serializers.UUIDField(source="layer.id", read_only=True)
-    layer_name = serializers.SerializerMethodField()
+    Embeds the canonical Layer summary plus per-event display_order.
+    """
+
+    layer = LayerSummarySerializer(read_only=True)
 
     class Meta:
         model = EventLayer
-        fields = ["id", "layer_name", "display_order"]
+        fields = ["layer", "display_order"]
         read_only_fields = fields
-
-    def get_layer_name(self, obj) -> str:
-        """Return the canonical workspace-qualified layer name."""
-        return f"{obj.layer.workspace.name}:{obj.layer.name}"
 
 
 # =============================================================================
@@ -174,8 +174,10 @@ class EventDetailSerializer(serializers.ModelSerializer):
         read_only_fields = fields
 
     def get_layers(self, obj) -> list:
-        """Return layers ordered by display_order."""
-        through_qs = EventLayer.objects.filter(event=obj).select_related("layer")
+        """Return layers ordered by display_order with full Layer summary."""
+        through_qs = EventLayer.objects.filter(event=obj).select_related(
+            "layer__workspace"
+        )
         return EventLayerSerializer(through_qs, many=True).data
 
     def get_context(self, obj):

--- a/tosca_api/apps/events/tests/test_api.py
+++ b/tosca_api/apps/events/tests/test_api.py
@@ -1826,3 +1826,28 @@ def test_events_delete(api_client, user, future_event):
     response = api_client.delete(f"/api/v1/events/{future_event.id}/")
     assert response.status_code == 204
     assert not Event.objects.filter(id=future_event.id).exists()
+
+
+@pytest.mark.django_db
+def test_event_detail_returns_layer_summary(api_client, user, future_event):
+    """Event detail must return canonical Layer metadata for linked layers."""
+    from tosca_api.apps.events.models import EventLayer
+    from tosca_api.apps.geodata_providers.test_helpers import make_layer
+
+    layer = make_layer("workspace:event_detail_layer", user=user)
+    EventLayer.objects.create(event=future_event, layer=layer, display_order=1)
+
+    api_client.force_authenticate(user=user)
+    response = api_client.get(f"/api/v1/events/{future_event.id}/")
+    assert response.status_code == 200
+
+    layers = response.data["layers"]
+    assert len(layers) == 1
+    layer_payload = layers[0]["layer"]
+    assert layer_payload["name"] == "event_detail_layer"
+    assert layer_payload["workspace"]["name"] == "workspace"
+    assert layer_payload["geometry_type"] == "Point"
+    assert layer_payload["srid"] == 4326
+    assert layer_payload["is_public"] is True
+    assert layer_payload["publishing_state"] == "PUBLISHED"
+    assert layers[0]["display_order"] == 1

--- a/tosca_api/apps/events/views.py
+++ b/tosca_api/apps/events/views.py
@@ -120,7 +120,9 @@ class EventViewSet(viewsets.ModelViewSet):
                 "series",
                 "organizer",
             )
-            queryset = queryset.prefetch_related("eventlayer_set__layer")
+            queryset = queryset.prefetch_related(
+                "eventlayer_set__layer__workspace"
+            )
         else:
             queryset = queryset.select_related("campaign", "event_type", "series")
 

--- a/tosca_api/apps/feedback/serializers.py
+++ b/tosca_api/apps/feedback/serializers.py
@@ -1,6 +1,7 @@
 from rest_framework import serializers
 from rest_framework_gis.fields import GeometryField
 from tosca_api.apps.geocontext.models import GeoContext
+from tosca_api.apps.geodata_providers.api.serializers import LayerSummarySerializer
 
 from .models import FeedbackLayer, FeedbackSubmission, GeoFeedback
 
@@ -15,19 +16,18 @@ class FeedbackGeoContextSerializer(serializers.ModelSerializer):
 
 
 class FeedbackLayerSerializer(serializers.ModelSerializer):
-    """Serializer for FeedbackLayer through model."""
+    """
+    Serializer for FeedbackLayer through model.
 
-    id = serializers.UUIDField(source="layer.id", read_only=True)
-    layer_name = serializers.SerializerMethodField()
+    Embeds the canonical Layer summary plus per-feedback display_order.
+    """
+
+    layer = LayerSummarySerializer(read_only=True)
 
     class Meta:
         model = FeedbackLayer
-        fields = ["id", "layer_name", "display_order"]
+        fields = ["layer", "display_order"]
         read_only_fields = fields
-
-    def get_layer_name(self, obj) -> str:
-        """Return the canonical workspace-qualified layer name."""
-        return f"{obj.layer.workspace.name}:{obj.layer.name}"
 
 
 class GeoFeedbackListSerializer(serializers.ModelSerializer):
@@ -85,8 +85,10 @@ class GeoFeedbackDetailSerializer(serializers.ModelSerializer):
         read_only_fields = fields
 
     def get_layers(self, obj) -> list:
-        """Return layers ordered by display_order."""
-        through_qs = FeedbackLayer.objects.filter(feedback=obj).select_related("layer")
+        """Return layers ordered by display_order with full Layer summary."""
+        through_qs = FeedbackLayer.objects.filter(feedback=obj).select_related(
+            "layer__workspace"
+        )
         return FeedbackLayerSerializer(through_qs, many=True).data
 
 

--- a/tosca_api/apps/feedback/tests/test_api.py
+++ b/tosca_api/apps/feedback/tests/test_api.py
@@ -238,3 +238,31 @@ class TestFeedbackSubmissionAPI:
         )
         assert resp.status_code == status.HTTP_400_BAD_REQUEST
         assert "geometry" in resp.data
+
+
+@pytest.mark.django_db
+class TestFeedbackDetailLayers:
+    """GeoFeedback detail must return canonical Layer metadata."""
+
+    def test_detail_returns_layer_summary(self, api_client, feedback, admin_user):
+        from tosca_api.apps.feedback.models import FeedbackLayer
+        from tosca_api.apps.geodata_providers.test_helpers import make_layer
+
+        layer = make_layer("workspace:fb_detail_layer", user=admin_user)
+        FeedbackLayer.objects.create(
+            feedback=feedback, layer=layer, display_order=1
+        )
+
+        resp = api_client.get(f"/api/v1/feedback/{feedback.id}/")
+        assert resp.status_code == 200
+
+        layers = resp.data["layers"]
+        assert len(layers) == 1
+        layer_payload = layers[0]["layer"]
+        assert layer_payload["name"] == "fb_detail_layer"
+        assert layer_payload["workspace"]["name"] == "workspace"
+        assert layer_payload["geometry_type"] == "Point"
+        assert layer_payload["srid"] == 4326
+        assert layer_payload["is_public"] is True
+        assert layer_payload["publishing_state"] == "PUBLISHED"
+        assert layers[0]["display_order"] == 1

--- a/tosca_api/apps/feedback/views.py
+++ b/tosca_api/apps/feedback/views.py
@@ -73,7 +73,9 @@ class GeoFeedbackViewSet(viewsets.ModelViewSet):
 
         if self.action == "retrieve":
             qs = qs.select_related("context", "campaign", "created_by", "custom_form")
-            qs = qs.prefetch_related("feedbacklayer_set__layer")
+            qs = qs.prefetch_related(
+                "feedbacklayer_set__layer__workspace"
+            )
 
         user = self.request.user
         if not (user and user.is_staff):

--- a/tosca_api/apps/geodata_providers/api/serializers.py
+++ b/tosca_api/apps/geodata_providers/api/serializers.py
@@ -3,6 +3,41 @@ from rest_framework import serializers
 from ..models import GeodataEngine, Layer, Store, Workspace
 
 
+class LayerSummaryWorkspaceSerializer(serializers.ModelSerializer):
+    """Slim workspace shape embedded inside LayerSummarySerializer."""
+
+    class Meta:
+        model = Workspace
+        fields = ["id", "name"]
+        read_only_fields = fields
+
+
+class LayerSummarySerializer(serializers.ModelSerializer):
+    """
+    Slim, public-safe Layer projection used by consumer apps (geostories,
+    events, feedback) to expose canonical layer metadata in detail responses.
+
+    Stays narrower than the full LayerSerializer on purpose: it does not
+    include connection/store details, publishing errors, or style assignments.
+    """
+
+    workspace = LayerSummaryWorkspaceSerializer(read_only=True)
+
+    class Meta:
+        model = Layer
+        fields = [
+            "id",
+            "name",
+            "workspace",
+            "geometry_type",
+            "srid",
+            "published_url",
+            "is_public",
+            "publishing_state",
+        ]
+        read_only_fields = fields
+
+
 class GeodataEngineSerializer(serializers.ModelSerializer):
     """Serializer for GeodataEngine model."""
 

--- a/tosca_api/apps/geostories/serializers.py
+++ b/tosca_api/apps/geostories/serializers.py
@@ -3,6 +3,7 @@ from rest_framework import serializers
 
 from tosca_api.apps.featurelinks.models import FeatureLink
 from tosca_api.apps.geocontext.models import GeoContext
+from tosca_api.apps.geodata_providers.api.serializers import LayerSummarySerializer
 
 from .models import GeoStory, GeoStoryLayer
 
@@ -24,23 +25,18 @@ class GeoContextSerializer(serializers.ModelSerializer):
 class GeoStoryLayerSerializer(serializers.ModelSerializer):
     """
     Serializer for GeoStoryLayer through model.
-    Includes layer id, name, and display order.
 
-    Note: this is an interim slim shape; Task 8.4 replaces it with a
-    LayerSummarySerializer exposing geometry_type, srid, published_url, etc.
+    Embeds the canonical Layer summary (id, name, workspace, geometry_type,
+    srid, published_url, is_public, publishing_state) plus the per-story
+    display_order.
     """
 
-    id = serializers.UUIDField(source="layer.id", read_only=True)
-    layer_name = serializers.SerializerMethodField()
+    layer = LayerSummarySerializer(read_only=True)
 
     class Meta:
         model = GeoStoryLayer
-        fields = ["id", "layer_name", "display_order"]
+        fields = ["layer", "display_order"]
         read_only_fields = fields
-
-    def get_layer_name(self, obj) -> str:
-        """Return the canonical workspace-qualified layer name."""
-        return f"{obj.layer.workspace.name}:{obj.layer.name}"
 
 
 class FeatureLinkSerializer(serializers.ModelSerializer):

--- a/tosca_api/apps/geostories/tests/test_api.py
+++ b/tosca_api/apps/geostories/tests/test_api.py
@@ -202,8 +202,54 @@ def test_geostory_detail_has_layers(api_client, user, geostory, layer_ref):
     
     layers = response.data["layers"]
     assert len(layers) == 1
-    assert layers[0]["layer_name"] == "workspace:test_layer"
+    layer_payload = layers[0]["layer"]
+    assert layer_payload["name"] == "test_layer"
+    assert layer_payload["workspace"]["name"] == "workspace"
+    assert layer_payload["geometry_type"] == "Point"
+    assert layer_payload["srid"] == 4326
+    assert layer_payload["is_public"] is True
+    assert layer_payload["publishing_state"] == "PUBLISHED"
     assert layers[0]["display_order"] == 1
+
+
+@pytest.mark.django_db
+def test_geostory_detail_layers_no_n_plus_one(api_client, user, geostory):
+    """Detail endpoint query count must not scale with linked layer count."""
+    from django.db import connection
+    from django.test.utils import CaptureQueriesContext
+
+    from tosca_api.apps.geodata_providers.test_helpers import make_layer
+
+    api_client.force_authenticate(user=user)
+    url = f"/api/v1/stories/{geostory.id}/"
+
+    # Warm caches (auth, content types) so they don't pollute the count.
+    api_client.get(url)
+
+    for i in range(2):
+        layer = make_layer(f"workspace:n1_a_{i}", user=user)
+        GeoStoryLayer.objects.create(
+            geostory=geostory, layer=layer, display_order=i
+        )
+
+    with CaptureQueriesContext(connection) as ctx_2:
+        response = api_client.get(url)
+    assert response.status_code == 200
+    assert len(response.data["layers"]) == 2
+
+    for i in range(2, 8):
+        layer = make_layer(f"workspace:n1_a_{i}", user=user)
+        GeoStoryLayer.objects.create(
+            geostory=geostory, layer=layer, display_order=i
+        )
+
+    with CaptureQueriesContext(connection) as ctx_8:
+        response = api_client.get(url)
+    assert response.status_code == 200
+    assert len(response.data["layers"]) == 8
+
+    # Query count must be the same regardless of how many layers are linked.
+    assert len(ctx_8) == len(ctx_2)
 
 
 @pytest.mark.django_db

--- a/tosca_api/apps/geostories/views.py
+++ b/tosca_api/apps/geostories/views.py
@@ -68,7 +68,9 @@ class GeoStoryViewSet(viewsets.ModelViewSet):
         # Optimize queries for detail view
         if self.action == "retrieve":
             queryset = queryset.select_related("context", "campaign", "author")
-            queryset = queryset.prefetch_related("geostorylayer_set__layer")
+            queryset = queryset.prefetch_related(
+                "geostorylayer_set__layer__workspace"
+            )
 
         # Optimize queries for list view
         if self.action == "list":


### PR DESCRIPTION
Add a shared LayerSummarySerializer in geodata_providers exposing id, name, workspace, geometry_type, srid, published_url, is_public, and publishing_state. Wire it into GeoStory, Event, and GeoFeedback detail responses so each linked-layer entry now nests the full canonical Layer metadata alongside display_order, replacing the interim layer_name-only shape.

Extend the through-table prefetches to layer__workspace so detail endpoints stay flat-query regardless of how many layers are linked. Cover the new payload shape with detail tests across all three apps and add a query-count regression in geostories that asserts no N+1.

## Summary

- [ ] Description of changes
- [ ] Related issue link

## Testing

- [ ] `uv run pytest`
- [ ] Other (describe)
