### PR TITLE
feat(layers): accept Layer UUIDs in nested writes

### DIFF
--- a/.github/copilot-instructions_local.md
+++ b/.github/copilot-instructions_local.md
@@ -1,0 +1,198 @@
+# TOSCA-Web API - AI Coding Agent Instructions
+
+## Project Overview
+Django 5.1 REST API backend for a geospatial web platform. Uses Keycloak for authentication, GeoServer for serving map layers, and PostGIS for geospatial data storage.
+
+## Architecture
+
+### Three-Service Stack
+- **Django** (this repo): Control plane for access control decisions, user management, and API orchestration
+- **Keycloak**: IAM provider - stores users, roles, issues JWT tokens
+- **GeoServer**: Geospatial server accessed directly by clients using JWT authentication (no Django proxy)
+
+### Critical Design Decision: Direct GeoServer Access
+Clients access GeoServer directly for WMS/WFS/WMTS requests. Django does NOT proxy these requests. This architectural choice means:
+- All access control must be **role-based (RBAC)**, not attribute-based (ABAC)
+- Access rules are **precomputed** and synchronized to GeoServer
+- No per-request authorization logic is possible for GeoServer endpoints
+
+See [docs/development/IAM_access_control.md](../docs/development/IAM_access_control.md) for the complete access control model.
+
+### App Structure
+```
+tosca_api/
+├── settings/          # Environment-based: base.py, development.py, production.py, test.py
+├── apps/
+│   ├── core/         # Shared utilities (TimeStampedModel, pagination, permissions, jwt_utils)
+│   ├── authentication/  # Keycloak OAuth2/OIDC integration (django-allauth)
+│   └── tosca_web/    # Main API endpoints (layers, participation)
+```
+
+## Environment & Settings
+
+### Settings Module Selection
+Use `ENV` variable to select environment file:
+- `ENV=dev` → uses `.env.dev` → loads `tosca_api.settings.development`
+- `ENV=prod` → uses `.env.prod` → loads `tosca_api.settings.production`
+- Tests always use `tosca_api.settings.test` (configured in pytest.ini)
+
+### Database Schema Architecture
+PostGIS database with 3 schemas:
+- `tosca_api`: Django models and application data (Django connects here)
+- `geoserver`: GeoServer workspace/layer metadata
+- `gis`: Actual geospatial data (geometry tables)
+
+Django's `search_path` is set in [tosca_api/settings/base.py](../tosca_api/settings/base.py#L120) via `PG_SCHEMA_API` env var.
+
+## Authentication & Authorization
+
+### Keycloak Integration Flow
+1. User clicks login → redirected to Keycloak
+2. After authentication, Keycloak redirects back with authorization code
+3. `KeycloakAdapter.pre_social_login()` in [tosca_api/apps/authentication/backends.py](../tosca_api/apps/authentication/backends.py) handles:
+   - User creation/lookup by username
+   - Role synchronization from JWT token claims
+   - Django permission assignment (is_staff, is_superuser based on roles)
+
+See [tosca_api/apps/authentication/docs/keycloak_logic.md](../tosca_api/apps/authentication/docs/keycloak_logic.md) for sequence diagrams.
+
+### API Authentication
+DRF uses `KeycloakTokenAuthentication` for Bearer token validation:
+- Verifies JWT signature using Keycloak's JWKS endpoint
+- Extracts roles from `realm_access.roles` and `resource_access.{client}.roles`
+- Syncs roles to Django user on every request
+- Available for mobile/Vue/API clients
+
+Default auth classes in [tosca_api/settings/base.py](../tosca_api/settings/base.py#L153):
+```python
+"DEFAULT_AUTHENTICATION_CLASSES": [
+    "tosca_api.apps.authentication.backends.KeycloakTokenAuthentication",  # JWT
+    "rest_framework.authentication.SessionAuthentication",  # Browser
+]
+```
+
+### Role Mapping
+- `ROLE_GEOSERVER_ADMIN` → `is_staff=True`, `is_superuser=True`
+- `ROLE_AUTHENTICATED` → Any logged-in user
+- `ROLE_PUBLIC_ACCESS` → Anonymous users (mapped to GeoServer's `ROLE_ANONYMOUS`)
+
+## Development Workflows
+
+### Package Management (UV)
+Uses `uv` for Python dependency management (not pip):
+```bash
+make uv-sync              # Install dependencies from lockfile
+make uv-add PKG=requests  # Add new package
+make uv-lock              # Update lockfile
+```
+
+Never commit changes to `pyproject.toml` without running `make uv-lock` to update `uv.lock`.
+
+### Docker Development
+Primary workflow uses Docker Compose:
+```bash
+make up                  # Start all services (db, geoserver, django)
+make django-logs         # Follow Django logs
+make django-shell        # Open Django shell in container
+make django-migrate      # Run migrations
+make django-test         # Run pytest suite
+```
+
+See [Makefile](../Makefile) for all commands. The Makefile handles:
+- Environment file selection (ENV=dev or ENV=prod)
+- Docker Compose file selection
+- Service orchestration
+
+### Testing
+- Framework: pytest + pytest-django
+- Settings: `tosca_api.settings.test` (uses SQLite in-memory)
+- Run tests: `make django-test` or `pytest` (if running locally with uv)
+- Test naming: `test_*.py` or `*_tests.py`
+
+Example test pattern from [tosca_api/apps/authentication/tests/test_token_verification.py](../tosca_api/apps/authentication/tests/test_token_verification.py):
+- Generate real RSA keys for JWT signing
+- Mock JWKS endpoint with actual public key
+- Test both valid and invalid token scenarios
+
+### Migrations
+Always create migrations for model changes:
+```bash
+make django-makemigrations         # Create migrations
+make django-makemigrations APP=core  # For specific app
+make django-migrate                # Apply migrations
+```
+
+## Code Conventions
+
+### Logging Strategy
+Follow [docs/development/logging-strategy.md](../docs/development/logging-strategy.md):
+- Use `logger = logging.getLogger(__name__)` in each module
+- **NEVER** log tokens, passwords, or sensitive data
+- **ALWAYS** log authentication failures and security events
+- Use structured logging with context (user_id, request_id)
+- Use appropriate log levels (DEBUG for dev only, INFO for operations, WARNING/ERROR for issues)
+
+### Models
+- Inherit from `TimeStampedModel` (in [tosca_api/apps/core/models.py](../tosca_api/apps/core/models.py)) for automatic `created_at`/`updated_at` timestamps
+- Use `from __future__ import annotations` for forward references
+- Type hints on all methods (see Layer model in [tosca_api/apps/tosca_web/layers/models.py](../tosca_api/apps/tosca_web/layers/models.py))
+
+### ViewSets
+Standard pattern:
+```python
+class LayerViewSet(viewsets.ModelViewSet):
+    queryset = Layer.objects.select_related("owner")  # Always optimize queries
+    serializer_class = LayerSerializer
+    permission_classes = [permissions.IsAuthenticated]
+    
+    def perform_create(self, serializer):
+        serializer.save(owner=self.request.user)  # Inject current user
+```
+
+### Git Workflow
+- Follow Conventional Commits: `feat:`, `fix:`, `docs:`, `refactor:`, `chore:`
+- Branch naming: `feat/description`, `fix/bug-name`, `docs/topic`
+- Keep PRs small and focused
+- Target all PRs to `main` branch
+
+See [docs/development/git-workflow.md](../docs/development/git-workflow.md).
+
+## Key Files Reference
+
+- [tosca_api/settings/base.py](../tosca_api/settings/base.py) - Core Django settings, DRF config, Keycloak setup
+- [tosca_api/apps/authentication/backends.py](../tosca_api/apps/authentication/backends.py) - Keycloak OAuth2 adapter, JWT auth backend
+- [tosca_api/apps/core/jwt_utils.py](../tosca_api/apps/core/jwt_utils.py) - JWT verification logic
+- [Makefile](../Makefile) - All Docker and development commands
+- [project_structure.md](../project_structure.md) - Detailed repository layout
+
+## Common Patterns
+
+### Adding a New API Endpoint
+1. Create model in `tosca_api/apps/tosca_web/{module}/models.py`
+2. Create serializer in `serializers.py`
+3. Create viewset in `views.py`
+4. Register routes in `urls.py`
+5. Include in parent URLconf if needed
+6. Create tests in `tests/test_{module}.py`
+7. Run `make django-makemigrations` and `make django-migrate`
+
+### Working with JWT Tokens
+Use `verify_and_decode_token()` from `tosca_api.apps.core.jwt_utils` - it handles:
+- JWKS fetching and caching
+- Signature verification
+- Issuer/audience validation
+- Token expiration checking
+
+### Permission Checking
+Default: `permissions.IsAuthenticated` for all DRF views. Override per-view if needed. Custom permissions go in `tosca_api/apps/core/permissions.py`.
+
+## Troubleshooting
+
+### "No module named 'tosca_api'"
+Ensure you're using the correct settings module. Check `DJANGO_SETTINGS_MODULE` environment variable or use `--settings` flag.
+
+### Database Connection Errors
+Verify `.env.dev` contains correct `PG_HOST`, `PG_PORT`, `PG_DATABASE`, `PG_API_USER`, `PG_API_PASSWORD`. For Docker: `make down && make up` to restart services.
+
+### JWT Verification Failures
+Check that `KEYCLOAK_JWKS_URL` and `KEYCLOAK_ISSUER` in settings match your Keycloak realm configuration. Verify token audience matches `ALLOWED_TOKEN_AUDIENCES`.

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -43,7 +43,7 @@ services:
       - geoserver_data:/geoserver_data/data
       # Optional: set GEOSERVER_LOCAL_DATA_PATH in your .env.dev to mount local geodata.
       # Falls back to an empty directory when the variable is not set.
-      - ${GEOSERVER_LOCAL_DATA_PATH:-./docker/geoserver-empty}:/mnt/home
+      - /Users/gokturkburakkose/Documents/dev/TOSCA-Geodata:/mnt/home
     depends_on:
       db:
         condition: service_healthy

--- a/docs/features-to-add_local/analytical-concept.md
+++ b/docs/features-to-add_local/analytical-concept.md
@@ -1,0 +1,152 @@
+# **Analytical Concept Document: Geostories × Calendar × Participation**
+
+## **1. Executive Summary**
+
+**Geostories × Calendar × Participation** introduces an integrated participation ecosystem that connects **narratives, actions, and feedback** through a shared **Campaign** umbrella.
+
+It transforms how institutions and citizens collaborate around local challenges:
+
+- **Campaigns** define the thematic scope, geography, and partner coalition that bind every participation artifact together.
+- **Geostories** raise awareness through contextual, map-based storytelling.
+- **Calendar Events** translate those stories into real-world community actions.
+- **Feedback Mechanisms** evaluate impact, closing the loop with data-driven insights.
+
+The result is a **continuous participation cycle** — a self-learning system that strengthens engagement, transparency, and decision-making in cities and organizations, while campaign dashboards provide a mission-level view of progress.
+
+---
+
+## **2. Concept Model**
+
+| **Stage**      | **Core Component**           | **Purpose**                                                                               | **Primary Actors**                   | **Example Output**                                                     |
+| -------------- | ---------------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------ | ---------------------------------------------------------------------- |
+| **Framing**    | **Campaigns**                | Define scope, partners, KPIs, and the shared spatial layer that connects all assets.      | Program leads, institutions          | “Heat Resilience 2025” campaign with timeline and goals.               |
+| **Awareness**  | **Geostories**               | Communicate local problems, opportunities, and goals using spatial and narrative context. | Institutions, NGOs, researchers      | “Heat Risk in Wandsbek” story showing hotspots and citizen interviews. |
+| **Action**     | **Calendar Events**          | Mobilize real-world initiatives linked to story regions and the campaign mission.         | Citizens, local groups, city offices | “Community Cooling Day”, “Tree Planting Weekend”.                      |
+| **Reflection** | **Feedback Tools**           | Collect experiences, assess usefulness, measure improvement.                              | Participants, organizers             | Ratings, post-event surveys, structured outcome reports.               |
+| **Iteration**  | **Story & Campaign Updates** | Integrate outcomes into updated narratives and campaign dashboards, restarting the cycle. | Editors, planners                    | Revised Geostory plus refreshed campaign KPIs.                         |
+
+---
+
+## **3. System Components**
+
+| **Component**               | **Description**                                         | **Key Features**                                                                                                           | **Dependencies**                                        |
+| --------------------------- | ------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| **Campaign Module**         | Umbrella that groups stories, events, and feedback.     | Goals & KPIs, timeline, partner roles, cross-feature analytics.                                                            | User & role management, analytics.                      |
+| **Geostory Module**         | Narrative and spatial context builder.                  | Media-rich storytelling, map linkage (via `LayerRef`), tagging, open call section, embedded `GeoContext` for rich content. | Map backend (GeoServer), media library.                 |
+| **Event Module (Calendar)** | Event creation and spatial scheduling.                  | Date/time, map link (via `LayerRef`), description, organizer profile, embedded `GeoContext`.                               | Shared geodata layer, Campaign + Geostory reference.    |
+| **Feedback Module**         | Rating + form builder and submission logic.             | Pre/post feedback, configurable forms, analytics, optional `GeoContext` for instructions.                                  | Campaign, Event, and/or Geostory IDs, user permissions. |
+| **Analytics & Outcome**     | Aggregates all feedback data and links back to stories. | Sentiment trends, outcome summaries, impact dashboards.                                                                    | Database aggregation and visualization.                 |
+| **User Roles & Governance** | Defines permissions and workflows.                      | Editors, partners, citizens, moderators.                                                                                   | Authentication & authorization service.                 |
+
+---
+
+## **4. Target Groups**
+
+| **Group**                                | **Interest / Use Case**                                                            | **Value Proposition**                                         |
+| ---------------------------------------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| **Public Institutions**                  | Communicate urban or environmental challenges; evaluate programs within campaigns. | Public transparency, measurable impact.                       |
+| **Insurance Companies / Private Sector** | Raise awareness about local risk factors; support prevention.                      | Improved engagement and CSR visibility.                       |
+| **Researchers & Universities**           | Test participatory models; collect spatial perception data.                        | Research infrastructure for human-environment feedback loops. |
+| **Citizens & Community Groups**          | Learn about local challenges and join or organize initiatives.                     | Accessible, map-based participation and storytelling.         |
+
+---
+
+## **5. Strengths, Weaknesses, Opportunities, Risks (SWOR Analysis)**
+
+| **Strengths**                                     | **Weaknesses**                                      |
+| ------------------------------------------------- | --------------------------------------------------- |
+| Modular design: reusable across projects.         | Requires strong content curation for stories.       |
+| Integrates narrative, spatial, and social layers. | Feedback quality depends on participant motivation. |
+| Supports both institutional and citizen use.      | Complex moderation and data protection handling.    |
+| Encourages collaboration between sectors.         | Higher initial development effort.                  |
+
+| **Opportunities**                                               | **Risks / Caveats**                                         |
+| --------------------------------------------------------------- | ----------------------------------------------------------- |
+| Expansion into thematic domains (health, environment, culture). | Misinterpretation of public feedback without expert review. |
+| Cross-institutional data and storytelling network.              | Data privacy and GDPR compliance in feedback storage.       |
+| Foundation for AI-based insights and policy modeling.           | Dependence on continuous institutional engagement.          |
+
+---
+
+## **6. Implementation Logic**
+
+**Cycle Workflow**
+
+```
+[Campaign Launched]
+        ↓
+[Geostory Published]
+        ↓
+[Event Creation (linked region)]
+        ↓
+[Citizen Participation]
+        ↓
+[Feedback Collected]
+        ↓
+[Impact Evaluation & Analytics]
+        ↓
+[Updated Geostory / New Cycle]
+```
+
+### **Key Principles**
+
+- **Shared data model:** one spatial layer links stories, events, and feedback via campaigns.
+- **No-code configurability:** non-developers can create stories, forms, and campaigns.
+- **Scalable participation:** one backend, multiple local instances.
+- **Governance layer:** moderation, approval, visibility settings.
+
+---
+
+## **7. Pros & Cons Summary**
+
+| **Pros**                                           | **Cons**                                                     |
+| -------------------------------------------------- | ------------------------------------------------------------ |
+| Encourages civic action and shared responsibility. | May require training for story, event, and campaign authors. |
+| Produces measurable, location-specific insights.   | Needs moderation and quality control.                        |
+| Bridges institutions and citizens.                 | Complexity may increase onboarding time.                     |
+| Supports evaluation for funding and reporting.     | Risk of underuse without strong communication strategy.      |
+
+---
+
+## **8. Caveats and Risk Mitigation**
+
+| **Risk**                   | **Mitigation Strategy**                                                      |
+| -------------------------- | ---------------------------------------------------------------------------- |
+| **Low participation rate** | Promote hybrid participation (online/offline), partnerships with local NGOs. |
+| **Data sensitivity**       | Store only aggregated or anonymized feedback; clear consent forms.           |
+| **Content inconsistency**  | Provide templates and editorial review workflows.                            |
+| **Institutional silos**    | Enable shared campaign dashboard across departments for visibility.          |
+
+---
+
+## **9. Implementation Roadmap (Indicative)**
+
+| **Phase** | **Objective**                                                  | **Deliverables**                                       | **Timeline** |
+| --------- | -------------------------------------------------------------- | ------------------------------------------------------ | ------------ |
+| Phase 1   | Core architecture + Campaign, Geostory & Event modules.        | Working prototype with campaign > story/event linkage. | 2–3 months   |
+| Phase 2   | Add Feedback and Analytics.                                    | Pre/post feedback collection and campaign dashboards.  | +2 months    |
+| Phase 3   | Integrate moderation, multilingual support, and accessibility. | Stable public release.                                 | +2 months    |
+| Phase 4   | Pilot evaluation with partners.                                | Reports, KPIs, refinement.                             | +1–2 months  |
+
+---
+
+## **10. Expected Outcomes**
+
+| **Dimension**      | **Expected Impact**                                                                      |
+| ------------------ | ---------------------------------------------------------------------------------------- |
+| **Social**         | Stronger community engagement and trust in institutions.                                 |
+| **Organizational** | Simplified workflow for cross-sector collaboration.                                      |
+| **Technical**      | Shared infrastructure for map-based participation features with campaign-level grouping. |
+| **Strategic**      | Framework adaptable to other domains (health, mobility, environment).                    |
+
+---
+
+## **11. Summary Statement**
+
+> Geostories × Calendar × Participation
+
+> It moves public engagement beyond awareness — creating a dynamic environment where institutions and citizens collaborate to define problems, co-create solutions, and learn from results.
+
+> The system is modular, transparent, and scalable, forming the backbone for the next generation of participatory urban intelligence platforms.
+>
+> Campaigns provide the strategic umbrella that keeps every story, action, and feedback loop aligned.

--- a/docs/features-to-add_local/calendar-event-er-diagram.md
+++ b/docs/features-to-add_local/calendar-event-er-diagram.md
@@ -1,0 +1,70 @@
+# Calendar Event ER Diagram
+
+The following Entity-Relationship diagram outlines the technical database schema for `CalendarEvent` within the TOSCA-Backend. It illustrates how an event integrates with its parent campaign, its author, the core narrative context, map layers, and polymorphic feature links.
+
+```mermaid
+erDiagram
+    %% Core Entity
+    CALENDAR-EVENT {
+        UUID id PK
+        CharField title
+        TextField description
+        DateTimeField start_datetime
+        DateTimeField end_datetime
+        PointField location "Optional (SRID 4326)"
+        CharField status "draft | published | cancelled"
+        CharField visibility "public | private"
+        UUID campaign_id FK
+        UUID organizer_id FK
+        UUID context_id FK "1:1 relation"
+    }
+
+    %% Related Entities
+    CAMPAIGN {
+        UUID id PK
+        CharField name
+    }
+
+    USER {
+        int id PK
+        CharField username
+    }
+
+    GEO-CONTEXT {
+        UUID id PK
+        TextField content
+        CharField content_type
+    }
+
+    LAYER-REF {
+        UUID id PK
+        CharField title
+    }
+
+    %% Through Model
+    EVENT-LAYER {
+        UUID id PK
+        UUID event_id FK
+        UUID layer_id FK
+        int display_order
+    }
+
+    %% Generic Relations
+    FEATURE-LINK {
+        UUID id PK
+        CharField source_content_type
+        UUID source_object_id
+        CharField target_content_type
+        UUID target_object_id
+    }
+
+    %% Relationships
+    CAMPAIGN ||--o{ CALENDAR-EVENT : "contains"
+    USER ||--o{ CALENDAR-EVENT : "organizes (created_by)"
+    GEO-CONTEXT ||--o| CALENDAR-EVENT : "provides rich narrative for"
+
+    CALENDAR-EVENT ||--o{ EVENT-LAYER : "orders layer via"
+    LAYER-REF ||--o{ EVENT-LAYER : "is referenced by"
+
+    CALENDAR-EVENT ||--o{ FEATURE-LINK : "polymorphically links to (as source or target)"
+```

--- a/docs/features-to-add_local/calendar-event-flowchart.md
+++ b/docs/features-to-add_local/calendar-event-flowchart.md
@@ -1,0 +1,31 @@
+# Calendar Event Workflow Diagram
+
+Based on the TOSCA-Backend data architecture, the following diagram illustrates the streamlined life-cycle of creating and publishing a Calendar Event.
+
+```mermaid
+flowchart LR
+    %% Define Styles
+    classDef startend fill:#f9f9f9,stroke:#333,stroke-width:2px,rx:20,ry:20
+    classDef process fill:#e1f5fe,stroke:#0288d1,stroke-width:2px
+    classDef database fill:#e8f5e9,stroke:#388e3c,stroke-width:2px,shape:cylinder
+    classDef optional fill:#fff3e0,stroke:#f57c00,stroke-width:1px,stroke-dasharray: 5 5
+
+    %% Nodes
+    A([Start Calendar Event Creation]):::startend
+    B[Define Title & Description]:::process
+    C[Set Start/End Datetimes & Spatial Location]:::process
+    D[Attach Geo-referenced Map Layers *Optional*]:::optional
+    E[Embed Rich Media into GeoContext *Optional*]:::optional
+    F[Link to Related GeoStories/External Features *Optional*]:::optional
+    G[(Save Event to Database)]:::database
+    H([End: Event Live]):::startend
+
+    %% Flow
+    A --> B
+    B --> C
+    C --> D
+    D --> E
+    E --> F
+    F --> G
+    G --> H
+```

--- a/docs/features-to-add_local/calendar-module-architecture.md
+++ b/docs/features-to-add_local/calendar-module-architecture.md
@@ -1,0 +1,58 @@
+# Technical Structure: Calendar Module Integration
+
+This architectural illustration explains the process and innovation of how the **Calendar Module** acts as an integrated multimedia hub, combining temporal data, spatial contexts, and rich narratives into a cohesive user experience.
+
+```mermaid
+flowchart TD
+    %% Custom Styling for High Quality Visuals
+    classDef input fill:#ffb74d,stroke:#f57c00,stroke-width:2px,color:#000,rx:10,ry:10
+    classDef core fill:#29b6f6,stroke:#0288d1,stroke-width:3px,color:#fff,rx:20,ry:20
+    classDef connect fill:#81c784,stroke:#388e3c,stroke-width:2px,color:#000
+    classDef output fill:#ba68c8,stroke:#7b1fa2,stroke-width:2px,color:#fff,rx:10,ry:10
+
+    subgraph Phase1 ["1. Temporal & Spatial Input (TOP)"]
+        direction LR
+        A["Define Event Metadata<br/><i>(Title, Dates, Organizer)</i>"]:::input
+        B["Specify Spatial Location<br/><i>(SRID 4326 Point Geometry)</i>"]:::input
+    end
+
+    subgraph IntegrationLayer ["3. Innovative Data Integrations (LEFT)"]
+        direction TB
+        D["<b>GeoContext API</b><br/><i>1:1 Rich HTML Narrative</i>"]:::connect
+        E["<b>Spatial Layers Data</b><br/><i>M:N OGC Web Map Services</i>"]:::connect
+        F["<b>FeatureLinks</b><br/><i>Polymorphic Relational Graph</i>"]:::connect
+    end
+
+    subgraph CoreEngine ["2. Heart of the System (CENTER)"]
+        C(("**Calendar Event<br/>Core Engine**")):::core
+    end
+
+    subgraph PresentationLayer ["4. Frontend Visual Outputs (BOTTOM)"]
+        direction LR
+        G["Interactive Web-GIS Map"]:::output
+        H["Chronological Timeline UI"]:::output
+    end
+
+    %% Data Ingestion Flow (Top to Center)
+    A -->|Initializes| C
+    B -->|Pins to Map| C
+
+    %% Multi-dimensional Integrations Flow (Left to Center)
+    D <==>|Provides Deep Context| C
+    E <==>|Renders Base Imagery| C
+    F <==>|Traverses Ecosystem| C
+
+    %% Delivery / Output Flow (Center & Left to Bottom)
+    C == "Plots Temporal Data" ===> H
+    C == "Plots Spatial Data" ===> G
+    D -.->|Parsed as| G
+    E -.->|Overlaid on| G
+    F -.->|Clickable Entities in| H
+```
+
+### Key Innovations Explained:
+
+1. **Spatial-Temporal Duality:** The core engine natively processes items both chronologically (start/end boundaries) and spatially (GIS coordinate nodes).
+2. **Pluggable Narrative Architecture (GeoContext):** Instead of forcing rich-text into the event table, an independent context block allows limitless multimedia potential without bloating the timeline index.
+3. **Cross-Service Ecosystem Graph (FeatureLinks):** The event is not isolated. A polymorphic relationship enables an event to natively point to associated `GeoStories` or `Citizen Feedback` campaigns inside the database context tree.
+4. **Dynamic Cartography Rendering:** Abstracting layers from events lets the Interactive Web-GIS map dynamically composite OGC maps alongside the specific time-bound geometries.

--- a/docs/features-to-add_local/database_schema.md
+++ b/docs/features-to-add_local/database_schema.md
@@ -1,0 +1,254 @@
+# GeoStory Event Feedback System - Database Schema
+
+## Entity Relationship Diagram
+
+```mermaid
+erDiagram
+    %% Core Entities
+    CAMPAIGN {
+        UUID id PK
+        VARCHAR title
+        TEXT summary
+        ENUM status "draft, active, archived"
+        ENUM visibility "public, private"
+        UUID created_by_id FK
+        TIMESTAMPTZ created_at
+        TIMESTAMPTZ updated_at
+    }
+
+    GEOCONTEXT {
+        UUID id PK
+        TEXT content
+        ENUM content_type "simple, rich"
+        UUID created_by_id FK
+        TIMESTAMPTZ created_at
+        TIMESTAMPTZ updated_at
+    }
+
+    LAYERREF {
+        UUID id PK
+        VARCHAR layer_name UK "workspace:layer format"
+        TIMESTAMPTZ created_at
+    }
+
+    %% Feature Entities
+    GEOSTORY {
+        UUID id PK
+        UUID campaign_id FK
+        VARCHAR title
+        TEXT summary
+        ENUM status "draft, published, archived"
+        UUID author_id FK
+        UUID cover_media_id FK
+        UUID context_id FK "1:1 UNIQUE"
+        TIMESTAMPTZ created_at
+        TIMESTAMPTZ updated_at
+    }
+
+    CALENDAREVENT {
+        UUID id PK
+        UUID campaign_id FK
+        VARCHAR title
+        TEXT description
+        UUID context_id FK "1:1 UNIQUE"
+        TIMESTAMPTZ start_datetime
+        TIMESTAMPTZ end_datetime
+        GEOMETRY location "Point 4326"
+        UUID organizer_id FK
+        ENUM status "draft, published, cancelled"
+        ENUM visibility "public, private"
+        TIMESTAMPTZ created_at
+        TIMESTAMPTZ updated_at
+    }
+
+    GEOFEEDBACK {
+        UUID id PK
+        UUID campaign_id FK
+        VARCHAR title
+        BOOL rating_enabled
+        BOOL form_enabled
+        BOOL allow_drawings
+        UUID custom_form_id FK "nullable (from formbuilder)"
+        UUID context_id FK "1:1 UNIQUE"
+        TIMESTAMPTZ active_from
+        TIMESTAMPTZ active_to
+        ENUM visibility "public, private"
+        UUID created_by_id FK
+        TIMESTAMPTZ created_at
+        TIMESTAMPTZ updated_at
+    }
+
+    %% Feedback Categorization (Provided by formbuilder)
+    CUSTOM_FORM {
+        UUID id PK
+        VARCHAR name
+        VARCHAR slug UK
+        JSONB json_schema
+        ENUM status
+    }
+
+    FEEDBACKSUBMISSION {
+        UUID id PK
+        UUID feedback_id FK
+        UUID user_id FK "nullable"
+        INT rating "1-5, nullable"
+        JSONB form_data
+        GEOMETRY geometry "Any geometry type"
+        BOOL is_anonymized
+        TIMESTAMPTZ created_at
+    }
+
+    %% Direct Linking (M:N via GenericForeignKey)
+    FEATURELINK {
+        UUID id PK
+        UUID campaign_id FK
+        INT source_content_type_id FK
+        UUID source_object_id
+        INT target_content_type_id FK
+        UUID target_object_id
+        ENUM link_type "direct, read_more, action"
+        UUID created_by_id FK
+        TIMESTAMPTZ created_at
+    }
+
+    %% Users (Django auth_user)
+    USER {
+        UUID id PK
+        VARCHAR username
+        VARCHAR email
+    }
+
+    %% =====================================================
+    %% RELATIONSHIPS
+    %% =====================================================
+
+    %% Parent-Child (FK) Relationships
+    CAMPAIGN ||--o{ GEOSTORY : "contains"
+    CAMPAIGN ||--o{ CALENDAREVENT : "contains"
+    CAMPAIGN ||--o{ GEOFEEDBACK : "contains"
+    CAMPAIGN ||--o{ FEATURELINK : "scopes"
+
+    %% 1:1 GeoContext (UNIQUE constraint enforced)
+    GEOSTORY ||--o| GEOCONTEXT : "has content (1:1)"
+    CALENDAREVENT ||--o| GEOCONTEXT : "has content (1:1)"
+    GEOFEEDBACK ||--o| GEOCONTEXT : "has content (1:1)"
+
+    %% Layer Associations (M:N via junction tables)
+    GEOSTORY }o--o{ LAYERREF : "displays via geostory_layers"
+    CALENDAREVENT }o--o{ LAYERREF : "displays via event_layers"
+    GEOFEEDBACK }o--o{ LAYERREF : "displays via feedback_layers"
+
+    %% Feedback Structure
+    GEOFEEDBACK }o--o| CUSTOM_FORM : "uses schema from"
+    GEOFEEDBACK ||--o{ FEEDBACKSUBMISSION : "receives"
+
+    %% User Relations
+    FEEDBACKSUBMISSION }o--o| USER : "submitted by"
+    GEOSTORY }o--|| USER : "authored by"
+    CALENDAREVENT }o--|| USER : "organized by"
+    FEATURELINK }o--|| USER : "created by"
+    GEOCONTEXT }o--|| USER : "created by"
+    CAMPAIGN }o--|| USER : "created by"
+    GEOFEEDBACK }o--|| USER : "created by"
+    %% =====================================================
+    %% STYLING
+    %% =====================================================
+    %% Define classes
+    classDef core fill:#e1f5fe,stroke:#01579b,stroke-width:2px;
+    classDef feature fill:#e8f5e9,stroke:#2e7d32,stroke-width:2px;
+    classDef feedback fill:#f3e5f5,stroke:#7b1fa2,stroke-width:2px;
+    classDef system fill:#f5f5f5,stroke:#616161,stroke-width:1px,stroke-dasharray: 5 5;
+
+    %% Apply classes
+    class CAMPAIGN,GEOCONTEXT,LAYERREF core;
+    class GEOSTORY,CALENDAREVENT,GEOFEEDBACK feature;
+    class FEEDBACKSUBMISSION feedback;
+    class CUSTOM_FORM system;
+    class USER,FEATURELINK system;
+```
+
+---
+
+## FeatureLink: Direct Linking Between Features
+
+FeatureLink enables **M:N direct linking** between any feature entities within the same campaign.
+
+### Allowed Link Combinations
+
+| Source        | Target        | Description                       |
+| ------------- | ------------- | --------------------------------- |
+| GeoStory      | GeoStory      | Story references another story    |
+| GeoStory      | CalendarEvent | Story links to related event      |
+| GeoStory      | GeoFeedback   | Story links to feedback form      |
+| CalendarEvent | GeoStory      | Event references related story    |
+| CalendarEvent | CalendarEvent | Event links to another event      |
+| CalendarEvent | GeoFeedback   | Event links to feedback form      |
+| GeoFeedback   | GeoStory      | Feedback references related story |
+| GeoFeedback   | CalendarEvent | Feedback links to related event   |
+| GeoFeedback   | GeoFeedback   | Feedback links to another form    |
+
+### Constraints
+
+- **Same campaign**: Source and target must belong to the same campaign
+- **No self-links**: An entity cannot link to itself (CHECK constraint)
+- **No duplicates**: Each source→target pair is unique (UNIQUE constraint)
+- **Trigger validation**: `validate_featurelink()` ensures entities exist
+
+---
+
+## Junction Tables
+
+### geostory_layers
+
+| Column        | Type    | Description          |
+| ------------- | ------- | -------------------- |
+| id            | UUID PK | Primary key          |
+| geostory_id   | UUID FK | References geostory  |
+| layer_id      | UUID FK | References layerref  |
+| display_order | INT     | Layer stacking order |
+
+UNIQUE(geostory_id, layer_id)
+
+### event_layers
+
+| Column        | Type    | Description              |
+| ------------- | ------- | ------------------------ |
+| id            | UUID PK | Primary key              |
+| event_id      | UUID FK | References calendarevent |
+| layer_id      | UUID FK | References layerref      |
+| display_order | INT     | Layer stacking order     |
+
+UNIQUE(event_id, layer_id)
+
+### feedback_layers
+
+| Column        | Type    | Description            |
+| ------------- | ------- | ---------------------- |
+| id            | UUID PK | Primary key            |
+| feedback_id   | UUID FK | References geofeedback |
+| layer_id      | UUID FK | References layerref    |
+| display_order | INT     | Layer stacking order   |
+
+UNIQUE(feedback_id, layer_id)
+
+---
+
+## Key Design Decisions
+
+### 1:1 GeoContext Relationship
+
+Each feature entity (GeoStory, CalendarEvent, GeoFeedback) can have **one optional GeoContext** for rich content. This is enforced by:
+
+- FK constraint on `context_id`
+- **UNIQUE constraint** on `context_id` to prevent multiple entities sharing the same context
+
+**Migration to N:N**: If needed later, drop the UNIQUE constraint and optionally create junction tables.
+
+### FeatureLink vs Explicit Junction Tables
+
+We use a **single polymorphic FeatureLink table** instead of explicit junction tables (e.g., `story_event_links`) because:
+
+- Fewer tables to maintain
+- Supports future entity types without schema changes
+- Trigger validation ensures referential integrity
+- Trade-off: No native FK enforcement on linked entities

--- a/docs/features-to-add_local/database_schema_v2.md
+++ b/docs/features-to-add_local/database_schema_v2.md
@@ -1,0 +1,632 @@
+# GeoStory Event Feedback System - Database Schema V2
+
+This document describes the proposed full-platform v2 schema. It keeps the original platform scope from [database_schema.md](/Users/gokturkburakkose/Documents/dev/TOSCA-Backend/docs/features-to-add/database_schema.md) while replacing the old `CalendarEvent` structure with the new event model.
+
+## Entity Relationship Diagram
+
+```mermaid
+%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#e8f4f8','primaryTextColor':'#1a1a1a','primaryBorderColor':'#2c5282','lineColor':'#4a5568','secondaryColor':'#f0f9ff','tertiaryColor':'#fef3c7'}}}%%
+erDiagram
+    direction LR
+    
+    %% ═════════════════════════════════════════════════════
+    %% █ CORE ENTITIES
+    %% ═════════════════════════════════════════════════════
+    
+    USER:::coreModel {
+        UUID id PK
+        VARCHAR username
+        VARCHAR email
+    }
+
+    CAMPAIGN:::coreModel {
+        UUID id PK
+        VARCHAR title
+        TEXT summary
+        ENUM status "draft, active, archived"
+        ENUM visibility "public, private"
+        UUID created_by_id FK
+        TIMESTAMPTZ created_at
+        TIMESTAMPTZ updated_at
+    }
+
+    LAYERREF:::coreModel {
+        UUID id PK
+        VARCHAR layer_name UK "workspace:layer format"
+        TIMESTAMPTZ created_at
+    }
+
+    GEOCONTEXT:::coreModel {
+        UUID id PK
+        TEXT content
+        ENUM content_type "simple, rich"
+        UUID created_by_id FK
+        TIMESTAMPTZ created_at
+        TIMESTAMPTZ updated_at
+    }
+
+    %% ═════════════════════════════════════════════════════
+    %% █ CONTENT FEATURES - enriched by GeoContext
+    %% ═════════════════════════════════════════════════════
+    
+    GEOSTORY:::contentModel {
+        UUID id PK
+        UUID campaign_id FK
+        VARCHAR title
+        TEXT summary
+        ENUM status "draft, published, archived"
+        UUID author_id FK
+        UUID cover_media_id FK
+        UUID context_id FK "optional"
+        TIMESTAMPTZ created_at
+        TIMESTAMPTZ updated_at
+    }
+
+    GEOFEEDBACK:::contentModel {
+        UUID id PK
+        UUID campaign_id FK
+        VARCHAR title
+        TEXT description
+        BOOL rating_enabled
+        BOOL form_enabled
+        BOOL allow_drawings
+        UUID custom_form_id FK "nullable"
+        UUID context_id FK "optional"
+        ENUM status "draft, published, closed"
+        ENUM visibility "public, private"
+        UUID created_by_id FK
+        TIMESTAMPTZ created_at
+        TIMESTAMPTZ updated_at
+    }
+
+    %% ═════════════════════════════════════════════════════
+    %% █ EVENT DOMAIN - types, series, and occurrences
+    %% ═════════════════════════════════════════════════════
+    
+    EVENT_TYPE:::eventModel {
+        UUID id PK
+        VARCHAR code UK
+        VARCHAR label
+        VARCHAR profile_mode "core, extension"
+        VARCHAR profile_key "nullable"
+        BOOL is_active
+        TIMESTAMPTZ created_at
+        TIMESTAMPTZ updated_at
+    }
+
+    EVENT_SERIES:::eventModel {
+        UUID id PK
+        UUID campaign_id FK
+        UUID event_type_id FK
+        UUID created_by_id FK
+        UUID default_context_id FK "optional shared context"
+        VARCHAR name
+        ENUM series_mode "manual_batch, recurring"
+        ENUM recurrence_type "daily, weekly, monthly"
+        DATE start_date
+        DATE end_date "nullable"
+        INT occurrence_count "nullable"
+        INT interval
+        TIME start_time
+        TIME end_time
+        VARCHAR timezone
+        ENUM monthly_rule_type "day_of_month, nth_weekday"
+        INT day_of_month "nullable"
+        INT week_of_month "nullable"
+        VARCHAR weekday_of_month "nullable"
+        JSONB by_weekday
+        TEXT notes
+        TIMESTAMPTZ created_at
+        TIMESTAMPTZ updated_at
+    }
+
+    EVENT_SERIES_DATE:::eventModel {
+        UUID id PK
+        UUID series_id FK
+        DATE occurrence_date
+        INT display_order
+    }
+
+    EVENT:::eventModel {
+        UUID id PK
+        UUID campaign_id FK
+        UUID series_id FK "nullable"
+        UUID event_type_id FK
+        UUID organizer_id FK
+        UUID context_id FK "optional"
+        VARCHAR external_id "nullable import id"
+        VARCHAR title
+        TEXT description
+        TIMESTAMPTZ start_datetime
+        TIMESTAMPTZ end_datetime
+        VARCHAR timezone
+        ENUM status "draft, published, cancelled, archived"
+        ENUM visibility "public, private"
+        ENUM location_mode "physical, online, hybrid"
+        GEOMETRY location "Point 4326, nullable"
+        VARCHAR venue_name
+        TEXT address_text
+        VARCHAR online_url
+        VARCHAR online_platform
+        TEXT access_notes
+        VARCHAR provider_name
+        VARCHAR provider_url
+        TEXT provider_contact
+        INT occurrence_index "nullable"
+        BOOL is_exception
+        TIMESTAMPTZ original_start_datetime "nullable"
+        JSONB metadata
+        TIMESTAMPTZ created_at
+        TIMESTAMPTZ updated_at
+    }
+
+    %% ═════════════════════════════════════════════════════
+    %% █ EVENT EXTENSION PROFILES - domain-specific data
+    %% ═════════════════════════════════════════════════════
+    
+    PUBLIC_HEALTH_EVENT_PROFILE:::eventModel {
+        UUID event_id PK
+        BOOL referral_required
+        BOOL insurance_eligible
+        BOOL clinical_setting
+        JSONB health_metadata
+        TIMESTAMPTZ created_at
+        TIMESTAMPTZ updated_at
+    }
+
+    SPORTS_EVENT_PROFILE:::eventModel {
+        UUID event_id PK
+        JSONB sports_metadata
+        TIMESTAMPTZ created_at
+        TIMESTAMPTZ updated_at
+    }
+
+    CULTURE_EVENT_PROFILE:::eventModel {
+        UUID event_id PK
+        JSONB culture_metadata
+        TIMESTAMPTZ created_at
+        TIMESTAMPTZ updated_at
+    }
+
+    %% ═════════════════════════════════════════════════════
+    %% █ TAXONOMY - dynamic classification system
+    %% ═════════════════════════════════════════════════════
+    
+    TAXONOMY_DIMENSION:::taxonomyModel {
+        UUID id PK
+        VARCHAR code UK
+        VARCHAR label
+        TEXT description
+        ENUM selection_mode "single, multiple"
+        BOOL is_active
+        BOOL is_system
+        INT sort_order
+        JSONB config
+        TIMESTAMPTZ created_at
+        TIMESTAMPTZ updated_at
+    }
+
+    TAXONOMY_TERM:::taxonomyModel {
+        UUID id PK
+        UUID dimension_id FK
+        UUID parent_term_id FK "nullable"
+        VARCHAR code
+        VARCHAR label
+        TEXT description
+        BOOL is_active
+        INT sort_order
+        JSONB metadata
+        TIMESTAMPTZ created_at
+        TIMESTAMPTZ updated_at
+    }
+
+    EVENT_TERM:::eventModel {
+        UUID id PK
+        UUID event_id FK
+        UUID term_id FK
+        TIMESTAMPTZ created_at
+    }
+
+    %% ═════════════════════════════════════════════════════
+    %% █ FEEDBACK & FORMS - user submissions
+    %% ═════════════════════════════════════════════════════
+    
+    CUSTOM_FORM:::contentModel {
+        UUID id PK
+        VARCHAR name
+        VARCHAR slug UK
+        JSONB json_schema
+        ENUM status
+    }
+
+    FEEDBACKSUBMISSION:::contentModel {
+        UUID id PK
+        UUID feedback_id FK
+        UUID user_id FK "nullable"
+        INT rating "1-5, nullable"
+        JSONB form_data
+        GEOMETRY geometry "Any geometry type"
+        BOOL is_anonymized
+        TIMESTAMPTZ created_at
+    }
+
+    %% ═════════════════════════════════════════════════════
+    %% █ JUNCTION TABLES - many-to-many relationships
+    %% ═════════════════════════════════════════════════════
+    
+    GEOSTORY_LAYER:::junctionModel {
+        UUID id PK
+        UUID geostory_id FK
+        UUID layer_id FK
+        INT display_order
+        TIMESTAMPTZ created_at
+    }
+
+    EVENT_LAYER:::junctionModel {
+        UUID id PK
+        UUID event_id FK
+        UUID layer_id FK
+        INT display_order
+        TIMESTAMPTZ created_at
+    }
+
+    FEEDBACK_LAYER:::junctionModel {
+        UUID id PK
+        UUID feedback_id FK
+        UUID layer_id FK
+        INT display_order
+        TIMESTAMPTZ created_at
+    }
+
+    FEATURELINK:::junctionModel {
+        UUID id PK
+        UUID campaign_id FK
+        INT source_content_type_id FK
+        UUID source_object_id
+        INT target_content_type_id FK
+        UUID target_object_id
+        ENUM link_type "direct, read_more, action"
+        UUID created_by_id FK
+        TIMESTAMPTZ created_at
+    }
+
+    %% ═════════════════════════════════════════════════════
+    %% █ RELATIONSHIPS
+    %% ═════════════════════════════════════════════════════
+    
+    %% ─────────────────────────────────────────────────────
+    %% Core ownership relationships
+    %% ─────────────────────────────────────────────────────
+    CAMPAIGN ||--o{ GEOSTORY : "contains"
+    CAMPAIGN ||--o{ GEOFEEDBACK : "contains"
+    CAMPAIGN ||--o{ EVENT : "contains"
+    CAMPAIGN ||--o{ EVENT_SERIES : "contains"
+    CAMPAIGN ||--o{ FEATURELINK : "scopes"
+
+    USER ||--o{ CAMPAIGN : "creates"
+    USER ||--o{ GEOCONTEXT : "creates"
+    USER ||--o{ GEOSTORY : "authors"
+    USER ||--o{ GEOFEEDBACK : "creates"
+    USER ||--o{ EVENT : "organizes"
+    USER ||--o{ EVENT_SERIES : "creates"
+    USER ||--o{ FEATURELINK : "creates"
+    USER ||--o{ FEEDBACKSUBMISSION : "submits"
+
+    %% ─────────────────────────────────────────────────────
+    %% GeoContext enriches content features
+    %% ─────────────────────────────────────────────────────
+    GEOCONTEXT ||--o{ GEOSTORY : "enriches"
+    GEOCONTEXT ||--o{ GEOFEEDBACK : "enriches"
+    GEOCONTEXT ||--o{ EVENT : "enriches"
+    GEOCONTEXT ||--o{ EVENT_SERIES : "defaults for"
+
+    %% ─────────────────────────────────────────────────────
+    %% Event domain relationships
+    %% ─────────────────────────────────────────────────────
+    EVENT_TYPE ||--o{ EVENT_SERIES : "classifies"
+    EVENT_TYPE ||--o{ EVENT : "classifies"
+    EVENT_SERIES ||--o{ EVENT : "groups"
+    EVENT_SERIES ||--o{ EVENT_SERIES_DATE : "stores dates"
+
+    %% ─────────────────────────────────────────────────────
+    %% Event extension profiles
+    %% ─────────────────────────────────────────────────────
+    EVENT ||--o| PUBLIC_HEALTH_EVENT_PROFILE : "extends if public_health"
+    EVENT ||--o| SPORTS_EVENT_PROFILE : "extends if sports"
+    EVENT ||--o| CULTURE_EVENT_PROFILE : "extends if culture"
+
+    %% ─────────────────────────────────────────────────────
+    %% Event taxonomy
+    %% ─────────────────────────────────────────────────────
+    TAXONOMY_DIMENSION ||--o{ TAXONOMY_TERM : "owns"
+    EVENT ||--o{ EVENT_TERM : "tagged by"
+    TAXONOMY_TERM ||--o{ EVENT_TERM : "assigned to"
+
+    %% ─────────────────────────────────────────────────────
+    %% Layer references for all features
+    %% ─────────────────────────────────────────────────────
+    GEOSTORY ||--o{ GEOSTORY_LAYER : "orders layers"
+    GEOFEEDBACK ||--o{ FEEDBACK_LAYER : "orders layers"
+    EVENT ||--o{ EVENT_LAYER : "orders layers"
+    LAYERREF ||--o{ GEOSTORY_LAYER : "is referenced by"
+    LAYERREF ||--o{ FEEDBACK_LAYER : "is referenced by"
+    LAYERREF ||--o{ EVENT_LAYER : "is referenced by"
+
+    %% ─────────────────────────────────────────────────────
+    %% Feedback forms
+    %% ─────────────────────────────────────────────────────
+    GEOFEEDBACK }o--o| CUSTOM_FORM : "uses schema from"
+    GEOFEEDBACK ||--o{ FEEDBACKSUBMISSION : "receives"
+
+    classDef coreModel fill:#e0f2fe,stroke:#0369a1,color:#0f172a,stroke-width:2px
+    classDef contentModel fill:#f3e8ff,stroke:#7c3aed,color:#2e1065,stroke-width:2px
+    classDef eventModel fill:#dcfce7,stroke:#15803d,color:#14532d,stroke-width:2px
+    classDef taxonomyModel fill:#fef3c7,stroke:#b45309,color:#78350f,stroke-width:2px
+    classDef junctionModel fill:#f3f4f6,stroke:#6b7280,color:#111827,stroke-width:1,5px
+```
+
+Note: the self-referential `TaxonomyTerm.parent_term_id` hierarchy is intentionally omitted from the main Mermaid ER diagram because Mermaid tends to render self-loops with long, distracting connector paths in large schemas. The hierarchy is still part of the model and is documented in the taxonomy constraints below.
+
+---
+
+## FeatureLink: Direct Linking Between Features
+
+FeatureLink continues to provide **M:N direct linking** between platform features within the same campaign.
+
+### Allowed Link Combinations
+
+| Source | Target | Description |
+| --- | --- | --- |
+| GeoStory | GeoStory | Story references another story |
+| GeoStory | Event | Story links to related event |
+| GeoStory | GeoFeedback | Story links to feedback form |
+| Event | GeoStory | Event references related story |
+| Event | Event | Event links to another event |
+| Event | GeoFeedback | Event links to feedback form |
+| GeoFeedback | GeoStory | Feedback references related story |
+| GeoFeedback | Event | Feedback links to related event |
+| GeoFeedback | GeoFeedback | Feedback links to another form |
+
+### Constraints
+
+- **Same campaign**: source and target must belong to the same campaign
+- **No self-links**: an entity cannot link to itself
+- **No duplicates**: each source-target pair is unique
+- **Validation**: linked content types must be platform feature entities
+
+---
+
+## Junction Tables
+
+### geostory_layers
+
+| Column | Type | Description |
+| --- | --- | --- |
+| `id` | UUID PK | Primary key |
+| `geostory_id` | UUID FK | References `geostory` |
+| `layer_id` | UUID FK | References `layerref` |
+| `display_order` | INT | Layer stacking order |
+
+Constraint:
+
+- `UNIQUE(geostory_id, layer_id)`
+
+### event_layers
+
+| Column | Type | Description |
+| --- | --- | --- |
+| `id` | UUID PK | Primary key |
+| `event_id` | UUID FK | References `event` |
+| `layer_id` | UUID FK | References `layerref` |
+| `display_order` | INT | Layer stacking order |
+
+Constraint:
+
+- `UNIQUE(event_id, layer_id)`
+
+### feedback_layers
+
+| Column | Type | Description |
+| --- | --- | --- |
+| `id` | UUID PK | Primary key |
+| `feedback_id` | UUID FK | References `geofeedback` |
+| `layer_id` | UUID FK | References `layerref` |
+| `display_order` | INT | Layer stacking order |
+
+Constraint:
+
+- `UNIQUE(feedback_id, layer_id)`
+
+### event_term
+
+| Column | Type | Description |
+| --- | --- | --- |
+| `id` | UUID PK | Primary key |
+| `event_id` | UUID FK | References `event` |
+| `term_id` | UUID FK | References `taxonomy_term` |
+| `created_at` | TIMESTAMPTZ | Assignment timestamp |
+
+Constraint:
+
+- `UNIQUE(event_id, term_id)`
+
+### event_series_date
+
+| Column | Type | Description |
+| --- | --- | --- |
+| `id` | UUID PK | Primary key |
+| `series_id` | UUID FK | References `event_series` |
+| `occurrence_date` | DATE | Explicit chosen date |
+| `display_order` | INT | UI ordering |
+
+Constraint:
+
+- `UNIQUE(series_id, occurrence_date)`
+
+---
+
+## Key Design Decisions in V2
+
+### GeoContext Reuse
+
+Unlike the v1 event model, event context is no longer modeled as a strict 1:1 content row.
+
+Reason:
+
+- `EventSeries.default_context_id` stores the shared default context for a series
+- `Event.context_id` is an optional per-occurrence override
+- effective context resolution is `event.context` -> `series.default_context` -> none
+- events without any effective context are valid
+
+`GeoStory` and `GeoFeedback` may stay 1:1 or move to the same pattern later, depending on product direction.
+
+### Event Core Ownership
+
+The following stay directly on `Event`:
+
+- location and online access data
+- provider data
+- schedule
+- basic content
+
+This avoids premature `Location` or `Provider` entities and keeps authoring simple.
+
+### Dynamic Taxonomy
+
+Event classification is no longer hardcoded. Instead:
+
+- `TaxonomyDimension` defines a bucket such as `topic` or `language`
+- `TaxonomyTerm` defines values inside one bucket
+- `EventTerm` attaches terms to events
+
+This supports open-source adaptability and deployment-specific vocabularies.
+
+### Event Type Registry and Profiles
+
+`EventType` controls whether an event:
+
+- is fully represented by the event core
+- or requires a domain-specific extension profile
+
+Binding rule:
+
+- `profile_mode=core` -> no extension row expected
+- `profile_mode=extension` -> only the matching profile table is valid
+
+### EventSeries and Exceptions
+
+`EventSeries` is a lightweight grouping and recurrence-definition model.
+
+It does not own the actual event data. Each occurrence is still a normal `Event`.
+
+Per-occurrence edits are tracked through:
+
+- `is_exception`
+- `original_start_datetime`
+- `occurrence_index`
+
+While an event remains attached to a series, it stays bound to that series for:
+
+- `campaign_id`
+- `event_type_id`
+
+Exceptions may diverge on schedule, content, or location, but not on `campaign_id` or `event_type_id` unless detached from the series.
+
+### Map / List Output Semantics
+
+The v2 API design assumes:
+
+- shared filters between map and list endpoints
+- different response shapes
+- map response returns:
+  - `spatial_events` as GeoJSON
+  - `online_events` as a plain JSON array
+- list response returns one paginated mixed stream ordered by `start_datetime`
+- `location_mode` tells clients whether a list item is `physical`, `hybrid`, or `online`
+- spatial filters constrain only `physical` and `hybrid`
+- `online` events bypass spatial predicates but still use all non-spatial filters
+
+---
+
+## Suggested Constraints Summary
+
+### Event
+
+- `end_datetime >= start_datetime`
+- `location_mode IN ('physical', 'online', 'hybrid')`
+- `physical` events require location
+- `hybrid` events require location and online URL
+- `online` events require online URL and may have `location = NULL`
+- `context_id` is nullable
+- `(series_id, occurrence_index)` should be unique when `series_id` is not null
+- `is_exception=true` requires `series_id`
+- if `series_id` is set, `campaign_id` must equal the series campaign
+- if `series_id` is set, `event_type_id` must equal the series event type
+
+### EventSeries
+
+- `series_mode IN ('manual_batch', 'recurring')`
+- recurring series require `recurrence_type`
+- `default_context_id` is nullable
+- exactly one end strategy:
+  - `end_date`
+  - or `occurrence_count`
+- weekly recurrence requires at least one weekday
+- monthly recurrence requires either:
+  - `day_of_month`
+  - or `week_of_month + weekday_of_month`
+- recurrence is defined in local wall time using a required IANA timezone
+- generated occurrences keep the same local time across DST transitions
+
+### EventSeriesDate
+
+- `UNIQUE(series_id, occurrence_date)`
+- `display_order >= 1`
+
+### Taxonomy
+
+- `TaxonomyDimension.code` unique
+- `UNIQUE(dimension_id, code)` on `TaxonomyTerm`
+- parent and child terms must belong to the same dimension
+- `UNIQUE(event_id, term_id)` on `EventTerm`
+
+### Profiles
+
+- profile row allowed only when it matches the event type binding
+
+## Recommended Indexes
+
+- `Event.location` GiST
+- `Event(campaign_id, status, start_datetime)`
+- `Event(event_type_id, start_datetime)`
+- `Event(location_mode, start_datetime)`
+- `Event(series_id, start_datetime)`
+- unique partial index on `(series_id, occurrence_index)` where `series_id IS NOT NULL`
+- `EventSeriesDate(series_id, occurrence_date)` unique
+- `TaxonomyTerm(dimension_id, code)` unique
+- `EventTerm(event_id, term_id)` unique
+- `EventTerm(term_id, event_id)` index
+
+---
+
+## Migration Orientation
+
+Suggested migration sequence:
+
+1. Introduce `EventType`
+2. Finalize the event schema and replace `CalendarEvent` with `Event`
+3. Add `EventSeries.default_context` plus optional `Event.context` override
+4. Introduce taxonomy tables
+5. Introduce `EventSeries` and `EventSeriesDate`
+6. Introduce event profile tables
+7. Refactor map/list APIs
+
+Because the system is not yet in production, rollout may use a destructive pre-production DB reset instead of row-level data backfill.
+
+---
+
+## Related Documents
+
+- [proposed-event-model.md](/Users/gokturkburakkose/Documents/dev/TOSCA-Backend/docs/features-to-add/proposed-event-model.md)
+- [database_schema.md](/Users/gokturkburakkose/Documents/dev/TOSCA-Backend/docs/features-to-add/database_schema.md)
+- [technical-architecture.md](/Users/gokturkburakkose/Documents/dev/TOSCA-Backend/docs/features-to-add/technical-architecture.md)

--- a/docs/features-to-add_local/decisions.md
+++ b/docs/features-to-add_local/decisions.md
@@ -1,0 +1,582 @@
+# Decision Log
+
+This document tracks key architectural and implementation decisions made during the development of the TOSCA-Backend features.
+
+## Phase 0: Infrastructure
+
+### [0.1] GDAL Installation Strategy
+
+- **Decision**: Install system libraries (`gdal-bin`, `libgdal-dev`) directly in the Docker image via `apt`.
+- **Rationale**: GeoDjango requires binary bindings to GDAL/GEOS. Using the system package manager is the most reliable way to ensure compatibility with the underlying OS (Debian Slim).
+- **Alternatives Considered**: Using a pre-built GeoDjango image (less control), compiling from source (too slow/complex).
+
+### [0.2] GeoDjango Configuration Strategy
+
+- **Decision**: Add `django.contrib.gis` to `INSTALLED_APPS` and use `django.contrib.gis.db.backends.postgis` as the database engine.
+- **Rationale**: This is the standard Django approach for enabling GeoDjango features. No custom backends or third-party packages needed.
+- **Favorites**: Using a separate GeoDjango project (rejected: unnecessary complexity).
+
+### [0.X] Test Location Strategy
+
+- **Decision**: Co-locate tests within each app directory (`apps/<app_name>/tests/`), using a package structure.
+- **Rationale**:
+  - **Modularity**: Allows apps to be portable.
+  - **Organization**: Breaking tests into `test_models.py`, `test_views.py` is cleaner than one giant file.
+  - **Django Default**: Standard convention expected by `manage.py test`.
+
+### [0.3] PostGIS Infrastructure Tests Strategy
+
+- **Decision**: Run PostGIS verification tests against the live dev database (`--ds=tosca_api.settings.base`), not a test database.
+- **Rationale**:
+  - **Speed**: Avoids creating/tearing down a test database just to verify a SQL query.
+  - **Infrastructure Focus**: These tests are verifying the _system_ (PostGIS extension is installed), not application logic.
+  - **Permission Issues**: The API user (`tosca_api`) lacks CREATEDB privileges, which is correct for security. Superuser tests would require a separate test database setup.
+- **Pattern**: Use a custom fixture (`db_access_without_rollback`) that unblocks the database connection without triggering test database creation.
+- **Run Command**: `pytest tosca_api/apps/core/tests/test_postgis.py -v --ds=tosca_api.settings.base`
+
+### [0.4] Campaign Model Design
+
+- **Decision**: Use UUID as primary key, TextChoices for status/visibility enums, and inherit from `TimeStampedModel`.
+- **Rationale**:
+  - **UUID PK**: Provides globally unique identifiers, avoids sequential ID enumeration (security), and is required for eventual multi-tenant sync.
+  - **TextChoices**: Human-readable values stored in DB (e.g., `"draft"`), easier to debug and query vs integer enums.
+  - **TimeStampedModel**: Reuses existing abstract base class from `core.models`, ensuring consistent timestamp fields across all models.
+  - **PROTECT on delete**: Prevents accidental deletion of users who own campaigns.
+
+### [0.5] GeoContext Model Design
+
+- **Decision**: Create a separate `geocontext` app with a standalone `GeoContext` model, linked 1:1 to parent features.
+- **Rationale**:
+  - **Separation of Concerns**: Content management is distinct from feature metadata (status, visibility, etc.).
+  - **Reusability**: The same content structure can be used by GeoStory, CalendarEvent, and GeoFeedback.
+  - **Flexibility**: Rich vs simple content types allow for progressive enhancement without schema changes.
+- **Linkage Pattern**: Parent features (GeoStory, etc.) will use `OneToOneField(GeoContext, null=True)`.
+- **Superseded Note**: This original `content` + `content_type` design is preserved as historical context, but is superseded for future implementation by Phase 7 Editor.js canonical JSON storage.
+
+### [SECURITY] Zero Trust Content Sanitization
+
+- **Policy**: All user-generated text content MUST be sanitized at the model level before persistence.
+- **Rationale**: Prevent XSS/HTML injection even if frontend or serializer validation is bypassed.
+- **Implementation**:
+  - **Simple Fields** (Title, Summary, etc.): Apply `sanitize_simple` (strip ALL tags).
+  - **Rich Fields** (GeoContext content type=rich): Apply `sanitize_rich` (allowlist only).
+  - **Location**: Override `save()` method on all content models (`Campaign`, `GeoContext`, `GeoStory`, etc.).
+- **Consistency**: Frontend should mirrored this policy, but Backend is the source of truth enforcement.
+- **Phase 7 Addendum**: For GeoContext Editor.js migration, sanitization applies to inline HTML fragments within Editor.js block text rather than to raw stored HTML documents.
+
+---
+
+## Phase 2: CalendarEvent Feature
+
+### [2.1] CalendarEvent API Dual-View Pattern
+
+- **Decision**: Implement two distinct response formats for the events API:
+  - **Calendar View** (default): Paginated JSON, includes all events (with or without location).
+  - **Map View** (spatial filter): GeoJSON FeatureCollection, only events WITH location.
+- **Rationale**:
+  - Calendar UI needs all events regardless of spatial data.
+  - Map UI needs GeoJSON format and only events that can be rendered on a map.
+  - Avoids null geometry issues in GeoJSON output.
+- **Trigger**: Map view is activated by `bbox` query param or `POST /within/` endpoint.
+
+### [2.2] Spatial Filtering Strategy
+
+- **Decision**: Use POST for polygon filters, GET for bbox filters.
+- **Rationale**:
+  - **BBox (GET)**: Simple, fits in URL query string: `?bbox=min_lon,min_lat,max_lon,max_lat`
+  - **Polygon (POST)**: Complex GeoJSON geometries don't fit well in URLs; POST body is cleaner.
+  - **Mutual Exclusivity**: `bbox` and `geometry` cannot be combined (no meaningful use case).
+- **Endpoints**:
+  - `GET /api/v1/events/?bbox=...` - Bounding box filter
+  - `POST /api/v1/events/within/` - Polygon/MultiPolygon filter
+
+### [2.3] Default Temporal Filter: Future Events Only
+
+- **Decision**: By default, the events API returns only future events (`start_datetime >= now`).
+- **Rationale**:
+  - Most frontend use cases display upcoming events.
+  - Past events are historical and require explicit opt-in via `include_past=true`.
+  - Reduces response payload size for typical queries.
+- **Override**: Use `?include_past=true` to include past events.
+
+### [2.4] GeoJSON Serialization via djangorestframework-gis
+
+- **Decision**: Use `djangorestframework-gis` for GeoJSON output instead of custom serializers.
+- **Rationale**:
+  - Standard library, well-maintained, integrates with DRF.
+  - `GeoFeatureModelSerializer` produces valid GeoJSON FeatureCollection.
+  - Handles SRID transformation and geometry serialization.
+- **Dependency**: Added `djangorestframework-gis>=1.0` to project.
+
+---
+
+## Phase 2B: Event Model V2
+
+### [2B.1] Event Core as the Source of Truth
+
+- **Decision**: Keep location, provider, schedule, and core event content directly on the event model rather than splitting them into separate `Location` or `Provider` models.
+- **Rationale**:
+  - Event authoring stays simple.
+  - The main use case is still event-centric, not location-centric or provider-centric.
+  - Avoids premature normalization and extra joins for the common create/edit/read path.
+- **Trade-off**: Reusable provider or venue entities can still be introduced later if product requirements justify them.
+
+### [2B.2] GeoContext Reuse for Event Series
+
+- **Decision**: Change event-to-`GeoContext` linkage from `OneToOneField` to `ForeignKey`.
+- **Rationale**:
+  - Multiple generated occurrences in the same series may initially share one context block.
+  - This avoids duplicating rich content during series generation.
+  - Users can still override context per event later if needed.
+- **Trade-off**: The event-context relationship becomes less strictly isolated than the current v1 event design, but the reuse benefit is higher for recurring workflows.
+
+### [2B.3] Dynamic Taxonomy Dimensions
+
+- **Decision**: Use `TaxonomyDimension`, `TaxonomyTerm`, and `EventTerm` instead of a hardcoded event taxonomy enum structure.
+- **Rationale**:
+  - The project is open source and should support different owner-defined classification schemes.
+  - New dimensions should not require schema changes.
+  - Hierarchical terms map naturally to workbook concepts such as `topic` / `topicFocus`.
+- **Trade-off**: Some validation moves from simple enum constraints to richer application logic and admin governance.
+
+### [2B.4] EventType Registry with Profile Binding
+
+- **Decision**: Introduce `EventType` as a registry with `profile_mode` and `profile_key`, and enforce profile compatibility through application validation.
+- **Rationale**:
+  - Some event types are fully represented by the event core.
+  - Other event types need extension profiles such as `PublicHealthEventProfile`.
+  - The registry makes event-type behavior explicit and data-driven.
+- **Implementation Rule**:
+  - `profile_mode=core` means no profile row is expected.
+  - `profile_mode=extension` means only the matching profile table is valid.
+
+### [2B.5] Shared Filters with Dual Output APIs
+
+- **Decision**: Keep one filtering contract for event retrieval, but provide separate map and list endpoints with different response shapes.
+- **Rationale**:
+  - Frontend logic stays simpler when filters are shared.
+  - Map consumers need GeoJSON.
+  - List and card consumers need paginated JSON.
+- **Map Output Rule**:
+  - Online events are included in GeoJSON with `geometry: null`.
+  - Spatial filters constrain spatial events, but online events remain in the result set for now.
+
+### [2B.6] Lightweight EventSeries Model
+
+- **Decision**: Model recurring and manual-batch relationships through a lightweight `EventSeries` model plus `EventSeriesDate` for explicit batch dates.
+- **Rationale**:
+  - Campaign is too broad to represent recurrence.
+  - Event rows must remain the canonical occurrence records.
+  - The system still needs persistent relation and recurrence-definition metadata.
+- **Scope**:
+  - `EventSeries` stores grouping and generation metadata.
+  - `Event` stores actual occurrence data.
+  - `EventSeriesDate` stores explicit dates for manual batches.
+
+### [2B.7] Exception Tracking for Individual Occurrence Edits
+
+- **Decision**: Track manually changed series occurrences via `is_exception` and `original_start_datetime`.
+- **Rationale**:
+  - Users need to adjust single occurrences without corrupting the whole series.
+  - Future series edits must not silently overwrite manually changed events.
+- **Default Behavior**:
+  - Future bulk updates should target only future non-exception events unless the user explicitly resets an exception.
+
+### [2B.8] Synthesized Admin Form for Event Series
+
+- **Decision**: Extend `EventSeriesAdminForm` with non-model (synthetic) template and profile fields rather than adding an `event_template` JSON column to the `EventSeries` model.
+- **Rationale**:
+  - Keeps the database schema clean and normalized.
+  - The series model serves strictly as recurrence metadata, while occurrences remain the canonical source of truth for event details.
+  - Allows the UI to automatically load the base template from the first non-exception occurrence when editing.
+- **Trade-off**: Requires more manual field management in the admin form, but avoids duplicating state in the database.
+
+### [2B.9] Shared Orchestration Layer
+
+- **Decision**: Extract series occurrence generation and synchronization logic into a context-independent service layer (`services.py`) shared by both DRF serializers and Django admin.
+- **Rationale**:
+  - Ensures exactly the same behavior and side-effects (profile row creation, taxonomy term assignment) regardless of whether a series is authored via API or Admin UI.
+  - Keeps forms and serializers strictly focused on input validation.
+  - Facilitates comprehensive unit testing of the complex recurrence logic.
+
+### [2B.10] Grouped Taxonomy Assignments for Event Writes
+
+- **Decision**: Replace raw `taxonomy_term_ids` write payloads with grouped `taxonomy_assignments` keyed by dimension for both event and event-series authoring.
+- **Rationale**:
+  - Taxonomy is conceptually an optional set of event attributes, not a direct join-table editing surface.
+  - Grouping terms under dimensions makes validation clearer for single-select vs multi-select dimensions.
+  - The feature is not yet published, so the contract can be corrected now without carrying compatibility debt.
+- **Rules**:
+  - Taxonomy remains optional for all event statuses.
+  - Only active dimensions and active leaf terms may be newly assigned.
+  - `EventTerm` remains the only persistence model for event taxonomy.
+  - Series authoring uses the same grouped assignment contract as direct event writes.
+
+### [2B.11] Grouped Taxonomy Hydration for Reads and Admin
+
+- **Decision**: Expose grouped taxonomy assignments on event detail and event-series retrieve responses, and render taxonomy in Django admin as one dynamic field per dimension.
+- **Rationale**:
+  - The authoring surface should match the conceptual model of taxonomy as optional event attributes.
+  - Event-series remains lightweight, so series taxonomy hydration should derive from the base non-exception occurrence rather than adding duplicate series-level taxonomy storage.
+  - Admin edit flows need to preserve visibility of already-assigned inactive terms without reopening the write contract for newly selecting inactive terms.
+- **Rules**:
+  - Event detail and series retrieve use the same grouped taxonomy shape as write payloads, with extra dimension/term metadata for hydration.
+  - EventSeries retrieve fails clearly when no usable base occurrence/template exists.
+  - Event and event-series admin forms generate taxonomy fields dynamically from active dimensions plus any inactive assigned dimensions already present on the source event.
+
+---
+
+## Phase 3: GeoFeedback Feature
+
+### [3.1] Dynamic Form Engine Strategy
+
+- **Decision**: Use `django-basic-form-builder` to manage customizable feedback forms instead of custom `FeedbackType` and `FeedbackOption` models.
+- **Rationale**:
+  - Offloads the complex business logic of generating schema JSON and managing individual form fields to a dedicated, tested package.
+  - Enables non-technical admins to build complex forms (dropdowns, conditional logic, checkboxes) using a polished inline admin interface without requiring backend changes per campaign.
+  - Native integration with Django 5.x and DRF schema output.
+- **Integration Profile**:
+  - `GeoFeedback` links to `formbuilder.CustomForm` via `custom_form_id`.
+  - The API exposes the Form Builder JSON schema via nested endpoints.
+  - `FeedbackSubmission` stores dynamic answers in a `JSONB` column (`form_data`), while preserving strictly-typed relationships for Native Ratings (`rating`) and Geospatial input (`geometry`).
+
+---
+
+## Phase 7: GeoContext Editor.js Migration
+
+### [7.1] Canonical GeoContext Storage Contract
+
+- **Decision**: Store GeoContext as canonical Editor.js JSON only.
+- **Rationale**:
+  - Structured content is a better long-term contract than HTML strings.
+  - A single JSON source of truth avoids drift between raw text, HTML, and derived representations.
+  - The feature is not yet published, so the contract can be corrected without compatibility debt.
+- **Rules**:
+  - `GeoContext.content` is canonical Editor.js JSON.
+  - `content_type` is removed from the future contract.
+  - Empty content is stored as `{ "blocks": [] }`.
+  - Stored data is intentionally narrower than the full Editor.js save envelope.
+
+### [7.2] Admin Authoring Surface
+
+- **Decision**: Introduce Editor.js in Django admin only, using progressive enhancement over a JSON textarea.
+- **Rationale**:
+  - The repository has no frontend bundler and does not need one for this authoring surface.
+  - Django admin is the immediate editing environment that benefits from WYSIWYG authoring.
+  - A textarea fallback preserves operability if JavaScript fails or is disabled.
+- **Rules**:
+  - No CDN dependency for Editor.js assets.
+  - No custom AJAX submission path; standard Django form POST remains the write path.
+  - The raw textarea remains the no-JS fallback.
+
+### [7.2b] Validation Errors Raise Django ValidationError
+
+- **Decision** (implementation, Task 7.2): The Editor.js validator raises `django.core.exceptions.ValidationError` directly from `GeoContext.save()` rather than introducing a DRF-specific exception layer.
+- **Rationale**:
+  - Validation must run for all write paths (admin, shell, fixtures, future serializers) — coupling it to DRF would bypass admin.
+  - Django's admin and model-form stack already translate `ValidationError` into user-visible form errors; DRF translates model `ValidationError` into HTTP 400 at the view layer.
+- **Rules**:
+  - The validator is a pure function (`validate_and_normalize`) with no framework dependency beyond `django.core.exceptions.ValidationError`.
+  - Input envelope fields (`time`, `version`, block `id`, `tunes`) are silently stripped; only schema violations raise.
+
+### [7.3] Deterministic Normalization and Validation
+
+- **Decision**: Centralize Editor.js validation and normalization in a dedicated module.
+- **Rationale**:
+  - JSON document validation is a separate concern from legacy HTML sanitization.
+  - Deterministic normalization prevents round-trip drift and makes migration output predictable.
+  - Strict schema rules reduce ambiguity in future authoring and migration behavior.
+- **Rules**:
+  - Strip `time`, `version`, and block `id` from stored content.
+  - Normalize `<b>` to `<strong>` and `<i>` to `<em>`.
+  - Reject `quote.alignment`.
+  - Constrain `list.meta` to `{}` for MVP.
+  - Allow only the defined MVP block and inline toolset.
+
+### [7.3b] Vendored Editor.js Versions
+
+- **Decision** (implementation, Task 7.3): Vendor `@editorjs/editorjs@2.30.7`, `@editorjs/header@2.8.8`, `@editorjs/list@1.10.0`, `@editorjs/quote@2.7.3`, `@editorjs/delimiter@1.4.2`, `@editorjs/code@2.9.3` under `tosca_api/apps/geocontext/static/geocontext/editorjs/vendor/` with each upstream `LICENSE` file preserved alongside.
+- **Rationale**:
+  - `@editorjs/list@2.x` ships only an ESM build (`list.mjs`); the 1.10.0 UMD drop is the newest version that loads cleanly via Django's static-file `<script>` tags without a bundler.
+  - Pinned exact versions keep the admin build reproducible and auditable; LICENSE files satisfy MIT attribution requirements for redistribution.
+- **Rules**:
+  - Upgrades require re-vendoring both the UMD bundle and the upstream `LICENSE`.
+  - No CDN fallback is permitted; a CDN-URL presence test runs in `test_admin.py`.
+
+### [7.4] Legacy HTML Migration Rules
+
+- **Decision**: Sanitize legacy HTML first, then parse it into canonical Editor.js blocks, aborting on media markup.
+- **Rationale**:
+  - Sanitizing first keeps legacy conversion inside the existing security posture.
+  - Parsing into a fixed block schema preserves supported narrative content while avoiding silent data loss.
+  - Explicit abort behavior is safer than partially migrating unsupported media-bearing rows.
+- **Rules**:
+  - Preserve paragraphs, headers, nested lists, blockquotes, code blocks, inline code, and `<br>`.
+  - Fold top-level text nodes into paragraph blocks.
+  - Abort on `img`, `figure`, and `figcaption`.
+  - Preflight and real migration share the same detection logic.
+
+### [7.4b] Stdlib HTMLParser for Legacy Conversion
+
+- **Decision** (implementation, Task 7.4): Use Python's stdlib
+  `html.parser.HTMLParser` (not `beautifulsoup4` or `lxml`) as the parsing
+  engine inside `tosca_api/apps/core/legacy_html.py`.
+- **Rationale**:
+  - bs4/lxml are not currently project dependencies; adding them for a
+    one-shot legacy converter is disproportionate.
+  - `HTMLParser` is event-driven, which matches the deterministic
+    block-builder shape (open/close/data hooks → push/pop/append) and
+    keeps the converter dependency-free.
+  - Sanitization already runs through `nh3` before parsing, so the
+    parser only ever sees an allowlisted tag set.
+- **Consequences**:
+  - Media detection must run **before** sanitization so that rows with
+    `<img>`/`<figure>`/`<figcaption>` still abort even though
+    `sanitize_rich` would happily preserve them.
+  - Inline tag handling is suppressed inside `<pre>` so that
+    `<pre><code>…</code></pre>` collapses to a single canonical `code`
+    block with only the inner text.
+
+### [7.4c] Preflight Is Read-Only, Output Is Sorted UUID
+
+- **Decision** (implementation, Task 7.4): The `geocontext_preflight`
+  management command never writes to the database and emits failing
+  GeoContext rows sorted by UUID (optionally alongside dry-run failures
+  from a `--legacy-input-json` file).
+- **Rationale**:
+  - Sorted output means two consecutive runs on unchanged data produce
+    byte-equal output, which is diffable across environments and in CI.
+  - Read-only behavior lets operators run the preflight against a
+    production snapshot without any migration-time coupling.
+  - Dry-running a separate legacy-HTML JSON file decouples "check which
+    legacy strings would convert" from any future real backfill
+    migration that might mutate rows.
+- **Consequences**:
+  - Because Release 1 (Task 7.1) destructively reset GeoContext, the
+    command currently scans a (typically empty) canonical table; the
+    real value is that future releases or data-imports can reuse the
+    same validation + converter entry points.
+
+### [7.5] Multi-Release Migration Strategy
+
+- **Decision** (planning): Execute the GeoContext migration over three releases.
+- **Rationale**:
+  - A staged rollout preserves rollback safety while switching application behavior.
+  - Separating backfill, read/write switch, and cleanup reduces the risk of destructive migration mistakes.
+  - Final schema cleanup should occur only after the JSON-backed contract is already active.
+- **Rules (planned)**:
+  - Release 1: add `content_json` and backfill it.
+  - Release 2: switch reads and writes to `content_json`, while keeping old columns.
+  - Release 3: drop legacy fields and rename `content_json` to `content`.
+
+### [7.5b] Phased Migration Collapsed by Destructive Task 7.1
+
+- **Decision** (implementation, Tasks 7.1 / 7.5 / 7.6): Collapse the
+  three-release phased migration into a single destructive Release 1
+  that drops `content_type` and the legacy text `content` column and
+  promotes the canonical Editor.js JSON directly onto
+  `GeoContext.content`.
+- **Rationale**:
+  - Pre-Release 1 there were zero production rows to preserve, so the
+    rollback-safety case that motivated the three-release strategy
+    evaporated.
+  - Carrying a parallel `content_json` field plus a read/write switch
+    through two more releases would add migration + code paths that
+    only exist to protect data that does not exist.
+  - Dropping the legacy columns up-front keeps the single-source-of-
+    truth narrative clean (`GeoContext.content` is always Editor.js
+    JSON) and avoids a temporary nullable-JSON shape that downstream
+    serializers would have to special-case.
+- **Consequences**:
+  - Tasks 7.5 ("switch to `content_json`") and 7.6 ("drop legacy
+    fields / rename back to `content`") have no code changes to make;
+    both are marked folded into 7.1 in tasks.md + issues.md.
+  - Task 7.5 still owns the regression coverage proving every nested
+    serializer (geostories / events / feedback) emits the canonical
+    `{"blocks": [...]}` contract and that no code path depends on the
+    retired `content_type` discriminator — this lives in
+    `tosca_api/apps/geocontext/tests/test_json_contract.py`.
+  - Task 7.5 also owns removal of the now-dead
+    `tosca_api.apps.core.sanitization.sanitize_content` helper, which
+    dispatched on the retired `content_type` discriminator string.
+  - Phased column-level rollback is no longer available for any future
+    GeoContext storage change. Future migrations that would benefit
+    from a parallel-field rollout will need to reintroduce the pattern
+    deliberately rather than relying on the historical Release 1 → 2 → 3
+    shape documented in §[7.5].
+
+### [7.5c] GeoContext Title for Related-Object Dropdowns
+
+- **Decision** (UX, post-Task 7.5): Add an optional
+  `GeoContext.title = CharField(max_length=200, blank=True, default="")`
+  and make `__str__` dropdown-friendly so admin pickers for GeoStory,
+  Event, and GeoFeedback expose meaningful labels instead of
+  `"GeoContext: 4 block(s)"`.
+- **Rationale**:
+  - Block-count-only labels made it impossible to pick the right
+    context from the Django admin related-object dropdown when
+    authoring GeoStory / Event / GeoFeedback rows.
+  - An explicit title is clearer than any derived excerpt and lets
+    editors name contexts intentionally (e.g. "Smart City Logistics
+    Overview") regardless of the current block contents.
+  - Keeping the field optional (`blank=True`, default `""`) avoids a
+    disruptive data migration and preserves backwards compatibility
+    with existing fixtures and callers.
+- **Fallback chain for `__str__`**:
+  1. explicit `title` → `"Title (N block(s))"`
+  2. first `header` / `paragraph` / `quote` excerpt (up to 60 chars)
+  3. `"GeoContext {short-uuid} (N block(s))"`
+- **Consequences**:
+  - `GeoContext` nested serializers for GeoStory, Event, and GeoFeedback
+    now expose `{id, title, content}`. Frontends can show the title
+    next to the JSON blocks.
+  - Admin list view shows `title_or_excerpt` as the primary column;
+    `search_fields` covers `title` in addition to `id`.
+  - Migration `geocontext.0003_geocontext_title` ships the column with
+    default `""`, so previously stored rows (there are none post-7.1
+    reset) would remain readable without operator action.
+
+---
+
+## Phase 8: GeoData Provider Integration & LayerRef Refactor
+
+### [8.1] Direct FK Replaces the LayerRef Indirection
+
+- **Decision**: Replace the `layerrefs.LayerRef` indirection with a direct `ForeignKey` from `GeoStoryLayer`, `EventLayer`, and `FeedbackLayer` to `geodata_providers.Layer`. Delete the `layerrefs` app.
+- **Rationale**:
+  - `geodata_providers.Layer` is already the canonical layer registry and reconciles with GeoServer / Martin / pg_tileserv via `GeoServerSyncService`.
+  - `LayerRef` only stored a free-form `"workspace:layername"` string with no link to canonical metadata, so consumers could not verify existence, public flag, publishing state, geometry type, SRID, or published URL without parsing the string.
+  - The indirection earned its keep only in two cases — referencing layers that do not yet exist in `geodata_providers`, or keeping consumer apps decoupled for plugin-style extraction. Neither applies here.
+- **Trade-off**: Consuming apps (`geostories`, `events`, `feedback`) now import from `geodata_providers`. That coupling reflects reality — these features genuinely depend on canonical layer metadata.
+- **Pre-production note**: The system is not yet in production, so this lands as a destructive schema reset for the affected through tables; no row preservation is required.
+
+### [8.2] Cascade Deletion With Pre-delete Usage Warning
+
+- **Decision**: Use `on_delete=CASCADE` on the FK from each through model to `Layer`, but warn admins and API callers about usage counts before the delete proceeds.
+- **Rationale**:
+  - CASCADE keeps the data model simple: deleting a `Layer` simply removes its through-rows from any GeoStory / Event / GeoFeedback that referenced it.
+  - The alternative (`SET_NULL`) preserves a tombstone row but creates orphan-handling complexity in serializers and admin UIs.
+  - The real risk is silent removal of layer assignments without operator awareness. Surfacing a usage summary at delete time addresses that risk without requiring tombstones.
+- **Rules**:
+  - `Layer.usage_summary()` returns counts via `geostory_uses`, `event_uses`, `feedback_uses` related managers.
+  - Admin delete confirmation displays the usage counts and requires explicit confirmation.
+  - `LayerViewSet.destroy` returns `409 Conflict` with the usage breakdown unless the caller passes `?confirm=true`.
+
+### [8.3] Public + Published Required for Layer Assignment
+
+- **Decision**: Through-model `clean()` rejects assigning any layer that is not both `is_public=True` and `publishing_state="PUBLISHED"`.
+- **Rationale**:
+  - GeoStory, Event, and GeoFeedback are user-facing surfaces. Linking a draft, failed, or non-public layer would either render nothing or expose internal data.
+  - Keeping the rule at the through-model layer means it applies equally to admin saves, DRF writes, and any future fixture-based or shell-based code path.
+- **Rules**:
+  - The check runs in each through model's `clean()` so it surfaces in admin forms and DRF serializers as a `ValidationError`.
+  - `feedback` follows the same rule even though feedback layers are pure visualization backdrops.
+
+### [8.4] `LayerSummarySerializer` as the Shared Read Contract
+
+- **Decision**: Add a slim, reusable `LayerSummarySerializer` exposing `id`, `name`, `workspace`, `geometry_type`, `srid`, `published_url`, `is_public`, `publishing_state` and use it on every consumer detail response.
+- **Rationale**:
+  - Consumers need enough metadata to render the layer on a map (`published_url`, `geometry_type`, `srid`) and to display human-friendly labels (`name`, `workspace`) without a second API round-trip.
+  - A single shared serializer keeps the layer payload shape consistent across GeoStory, Event, and GeoFeedback.
+  - Slim by design: heavier metadata (style assignments, store details, internal publishing errors) is not exposed to public consumers.
+- **Rules**:
+  - The serializer lives in `geodata_providers` and is imported by consumer apps.
+  - Each linked-layer entry in a detail response carries `display_order` from the through model.
+  - Detail-endpoint querysets use `select_related("workspace")` and `prefetch_related` on the through tables to avoid N+1 queries.
+
+### [8.5] UUID-based Nested Layer Writes
+
+- **Decision**: Nested layer writes on GeoStory / Event / GeoFeedback accept a list of `Layer.id` UUIDs (optionally with `display_order`) instead of the legacy `layer_name` strings.
+- **Rationale**:
+  - UUIDs let the serializer resolve a structured `Layer` object directly and run through-model validation without parsing strings.
+  - The legacy `layer_name` contract had no validation that the layer existed, was public, or was published.
+  - The system is not yet in production, so the contract can be corrected now without a compatibility shim.
+- **Consequence**: This supersedes the layer sub-bullet of Task 1.3b. Nested writes for `context` (the other half of 1.3b) are unaffected.
+
+### [8.6] `GeoServerSyncService` Supersedes Standalone LayerRef Sync
+
+- **Decision**: Tasks 1.4a (LayerRef Sync Client) and 1.4b (LayerRef Sync Endpoint) are superseded by the `GeoServerSyncService` already shipped in `geodata_providers`.
+- **Rationale**:
+  - `geodata_providers` already implements multi-engine sync (GeoServer / Martin / pg_tileserv) via `EngineClientFactory` and reconciles workspaces, stores, layers, and styles in `GeoServerSyncService`.
+  - Maintaining a separate sync surface in `layerrefs` would duplicate the responsibility and diverge over time.
+- **Rule**: All future layer-sync work lives in `geodata_providers`. The legacy task entries remain in the docs as "Superseded by Phase 8" pointers for historical traceability.
+
+---
+
+## Phase 9: GeoStory & GeoContext Image Support
+
+### [9.1] Storage Strategy
+
+- **Decision**: For v1, store GeoStory hero images and EditorJS uploaded images through Django's storage abstraction using `ImageField`/file storage paths, without introducing a dedicated media-asset domain model in this phase.
+- **Rationale**:
+  - This is the fastest path to deliver strict image support with minimal schema complexity.
+  - Django storage remains backend-agnostic, so the same model contract can run on local media storage now and S3-compatible backends later.
+  - Introducing a separate MediaAsset service/model now would increase delivery scope and cross-feature coupling.
+- **Rules**:
+  - Hero images store under a GeoStory namespace (e.g. `geostories/hero/...`).
+  - EditorJS uploads store under a GeoContext namespace (e.g. `geocontext/editorjs/...`).
+  - Storage backend selection is environment-configured via Django settings, not hard-coded in feature logic.
+
+### [9.2] Strict Image Policy
+
+- **Decision**: Enforce one strict server-side validation policy for all image ingestion paths in this phase.
+- **Rationale**:
+  - A unified policy avoids drift between hero-image and EditorJS upload behavior.
+  - Strict bounds reduce security risk, bandwidth abuse, and rendering failures.
+  - Required alt text establishes a baseline accessibility contract from day one.
+- **Rules**:
+  - Allowed MIME types: `image/jpeg`, `image/png`, `image/webp`.
+  - Maximum file size: `8 MB`.
+  - Minimum dimensions: `800x450`.
+  - Maximum dimensions: `6000x6000`.
+  - Alt text is required for both GeoStory hero images and EditorJS image blocks.
+
+### [9.3] EditorJS Image Canonical Contract
+
+- **Decision**: Extend canonical EditorJS storage to accept a strict `image` block shape with deterministic normalization.
+- **Rationale**:
+  - Image support must preserve the same deterministic storage guarantees introduced in Phase 7.
+  - A narrow canonical shape keeps client behavior predictable and prevents arbitrary JSON growth.
+  - Block-level validation keeps content integrity independent of authoring client quirks.
+- **Rules**:
+  - `image` block is added to allowed block types in `core/editorjs.py`.
+  - Canonical stored data includes required URL + metadata fields (URL, alt, mime, width, height) and optional sanitized caption/tool flags.
+  - Unknown keys are stripped during normalization.
+  - URL schemes outside approved set are rejected.
+
+### [9.4] Upload Endpoint Contract
+
+- **Decision**: Provide authenticated backend upload endpoint(s) for EditorJS image tool and return EditorJS-compatible response payloads.
+- **Rationale**:
+  - Upload mediation through backend ensures strict validation policy is always enforced.
+  - EditorJS tools expect a specific response shape; honoring it avoids frontend-specific patches.
+  - Authenticated upload routes reduce abuse and keep authoring paths controlled.
+- **Rules**:
+  - Upload endpoint requires authenticated/authorized caller.
+  - Server validates mime/size/dimensions/alt before persistence.
+  - Response payload includes stored URL and metadata needed to persist canonical image block data.
+  - Contract and error payloads are documented in OpenAPI/docs.
+
+### [9.5] Security Posture
+
+- **Decision**: Treat image support as a security-sensitive content path and enforce defensive validation at all trust boundaries.
+- **Rationale**:
+  - File uploads are a common attack vector; server-side checks cannot be delegated to client tools.
+  - EditorJS JSON can be malformed or hostile; block schema validation must remain strict.
+  - URL scheme restrictions prevent scriptable/unsafe link injection.
+- **Rules**:
+  - Reject unsupported MIME types and malformed image payloads.
+  - Reject unsupported or unsafe URL schemes in image block URLs.
+  - Require canonical metadata (alt/dimensions/mime) and fail closed on missing required fields.
+  - Keep regression tests for security-negative paths as mandatory coverage.
+
+### [9.6] S3 Deferral Decision
+
+- **Decision**: Do not implement S3-specific flows (presigned direct upload, S3-only metadata contracts, bucket coupling) in Phase 9; keep feature logic storage-backend-agnostic.
+- **Rationale**:
+  - Phase 9 focus is feature delivery (hero image + EditorJS image) with strict validation and clear contracts.
+  - S3-specific implementation adds deployment and infra complexity that is not required to validate product behavior.
+  - Django storage abstraction already enables later S3 adoption without changing model/API contracts.
+- **Rules**:
+  - No S3-only assumptions in serializers, validators, or EditorJS block schema.
+  - Any future S3-first rollout is a separate phase and may layer presigned-upload optimization without breaking Phase 9 contracts.

--- a/docs/features-to-add_local/done/serializer_standardization_plan.md
+++ b/docs/features-to-add_local/done/serializer_standardization_plan.md
@@ -1,0 +1,145 @@
+# Serializer Standardization Plan
+
+## Goal Description
+
+The current application serializers possess varying styles, naming conventions, and validation practices. We are going to standardize the DRF serializes across the `campaigns`, `events`, `feedback`, and `geostories` apps.
+
+## The "Superior" Style: `events/serializers.py`
+
+We will adopt the structural and behavioral patterns found in `events/serializers.py` as our baseline, and further establish explicit validation standards.
+
+The unified style guidelines are:
+
+1. **Separation of Concerns:**
+   Every core model should have three distinct serializers:
+   - `<Model>ListSerializer`: Slim, optimized for list views (`GET /`).
+   - `<Model>DetailSerializer`: Full, with nested fields and relations (`GET /{id}/`).
+   - `<Model>WriteSerializer`: Exclusively for creation and updating (`POST /`, `PATCH /{id}/`).
+
+2. **Strict Read-Only Protection (`Meta.read_only_fields`):**
+   - For `ListSerializer` and `DetailSerializer`, explicitly set `read_only_fields = fields`. This prevents accidental writes and clarifies the serializer's intent purely as a read conduit.
+   - For `WriteSerializer`, explicitly list immutable fields (e.g., `id`, `created_at`, `updated_at`, `created_by`).
+
+3. **Robust Validation:**
+   - Write serializers should implement an explicit `validate(self, attrs)` method when cross-field or model-backed validation is required.
+   - If a model has a `clean()` method, serializer validation must evaluate the full candidate object state, not `attrs` in isolation.
+   - For `create`, instantiate a transient model from the incoming values and call `.clean()` before save.
+   - For `update` and `partial_update`, merge `attrs` onto `self.instance` first, then call `.clean()` on that merged state.
+   - Validation must preserve DRF `400` responses at the API boundary instead of allowing Django model validation errors to surface during `save()`.
+   - For partial updates, validation must run against `instance + attrs`, not `attrs` alone.
+   - If the implementation uses `full_clean(exclude=...)` instead of `clean()`, the exclude behavior for omitted PATCH fields must be explicitly defined.
+
+4. **File Structure and Documentation:**
+   - Use standardized header blocks (`# =================...`) to group nested serializers and model serializers.
+   - Use clear docstrings describing the purpose of each serializer.
+
+## Important Public API / Interface Notes
+
+- No endpoint URLs change.
+- No response-shape changes are intended for existing campaign, event, feedback, or geostory endpoints beyond internal Python serializer class renames and view wiring.
+- Internal serializer class names will change as follows:
+  - `CalendarEventCreateSerializer` -> `CalendarEventWriteSerializer`
+  - `GeoFeedbackCreateUpdateSerializer` -> `GeoFeedbackWriteSerializer`
+  - `GeoStorySerializer` -> `GeoStoryWriteSerializer`
+  - `CampaignSerializer` -> `CampaignListSerializer`, `CampaignDetailSerializer`, `CampaignWriteSerializer`
+
+## Proposed Changes
+
+### `tosca_api/apps/campaigns/serializers.py`
+
+- Split `CampaignSerializer` into `CampaignListSerializer`, `CampaignDetailSerializer`, and `CampaignWriteSerializer` for naming consistency with the other apps.
+- There is no nested campaign detail payload in the current scope; this split is structural and low-risk.
+- `CampaignListSerializer`
+  - Fields: `id`, `title`, `summary`, `status`, `visibility`, `created_by`, `created_at`, `updated_at`
+  - `read_only_fields = fields`
+- `CampaignDetailSerializer`
+  - Same fields as `CampaignListSerializer` for now
+  - `read_only_fields = fields`
+- `CampaignWriteSerializer`
+  - Same fields as the current `CampaignSerializer`
+  - `read_only_fields = ["id", "created_by", "created_at", "updated_at"]`
+
+### `tosca_api/apps/events/serializers.py`
+
+- _Already our baseline._
+- Rename `CalendarEventCreateSerializer` to `CalendarEventWriteSerializer` for naming consistency.
+- Add an explicit `validate()` method to `CalendarEventWriteSerializer`.
+- The serializer must mirror the existing model rule that `end_datetime >= start_datetime`; it should not introduce a new rule.
+- Validation must evaluate the full candidate state:
+  - On create: validate using the incoming attrs.
+  - On patch/update: merge incoming attrs onto `self.instance` before calling model-backed validation.
+
+### `tosca_api/apps/feedback/serializers.py`
+
+- Rename `GeoFeedbackCreateUpdateSerializer` to `GeoFeedbackWriteSerializer`.
+- Add `read_only_fields = fields` to `GeoFeedbackListSerializer` (currently missing).
+- `GeoFeedbackWriteSerializer.validate()` must use the same merged-state validation pattern as events so PATCH requests validate against the persisted object plus incoming attrs.
+- `FeedbackSubmissionSerializer.validate()` may validate payload-local concerns only:
+  - field typing/parsing
+  - rating bounds if needed
+  - geometry payload shape/parsing
+- Campaign-specific submission rules must be validated using the parent `GeoFeedback` resolved from the URL, not inferred from serializer input alone.
+- Default implementation approach:
+  - Pass `feedback` into serializer context from the `submit` action.
+  - `FeedbackSubmissionSerializer.validate()` reads `self.context["feedback"]` and enforces `rating_enabled`, `form_enabled`, and `allow_drawings`.
+  - The `submit` action remains responsible for injecting the feedback object and saving `submitted_by`.
+- If context injection is not implemented, these campaign-specific submission checks must remain in the view and must not be moved incompletely.
+
+### `tosca_api/apps/geostories/serializers.py`
+
+- Rename `GeoStorySerializer` to `GeoStoryWriteSerializer`.
+- Update `FeatureLinkSerializer`, `GeoContextSerializer`, and `LayerRefSerializer` to use `read_only_fields = fields` (currently they duplicate the field list manually).
+- Update `GeoStoryListSerializer` and `GeoStoryDetailSerializer` `read_only_fields` syntax to use `read_only_fields = fields` consistently.
+- Ensure `GeoStoryWriteSerializer` correctly handles any cross-field validation rules (if any).
+- This standardization pass does not add nested write behavior for `context` or `layers`; those remain out of scope here and are already tracked in the existing geostory nested-write tasks.
+
+### View-side Effects (`tosca_api/apps/*/views.py`)
+
+- `CampaignViewSet`
+  - Replace `serializer_class = CampaignSerializer` with `get_serializer_class()`.
+  - `list` -> `CampaignListSerializer`
+  - `retrieve` -> `CampaignDetailSerializer`
+  - write actions -> `CampaignWriteSerializer`
+- `CalendarEventViewSet`
+  - Rename imports and references to `CalendarEventWriteSerializer`.
+  - Keep `CalendarEventGeoSerializer` for spatial list/within endpoints.
+  - Keep the current list vs retrieve branching.
+- `GeoFeedbackViewSet`
+  - Rename imports and references to `GeoFeedbackWriteSerializer`.
+  - Keep the `submit` action serializer path explicit.
+  - Inject `feedback` into serializer context for `submit` if serializer-level campaign validation is adopted.
+- `GeoStoryViewSet`
+  - Rename imports and references to `GeoStoryWriteSerializer`.
+  - Keep the current list vs retrieve branching.
+
+## Validation / Test Expectations
+
+- `CalendarEvent` create rejects `end_datetime < start_datetime` with HTTP 400.
+- `CalendarEvent` patch of only `end_datetime` rejects invalid merged state with HTTP 400.
+- `GeoFeedback` create rejects:
+  - `rating_enabled=False` and `form_enabled=False`
+  - `form_enabled=True` without `custom_form`
+- `GeoFeedback` patch rejects invalid merged state when toggling flags on an existing valid record.
+- `FeedbackSubmission` submit rejects:
+  - missing rating when `feedback.rating_enabled=True`
+  - missing form data when `feedback.form_enabled=True`
+  - geometry when `feedback.allow_drawings=False`
+- Existing list/detail serializers remain read-only and preserve current response fields.
+- Where the app already has API test coverage, add endpoint-level regression tests in addition to serializer-level validation tests.
+
+## Assumptions and Defaults
+
+- Keep the document's overall structure and intent; this is a revision, not a rewrite from scratch.
+- Keep the campaign serializer split in the plan, but make it explicit and low-risk.
+- Treat the two review findings around PATCH validation and feedback submission validation as mandatory corrections.
+- Do not add new product scope such as geostory nested writes, new endpoints, or response payload redesign.
+- Use "candidate state validation" as the canonical term for create/update validation against the full object state.
+
+## Open Questions / Requests for Confirmation
+
+- Should `FeedbackSubmission` campaign-rule validation move into the serializer via context injection, or intentionally remain in the view?
+  - Default assumption for this plan: use serializer context injection with `feedback` supplied by the `submit` action.
+- Should this standardization pass include serializer tests only, or also endpoint-level regression tests for create/PATCH validation behavior?
+  - Default assumption for this plan: add both serializer-level and API-level regression tests where existing coverage already exists.
+- Should `CampaignListSerializer` and `CampaignDetailSerializer` remain identical for now, or be collapsed later if the split proves unnecessary?
+  - Default assumption for this plan: keep the split for consistency in this pass and revisit later only if it creates maintenance churn.

--- a/docs/features-to-add_local/geostory-flowchart.md
+++ b/docs/features-to-add_local/geostory-flowchart.md
@@ -1,0 +1,31 @@
+# GeoStory Workflow Diagram
+
+Based on the TOSCA-Backend data architecture, the following diagram illustrates the streamlined life-cycle of creating and publishing a GeoStory.
+
+```mermaid
+flowchart LR
+    %% Define Styles
+    classDef startend fill:#f9f9f9,stroke:#333,stroke-width:2px,rx:20,ry:20
+    classDef process fill:#e1f5fe,stroke:#0288d1,stroke-width:2px
+    classDef database fill:#e8f5e9,stroke:#388e3c,stroke-width:2px,shape:cylinder
+    classDef optional fill:#fff3e0,stroke:#f57c00,stroke-width:1px,stroke-dasharray: 5 5
+
+    %% Nodes
+    A([Start GeoStory Creation]):::startend
+    B[Draft Core Narrative Title & Summary]:::process
+    C[Attach Geo-referenced Map Layers]:::process
+    D[Embed Rich Media into GeoContext]:::process
+    E[Link to External Features & Events *Optional*]:::optional
+    F[(Save Story to Database)]:::database
+    G[Ensure Published Status for User Viewing]:::process
+    H([End: GeoStory Live]):::startend
+
+    %% Flow
+    A --> B
+    B --> C
+    C --> D
+    D --> E
+    E --> F
+    F --> G
+    G --> H
+```

--- a/docs/features-to-add_local/issues.md
+++ b/docs/features-to-add_local/issues.md
@@ -1,0 +1,2005 @@
+# GitHub Issues for Implementation Tasks
+
+Use this file to create GitHub issues for each task. Copy the content below into GitHub.
+
+---
+
+## Phase Tracking (Epics)
+
+Use these "Epic" issues to track overall progress for a Phase. They won't be closed until all sub-tasks are done.
+
+### Issue: Phase 0 - Infrastructure Setup
+
+**Labels**: `epic`, `infrastructure`
+
+**Goal**: Prepare the backend for advanced geospatial capabilities.
+
+**Context**:
+Currently, the TOSCA backend uses a standard PostgreSQL configuration. To support features like GeoStories and flexible feedback forms, we need to upgrade our stack to support **PostGIS** (spatial database) and **GeoDjango** (ORM extensions). This phase lays the groundwork for all future spatial features.
+
+**Key Outcomes**:
+
+- Docker image includes GDAL/GEOS libraries.
+- Database engine switched to PostGIS.
+- Core app skeletons (`campaigns`, `geocontext`) created for future development.
+
+#### Task List
+
+- [ ] Task 0.1: Add GDAL to Docker
+- [ ] Task 0.2: Configure GeoDjango Settings
+- [ ] Task 0.3: Verify PostGIS Extension
+- [ ] Task 0.4: Campaigns App Skeleton
+- [ ] Task 0.5: GeoContext App
+- [x] Task 0.6: LayerRef App
+
+---
+
+### Issue: Phase 1 - GeoStory Feature
+
+**Labels**: `epic`, `feature`
+
+**Goal**: Enable administrators to create rich, map-based narratives (GeoStories).
+
+**Context**:
+GeoStories are the core content unit of the platform. They combine rich text (via GeoContext) with specific map layers (from GeoServer) to tell a spatial story. This phase implements the full backend lifecycle for these stories, from creation to API delivery.
+
+**Key Outcomes**:
+
+- **Campaign Management**: Grouping stories into broader initiatives.
+- **GeoStory CRUD**: Full API to create, edit, and publish stories.
+- **Layer Integration**: Syncing and linking WMS/WFS layers from GeoServer.
+- **Linking**: Ability to link stories to other content via `FeatureLink`.
+
+#### Task List
+
+- [x] Task 1.1: GeoStory Model
+- [x] Task 1.2: Campaign API
+- [x] Task 1.2a: API Documentation
+- [ ] Task 1.2b: Authentication API Docs Fix
+- [x] Task 1.3a: GeoStory Basic API
+- [ ] Task 1.3b: GeoStory Nested Writes API
+- [ ] Task 1.4a: LayerRef Client
+- [ ] Task 1.4b: LayerRef Endpoint
+- [x] Task 1.5: FeatureLink App
+- [x] Task 1.6: Enhanced GeoStory API
+
+---
+
+### Issue: Phase 2 - CalendarEvent Feature
+
+**Labels**: `epic`, `feature`
+
+**Goal**: Integrate time-bound events into the spatial platform.
+
+**Context**:
+Events are temporal points of interest (meetups, town halls, deadlines) associated with a campaign. Unlike static stories, they have a specific start/end time and location. This phase adds the ability to manage and query these events spatially and temporally.
+
+**Key Outcomes**:
+
+- **CalendarEvent Model**: Storing events with `Point` geometry and time ranges.
+- **GeoJSON API**: Delivering event data in standard spatial formats for frontend mapping.
+- **Filtering**: Querying events by date range and campaign.
+
+#### Task List
+
+- [x] Task 2.1: CalendarEvent Model
+- [x] Task 2.2: CalendarEvent API
+- [x] Task 2.3: FeatureLink for Events
+
+---
+
+### Issue: Phase 2B - Event Model V2
+
+**Labels**: `epic`, `feature`, `architecture`
+
+**Goal**: Refactor the event domain from the current `CalendarEvent` model into a more flexible event platform supporting dynamic taxonomy, profile binding, separate spatial and online map results, and recurring/batch event series.
+
+**Context**:
+The current event implementation is sufficient for basic calendar and map scenarios, but it does not model:
+
+- dynamic classification dimensions
+- event-type-to-profile binding
+- recurring/batch event generation
+- shared-filter map and list outputs
+- separate map-screen handling for online events without fake geometry
+
+The v2 model keeps event content, provider data, and location data on the event itself while introducing lightweight structural models (`EventType`, `TaxonomyDimension`, `TaxonomyTerm`, `EventTerm`, `EventSeries`, `EventSeriesDate`) to support more complex product requirements without overloading the core event table.
+
+**Key Outcomes**:
+
+- **Event Core Refactor**: Replace `CalendarEvent` with a generic `Event` core after schema freeze, with `location_mode`, provider fields, series metadata, and optional context enrichment.
+- **Dynamic Taxonomy**: Support owner-defined dimensions and hierarchical terms.
+- **Profile Binding**: Drive event-type-specific extension models from an `EventType` registry.
+- **Dual Output API**: Map and list endpoints share filters but return different response structures.
+- **Recurring / Batch Series**: Persist recurring rules and manual series dates while keeping actual event content on occurrence rows.
+
+Pre-production note: because the system is not yet in production, rollout may use a destructive DB reset instead of row-level backfill.
+
+Implementation note after 2B.4:
+
+- The codebase already contains minimal placeholder `EventType` and `EventSeries` models because `2B.2` referenced them before their later schema tasks.
+- `Event.context` is already a nullable override `ForeignKey`, not a `OneToOneField`.
+- Effective context resolution is already implemented as `event.context -> series.default_context -> none`.
+- The required GiST index on `Event.location` is currently satisfied by GeoDjango's spatial index.
+- `EventSeries.campaign` and `EventSeries.event_type` are currently nullable at the DB layer for destructive-reset development, but series-linked event validation already requires them.
+- Local tests use a persistent `test_tosca` database with `--reuse-db`. After destructive event-schema changes, reset or repair the reusable test DB before trusting failures that mention old event tables or content types.
+
+#### Task List
+
+- [x] Task 2B.1: Replace `CalendarEvent` With `Event`
+- [x] Task 2B.2: Add Event Core Fields and Mode Validation
+- [x] Task 2B.3: Add Series Default Context and Event Overrides
+- [x] Task 2B.4: Add Core Constraints and Indexes
+- [x] Task 2B.5: Add Taxonomy Schema and Admin
+- [x] Task 2B.6: Add Event-Taxonomy Assignment Rules
+- [x] Task 2B.7: Add Event Type Registry and Seeds
+- [x] Task 2B.8: Add Profile Extension Models and Compatibility Validation
+- [x] Task 2B.9: Add Shared Event Filter Layer
+- [x] Task 2B.10: Add Event List API V2
+- [x] Task 2B.11: Add Event Map API V2
+- [x] Task 2B.12: Add EventSeries and EventSeriesDate Schema
+- [x] Task 2B.13: Add Recurrence Generation, Exceptions, and DST Handling
+- [x] Task 2B.14: Review Cleanup for Event Filters and Validation
+
+---
+
+### Issue: Phase 3 - GeoFeedback Feature
+
+**Labels**: `epic`, `feature`
+
+**Goal**: Enable citizen participation through spatial feedback forms.
+
+**Context**:
+Participation is the final loop of the platform. Users need to provide feedback (ratings, comments, drawings) on specific locations or plans. This phase implements a flexible form system integrating `django-basic-form-builder` alongside native ratings, and a submission system (`FeedbackSubmission`) that handles user inputs along with spatial sketching.
+
+**Key Outcomes**:
+
+- **Configurable Forms**: Admins can toggle ratings, drawings, or link dynamic custom forms via the form builder.
+- **Spatial Submissions**: Users can submit points, lines, or polygons along with their feedback.
+- **Anonymity**: Support for both authenticated and anonymous participation.
+
+#### Task List
+
+- [x] Task 3.1: Feedback Models
+- [x] Task 3.2: Submission Model
+- [x] Task 3.3: Feedback API
+- [x] Task 3.4: FeatureLink for Feedback
+
+---
+
+### Issue: Phase 5 - Security Hardening
+
+**Labels**: `epic`, `security`
+
+**Goal**: Address security vulnerabilities and harden the application before production deployment.
+
+**Context**:
+As the application handles user-generated content (rich HTML in GeoContext) and public APIs, we need to implement security measures to prevent common attack vectors like XSS, CSRF, and API abuse.
+
+**Key Outcomes**:
+
+- **HTML Sanitization**: Prevent XSS attacks via rich content fields.
+- **Rate Limiting**: Protect public endpoints from abuse.
+- **Security Headers**: Configure CSP, CORS, and other protective headers.
+
+#### Task List
+
+- [ ] Task 5.1: Input Sanitization for All Content
+- [ ] Task 5.2: Rate Limiting for Public Endpoints
+- [ ] Task 5.3: Security Headers and CORS Hardening
+
+---
+
+## Output of Individual Tasks
+
+### Issue: Task 0.1 - Add GDAL to Docker Image
+
+**Labels**: `infrastructure`, `docker`
+**Branch**: `feat/gdal-docker`
+
+**Description**:
+Install system dependencies required for GeoDjango. This ensures we can use PostGIS features in the backend.
+
+**Technical Details**:
+
+- **Libraries needed**: `gdal-bin`, `libgdal-dev`, `libgeos-dev`, `libproj-dev`.
+- **Target File**: `docker/django/Dockerfile` (install via `apt-get`).
+
+#### Acceptance Criteria
+
+- [ ] `docker compose build django` succeeds
+- [ ] Inside container: `gdalinfo --version` returns version info
+- [ ] GeoDjango can import GDAL bindings
+
+---
+
+### Issue: Task 0.2 - Configure GeoDjango in Settings
+
+**Labels**: `infrastructure`, `django`
+**Branch**: `feat/geodjango-config`
+
+**Description**:
+Update Django settings to use the PostGIS database backend and enable GIS apps.
+
+**Technical Details**:
+
+- **Settings**:
+  - `INSTALLED_APPS`: Add `django.contrib.gis`.
+  - `DATABASES['default']['ENGINE']`: Change to `django.contrib.gis.db.backends.postgis`.
+  - Ensure `PSQL_VERSION` in Docker matches.
+
+#### Acceptance Criteria
+
+- [ ] `make up` starts without errors
+- [ ] `python manage.py check` passes
+- [ ] `SELECT PostGIS_Version();` returns version
+
+---
+
+### Issue: Task 0.3 - Verify PostGIS Extension
+
+**Labels**: `infrastructure`, `testing`
+**Branch**: `feat/postgis-verify`
+
+**Description**:
+Add a test case to explicitly verify that the PostGIS extension is installed and responding in the database.
+
+**Technical Details**:
+
+- **Test File**: `tosca_api/apps/core/tests/test_postgis.py`.
+- **Logic**: Run raw SQL `SELECT PostGIS_Version();` via Django cursor.
+
+#### Acceptance Criteria
+
+- [ ] Test passes: `pytest tosca_api/apps/core/tests/test_postgis.py -v`
+- [ ] PostGIS version query works from Django
+
+---
+
+### Issue: Task 0.4 - Create `campaigns` App Skeleton
+
+**Labels**: `feature`, `models`
+**Branch**: `feat/campaigns-app`
+
+**Description**:
+Initialize the `campaigns` app and implement the core `Campaign` model. This model serves as the parent container for all other features.
+
+**Technical Details**:
+
+- **App**: `tosca_api/apps/campaigns`.
+- **Model: `Campaign`**:
+  - `id`: UUID (Primary Key).
+  - `title`: CharField(255).
+  - `summary`: TextField (nullable).
+  - `status`: CharField (Draft/Active/Archived).
+  - `visibility`: CharField (Public/Private).
+  - `created_by`: FK to User.
+  - `timestamps`: created_at, updated_at.
+
+#### Acceptance Criteria
+
+- [ ] `python manage.py makemigrations campaigns` succeeds
+- [ ] `python manage.py migrate` succeeds
+- [ ] Campaign model visible in Django Admin
+- [ ] Tests pass (in `apps/campaigns/tests/`)
+
+---
+
+### Issue: Task 0.5 - Create `geocontext` App
+
+**Labels**: `feature`, `models`
+**Branch**: `feat/geocontext-app`
+
+**Description**:
+Initialize the `geocontext` app. This app holds shared content blocks (text/media) that are linked 1:1 to other features like Stories or Events.
+
+**Technical Details**:
+
+- **App**: `tosca_api/apps/geocontext`.
+- **Model: `GeoContext`**:
+  - `id`: UUID.
+  - `content`: TextField.
+  - `content_type`: CharField (choices: simple, rich).
+  - `created_by`: FK to User.
+
+#### Acceptance Criteria
+
+- [ ] Migrations apply successfully
+- [ ] Model visible in Admin
+- [ ] Tests pass (in `apps/geocontext/tests/`)
+
+---
+
+### Issue: Task 0.6 - Create `layerrefs` App
+
+**Labels**: `feature`, `models`
+**Branch**: `feat/layerrefs-app`
+
+**Description**:
+Initialize the `layerrefs` app. This model acts as a pointer to GeoServer layers, allowing us to link map layers to Stories/Events.
+
+**Technical Details**:
+
+- **App**: `tosca_api/apps/layerrefs`.
+- **Model: `LayerRef`**:
+  - `id`: UUID.
+  - `layer_name`: CharField(255), **unique**.
+  - `created_at`: Datetime.
+
+#### Acceptance Criteria
+
+- [ ] Migrations apply
+- [ ] LayerRef enforces unique `layer_name`
+- [ ] Tests pass (in `apps/layerrefs/tests/`)
+
+---
+
+## Phase 1: GeoStory Feature
+
+### Issue: Task 1.1 - Create `geostories` App with GeoStory Model
+
+**Labels**: `feature`, `models`
+**Branch**: `feat/geostories-model`
+
+**Description**:
+Create the `geostories` app. Implement the `GeoStory` model which links to `Campaign` (parent) and `GeoContext` (content). Also implement `GeoStoryLayer` for M2M linking to maps.
+
+**Technical Details**:
+
+- **App**: `tosca_api/apps/geostories`.
+- **Model: `GeoStory`**:
+  - `id`: UUID.
+  - `campaign`: FK to Campaign.
+  - `title`: CharField.
+  - `status`: CharField (Draft/Published/Archived).
+  - `author`: FK to User.
+  - `context`: OneToOneField to `GeoContext` (nullable).
+- **Model: `GeoStoryLayer`** (Through table):
+  - `geostory`: FK.
+  - `layer`: FK to LayerRef.
+  - `display_order`: Integer.
+
+#### Acceptance Criteria
+
+- [ ] GeoStory links to Campaign and GeoContext
+- [ ] GeoStoryLayer junction table supports ordering
+- [ ] Tests pass (in `apps/geostories/tests/`)
+
+---
+
+### Issue: Task 1.2 - Campaign API Endpoints
+
+**Labels**: `feature`, `api`
+**Branch**: `feat/campaigns-api`
+
+**Description**:
+Implement REST API endpoints for managing Campaigns. Use DRF ModelViewSet.
+
+**Technical Details**:
+
+- **URL**: `/api/v1/campaigns/`
+- **Permissions**: IsAuthenticated (ReadOnly for public if visible).
+- **Pagination**: usage of `CursorPagination`.
+- **Actions**: List, Retrieve, Create, Update.
+
+#### Acceptance Criteria
+
+- [ ] API returns 401 for unauthenticated requests
+- [ ] Authenticated user can create and list campaigns
+- [ ] Tests pass (in `apps/campaigns/tests/`)
+
+---
+
+### Issue: Task 1.3a - GeoStory Basic CRUD API
+
+**Labels**: `feature`, `api`
+**Branch**: `feat/geostories-api-basic`
+
+**Description**:
+Implement basic REST API for GeoStories (Metadata only).
+
+**Technical Details**:
+
+- **URL**: `/api/v1/stories/`.
+- **Filters**: Filter by `campaign_id`.
+- **Validation**: Ensure `campaign` exists.
+
+#### Acceptance Criteria
+
+- [ ] Can create/list/update GeoStory objects
+- [ ] Validation: Title required, Campaign valid
+- [ ] Tests pass (in `apps/geostories/tests/`)
+
+---
+
+### Issue: Task 1.3b - GeoStory Nested Writes (Context & Layers)
+
+**Labels**: `feature`, `api`
+**Branch**: `feat/geostories-api-nested`
+
+**Description**:
+Enhance `GeoStory` API to handle nested creation of `GeoContext` and `Layers` in a single POST/PATCH request.
+
+**Technical Details**:
+
+- **Serializer**: Override `create()`/`update()` in `GeoStorySerializer`.
+- **Logic**:
+  - If `context` dict present: create/update `GeoContext` model and link it.
+  - If `layers` list present: sync `GeoStoryLayer` M2M using `layer_name`.
+
+#### Acceptance Criteria
+
+- [ ] POST includes `context: {"content": "..."}` -> Creates GeoContext
+- [ ] POST includes `layers: ["workspace:roads"]` -> Creates GeoStoryLayer links
+- [ ] Tests pass (in `apps/geostories/tests/`) for nested creation (atomic transaction)
+
+---
+
+### Issue: Task 1.4a - LayerRef Sync Client
+
+**Labels**: `feature`, `integration`
+**Branch**: `feat/layerrefs-client`
+
+**Description**:
+Implement a service client to fetch the list of available layers from GeoServer's REST API.
+
+**Technical Details**:
+
+- **File**: `apps/layerrefs/client.py`.
+- **Lib**: Use `requests`.
+- **Config**: Read `GEOSERVER_URL` and credentials from settings/env.
+- **Output**: List of strings `["workspace:layer_name", ...]`.
+
+#### Acceptance Criteria
+
+- [ ] Function returns list of layer names
+- [ ] Handles connection errors gracefully
+- [ ] Unit tests with mocked responses (no real network calls)
+
+---
+
+### Issue: Task 1.4b - LayerRef Sync Endpoint
+
+**Labels**: `feature`, `api`
+**Branch**: `feat/layerrefs-endpoint`
+
+**Description**:
+Add an Admin-only endpoint to trigger the Layer Sync process manually.
+
+**Technical Details**:
+
+- **URL**: `POST /api/v1/layers/sync/`.
+- **Logic**: Call client -> Get Layers -> Create missing `LayerRef` -> Delete stale `LayerRef`.
+- **Response**: `{"added": 5, "removed": 2}`.
+
+#### Acceptance Criteria
+
+- [ ] Only Admin/Editor can call
+- [ ] Returns added/removed counts
+- [ ] Tests pass (in `apps/layerrefs/tests/`)
+
+---
+
+### Issue: Task 1.5 - Create `featurelinks` App
+
+**Labels**: `feature`, `models`
+**Branch**: `feat/featurelinks-app`
+
+**Description**:
+Create `featurelinks` app to handle explicit relationships (e.g., Story A links to Story B). This uses Generic relationships (polymorphism).
+
+**Technical Details**:
+
+- **Model: `FeatureLink`**:
+  - `source`: GenericForeignKey.
+  - `target`: GenericForeignKey.
+  - `campaign`: FK (Boundary enforcement).
+  - `link_type`: Enum (Direct/ReadMore/Action).
+- **Validation**:
+  - Source and Target must be in the same `campaign`.
+  - Source != Target.
+
+#### Acceptance Criteria
+
+- [ ] Can link GeoStory → GeoStory
+- [ ] Validation rejects cross-campaign links
+- [ ] Validation rejects self-links
+- [ ] Tests pass (in `apps/featurelinks/tests/`)
+
+---
+
+### Issue: Task 1.6 - Enhanced GeoStory API
+
+**Labels**: `feature`, `api`
+**Branch**: `feat/geostory-read-api`
+
+**Description**:
+Enhance `GeoStory` API to support public consumption with list/detail separation and nested data (Context, Layers, Links). Current API is too flat for frontend use.
+
+**Technical Details**:
+
+- **Serializers**:
+  - `GeoStoryListSerializer`: Slim payload (title, summary, cover).
+  - `GeoStoryDetailSerializer`: Full payload with nested Context, Layers, Links.
+  - `GeoContextSerializer`: Expose `content`.
+  - `LayerRefSerializer`: Expose `layer_name`.
+  - `FeatureLinkSerializer`: Expose outgoing links.
+- **Views**:
+  - Update `GeoStoryViewSet` to use `get_serializer_class`.
+  - Enforce `status='published'` for List view (filtering).
+  - Optimize queries with `select_related`/`prefetch_related`.
+
+#### Acceptance Criteria
+
+- [x] List endpoint returns only Published stories
+- [x] List endpoint returns optimized/slim fields
+- [x] Detail endpoint returns fully nested Context and Layers
+- [x] Detail endpoint returns outgoing FeatureLinks
+- [x] Tests verify payload structure
+
+---
+
+## Phase 2: CalendarEvent Feature
+
+### Issue: Task 2.1 - Create `events` App with CalendarEvent Model
+
+**Labels**: `feature`, `models`, `geodjango`
+**Branch**: `feat/events-model`
+
+**Description**:
+Create `events` app. Implement `CalendarEvent` model with spatial support (`PointField`).
+
+**Technical Details**:
+
+- **App**: `tosca_api/apps/events`.
+- **Model: `CalendarEvent`**:
+  - `location`: `PointField(srid=4326)`.
+  - `start_datetime`, `end_datetime`.
+  - `context`: OneToOne to `GeoContext`.
+- **Constraints**: `end_datetime >= start_datetime`.
+
+#### Acceptance Criteria
+
+- [ ] PointField migration applies successfully
+- [ ] Can save model with SRID 4326 point
+- [ ] IntegrityError if end < start
+- [ ] Tests pass (in `apps/events/tests/`)
+
+---
+
+### Issue: Task 2.2 - CalendarEvent API Endpoints
+
+**Labels**: `feature`, `api`, `geodjango`
+**Branch**: `feat/events-api`
+
+**Description**:
+Implement REST API for CalendarEvents. Output must be valid **GeoJSON**.
+
+**Technical Details**:
+
+- **Serializer**: Use `GeoFeatureModelSerializer` (DRF GIS).
+- **Filters**:
+  - Spatial: Bounding Box (optional).
+  - Temporal: `start_after`, `end_before`.
+
+#### Acceptance Criteria
+
+- [ ] GET /api/v1/events/ returns GeoJSON FeatureCollection
+- [ ] Can filter: ?start_after=2024-01-01
+- [ ] CursorPagination enabled
+- [ ] Tests pass (in `apps/events/tests/`)
+
+---
+
+### Issue: Task 2.3 - Extend FeatureLink for Events
+
+**Labels**: `feature`, `testing`
+**Branch**: `feat/featurelinks-events`
+
+**Description**:
+Ensure `FeatureLink` model works correctly with `CalendarEvent` as both source and target.
+
+**Technical Details**:
+
+- Add validation to `FeatureLink` to allow `CalendarEvent` content type.
+
+#### Acceptance Criteria
+
+- [ ] Tests pass (in `apps/featurelinks/tests/`) for linking events to other features
+- [ ] Admin UI allows selecting events in generic relation
+
+---
+
+## Phase 2B: Event Model V2
+
+### Issue: Task 2B.1 - Replace `CalendarEvent` With `Event`
+
+**Labels**: `feature`, `models`, `migration`, `geodjango`
+**Branch**: `feat/event-v2-rename`
+
+**Description**:
+Replace `CalendarEvent` with `Event` after schema freeze and update all direct dependencies in one sweep.
+
+**Technical Details**:
+
+- Replace the Django model name and ORM references
+- Update `FeatureLink` allowed content types and generic relation names
+- Update serializers, viewsets, admin, tests, and docs that still reference `CalendarEvent`
+- Pre-production destructive schema reset is acceptable; no row-level backfill is required.
+
+#### Acceptance Criteria
+
+- [x] No `CalendarEvent` references remain in the event app or `FeatureLink`
+- [x] Event CRUD still works under the new `Event` model name
+- [x] Tests covering event creation and linking pass
+
+---
+
+### Issue: Task 2B.2 - Add Event Core Fields and Mode Validation
+
+**Labels**: `feature`, `models`, `validation`
+**Branch**: `feat/event-v2-core-fields`
+
+**Description**:
+Add the new core fields required for online, hybrid, and provider-aware events.
+
+**Technical Details**:
+
+- Add `event_type`, `location_mode`, online fields, provider fields, `series`, `occurrence_index`, `is_exception`, and `original_start_datetime`
+- Enforce `physical`, `hybrid`, and `online` validation rules
+- Keep event context optional
+- Keep concrete event datetimes on `TIMESTAMPTZ`
+- `EventType` and `EventSeries` were introduced as minimal placeholders here because the original task order referenced them before `2B.7` and `2B.12`
+- Online access validation currently accepts either `online_url` or `online_platform`
+
+#### Acceptance Criteria
+
+- [x] Online events allow `location=NULL` and require online access data
+- [x] Hybrid events require both geometry and online access data
+- [x] Standalone events can exist without context
+- [x] Mode validation tests pass
+
+---
+
+### Issue: Task 2B.3 - Add Series Default Context and Event Overrides
+
+**Labels**: `feature`, `models`
+**Branch**: `feat/event-v2-context`
+
+**Description**:
+Implement the final shared-content model using series defaults plus per-occurrence overrides.
+
+**Technical Details**:
+
+- Add `EventSeries.default_context`
+- Keep `Event.context` as an optional override
+- Implement effective context resolution as `event.context -> series.default_context -> none`
+- Events without effective context remain valid
+- `Event.context` is now a nullable `ForeignKey` override rather than a `OneToOneField`
+- The detail serializer returns the resolved effective context
+
+#### Acceptance Criteria
+
+- [x] Series events can resolve shared context from `EventSeries.default_context`
+- [x] Individual occurrences can override shared context through `Event.context`
+- [x] Published events remain valid without any effective context
+- [x] Context resolution tests pass
+
+---
+
+### Issue: Task 2B.4 - Add Core Constraints and Indexes
+
+**Labels**: `feature`, `models`, `geodjango`
+**Branch**: `feat/event-v2-core-constraints`
+
+**Description**:
+Add the minimum production-ready constraints and indexes for the event core.
+
+**Technical Details**:
+
+- Add `end_datetime >= start_datetime`
+- Add series-linked invariants for `campaign` and `event_type`
+- Add GiST index on `location`
+- Add b-tree indexes on `(campaign_id, status, start_datetime)`, `(event_type_id, start_datetime)`, `(location_mode, start_datetime)`, `(series_id, start_datetime)`
+- Add unique partial index on `(series_id, occurrence_index)` where `series_id IS NOT NULL`
+- The current implementation satisfies the GiST requirement through GeoDjango's spatial index on `Event.location`
+- `EventSeries` now carries `campaign` and `event_type`; both remain nullable at the DB layer for destructive-reset development, but attached events are validated against populated values
+
+#### Acceptance Criteria
+
+- [x] Series-linked events reject `campaign` or `event_type` changes while attached
+- [x] Duplicate `(series_id, occurrence_index)` values are rejected
+- [x] Schema contains the agreed minimum index set
+- [x] Constraint tests pass
+
+---
+
+### Issue: Task 2B.5 - Add Taxonomy Schema and Admin
+
+**Labels**: `feature`, `models`, `taxonomy`
+**Branch**: `feat/event-v2-taxonomy-schema`
+
+**Description**:
+Add dynamic taxonomy models and admin configuration.
+
+**Technical Details**:
+
+- Add `TaxonomyDimension`, `TaxonomyTerm`, and `EventTerm`
+- Support `single` vs `multiple` selection modes
+- Support parent-child terms inside a dimension
+- Add admin configuration for dimensions and terms
+- Add unique `TaxonomyTerm(dimension_id, code)` and unique `EventTerm(event_id, term_id)`
+- Reuse the existing `EventType` and `EventSeries` models already present in the app; do not introduce replacement models while adding taxonomy support
+- `TaxonomyDimension`, `TaxonomyTerm`, and `EventTerm` now exist in the live schema, and `EventTerm` should be reused in `2B.6` rather than replaced by another relation model
+- Single-select assignment enforcement remains intentionally deferred to `2B.6`
+
+#### Acceptance Criteria
+
+- [x] Admin can create dimensions and terms
+- [x] Parent term validation rejects cross-dimension hierarchies
+- [x] Duplicate term assignment is rejected
+- [x] Schema and admin tests pass
+
+---
+
+### Issue: Task 2B.6 - Add Event-Taxonomy Assignment Rules
+
+**Labels**: `feature`, `api`, `taxonomy`
+**Branch**: `feat/event-v2-taxonomy-assignment`
+
+**Description**:
+Implement assignment-time validation and query support for event taxonomy.
+
+**Technical Details**:
+
+- Enforce single-select dimension rules on `EventTerm`
+- Add index `EventTerm(term_id, event_id)` for filtering
+- Add serializer/admin validation for event-term assignment
+- Add API/query support for filtering by term and dimension
+- Build on the existing `EventTerm` table and admin exposure introduced in `2B.5`
+- The current event API now uses `term_id` and `dimension_id` for taxonomy filtering, and write operations accept `taxonomy_term_ids`
+
+#### Acceptance Criteria
+
+- [x] Single-select dimensions reject conflicting assignments
+- [x] Event-term assignment works from admin and API
+- [x] Event filtering by taxonomy terms works
+- [x] Assignment tests pass
+
+---
+
+### Issue: Task 2B.7 - Add Event Type Registry and Seeds
+
+**Labels**: `feature`, `models`, `validation`
+**Branch**: `feat/event-v2-types`
+
+**Description**:
+Introduce the `EventType` registry as the source of truth for event-type behavior.
+
+**Technical Details**:
+
+- Add `EventType` with `code`, `label`, `profile_mode`, `profile_key`, and `is_active`
+- Seed `general`, `public_health`, `sports`, and `culture`
+- Add admin support for event type management
+- Extend the existing placeholder `EventType` model in place rather than replacing it
+- Because the event rollout is destructive-reset-based, reshape the placeholder schema directly instead of planning compatibility backfills
+- `EventType` now enforces the registry invariant: `core` rows must not carry a `profile_key`, while `extension` rows must define one
+- The seed migration now creates the canonical bindings: `general=core`, `public_health=extension/public_health`, `sports=extension/sports`, `culture=extension/culture`
+
+#### Acceptance Criteria
+
+- [x] Event types can be created and managed in admin
+- [x] Seeded event types exist and match the agreed profile bindings
+- [x] Tests for registry creation and seed data pass
+
+---
+
+### Issue: Task 2B.8 - Add Profile Extension Models and Compatibility Validation
+
+**Labels**: `feature`, `models`, `validation`
+**Branch**: `feat/event-v2-profiles`
+
+**Description**:
+Add extension profile tables and validate them against `EventType`.
+
+**Technical Details**:
+
+- Add `PublicHealthEventProfile`, `SportsEventProfile`, and `CultureEventProfile`
+- Validate `profile_mode=core` vs `profile_mode=extension`
+- Reject mismatched event-type/profile combinations
+- Reuse the `EventType` registry contract established in `2B.7` instead of redefining profile bindings in code
+- Profile compatibility is now enforced from the event type registry itself: `profile_mode=core` rejects extension rows, and `profile_mode=extension` accepts only the matching `profile_key`
+
+#### Acceptance Criteria
+
+- [x] Core event types work without extension rows
+- [x] Extension types reject mismatched profile rows
+- [x] Profile compatibility tests pass
+
+---
+
+### Issue: Task 2B.9 - Add Shared Event Filter Layer
+
+**Labels**: `feature`, `api`, `geodjango`
+**Branch**: `feat/event-v2-filters`
+
+**Description**:
+Centralize event filtering so list and map endpoints share one contract.
+
+**Technical Details**:
+
+- Add shared parsing/validation for campaign, date range, status, visibility, taxonomy, `include_past`, and spatial filters
+- Make spatial predicates apply only to `physical` and `hybrid`
+- Keep `online` events subject to all non-spatial filters
+- Preserve the `term_id` and `dimension_id` taxonomy filter semantics already introduced on the current event endpoints
+- The shared filter helper is now in place and reused by both list and polygon/bbox query paths
+- Until `2B.11` lands, eligible online events remain visible in the current GeoJSON responses as features with `null` geometry
+
+#### Acceptance Criteria
+
+- [x] List and map endpoints can reuse the same filter layer
+- [x] Spatial filters exclude out-of-area `physical`/`hybrid` events
+- [x] Eligible `online` events remain included after non-spatial filtering
+- [x] Filter-layer tests pass
+
+---
+
+### Issue: Task 2B.10 - Add Event List API V2
+
+**Labels**: `feature`, `api`
+**Branch**: `feat/event-v2-list-api`
+
+**Description**:
+Build the list endpoint as one chronological mixed stream using `location_mode`.
+
+**Technical Details**:
+
+- Add `GET /api/v1/events/list/`
+- Return one paginated stream ordered by `start_datetime`
+- Include `location_mode` in each item
+- Reuse the shared event filter layer
+- The dedicated list endpoint now stays in JSON form even when spatial filters are supplied
+- The legacy `/api/v1/events/` route still exists and still flips to GeoJSON on bbox requests; the new list contract lives on `/api/v1/events/list/`
+
+#### Acceptance Criteria
+
+- [x] List endpoint returns `physical`, `hybrid`, and `online` events in one chronological stream
+- [x] Filtering semantics match the shared contract
+- [x] Pagination works as expected
+- [x] List API tests pass
+
+---
+
+### Issue: Task 2B.11 - Add Event Map API V2
+
+**Labels**: `feature`, `api`, `geodjango`
+**Branch**: `feat/event-v2-map-api`
+
+**Description**:
+Build the map endpoint with separate spatial and online result buckets.
+
+**Technical Details**:
+
+- Add `GET /api/v1/events/map/`
+- Return `spatial_events` as GeoJSON for `physical` and `hybrid`
+- Return `online_events` as a separate JSON array
+- Reuse the shared event filter layer
+- The dedicated map endpoint now owns the v2 bucketed map response contract while the legacy bbox route remains in place for backward compatibility
+- `spatial_events` now contains only mapped `physical` and `hybrid` events, and `online_events` carries the separately returned `online` matches
+
+#### Acceptance Criteria
+
+- [x] Map endpoint returns valid GeoJSON in `spatial_events`
+- [x] Map endpoint returns `online_events` separately from spatial GeoJSON
+- [x] Spatial filtering behavior matches the agreed semantics
+- [x] Map API tests pass
+
+---
+
+### Issue: Task 2B.12 - Add EventSeries and EventSeriesDate Schema
+
+**Labels**: `feature`, `models`, `recurrence`
+**Branch**: `feat/event-v2-series-schema`
+
+**Description**:
+Add the structural models required for batch and recurring event generation.
+
+**Technical Details**:
+
+- Create `EventSeries`
+- Create `EventSeriesDate`
+- Add unique `EventSeriesDate(series_id, occurrence_date)` constraint
+- Add recurrence field validation for daily, weekly, and monthly rules
+- Extend the existing `EventSeries` table in place rather than introducing a new grouping model
+- After the destructive reset for the new event system, revisit whether `EventSeries.campaign` and `EventSeries.event_type` should be tightened from nullable to non-nullable at the schema level
+- The live `EventSeries` table now carries recurrence, schedule, timezone, and creator fields, and `EventSeriesDate` now persists explicit manual-batch dates
+- The "manual batch must already have at least one date" rule remains deferred to the creation/generation flow rather than raw model save
+
+#### Acceptance Criteria
+
+- [x] Manual batch series can persist explicit dates
+- [x] Weekly/monthly validation rules are enforced
+- [x] Duplicate manual batch dates are rejected
+- [x] Series schema tests pass
+
+---
+
+### Issue: Task 2B.13 - Add Recurrence Generation, Exceptions, and DST Handling
+
+**Labels**: `feature`, `api`, `recurrence`
+**Branch**: `feat/event-v2-series-generation`
+
+**Description**:
+Implement generation, exception behavior, and local-time recurrence semantics.
+
+**Technical Details**:
+
+- Add preview and creation flow for manual and recurring series
+- Persist generated events with `series_id`, `occurrence_index`, and `original_start_datetime`
+- Mark diverging occurrences as `is_exception`
+- Update only future non-exception occurrences by default
+- Generate occurrences in local wall time using `EventSeries.timezone`
+- Build on the `EventSeries` and `EventSeriesDate` schema already introduced in `2B.12`
+
+#### Acceptance Criteria
+
+- [x] Recurring weekly series generate correct occurrences
+- [x] Weekly recurring series preserve the same local wall time across DST boundaries
+- [x] Exception occurrences are skipped by default during future bulk updates
+- [x] Generation and exception-handling tests pass
+
+**Implementation Notes**:
+
+- Added the dedicated recurrence API surface at `POST /api/v1/event-series/preview/`, `POST /api/v1/event-series/`, and `PATCH /api/v1/event-series/{id}/`.
+- Generation runs through a shared recurrence service that produces local-time occurrences in the `EventSeries.timezone`, then persists or synchronizes `Event` rows with `series_id`, `occurrence_index`, and `original_start_datetime`.
+- Direct edits to series-generated events through `/api/v1/events/{id}/` now mark the occurrence as `is_exception=True` when schedule/content/location or taxonomy data diverges from the generated row.
+- Future bulk updates skip exception rows by default and only update/delete future non-exception occurrences.
+- Recurring generation is currently same-day only. The existing `EventSeries.end_date` field is being used as the recurrence termination boundary, so multi-day recurring occurrence duration would need separate schema support later.
+- Series `campaign` and `event_type` changes are rejected once occurrences exist so attached exception rows cannot drift from the series identity.
+
+---
+
+### Issue: Task 2B.14 - Review Cleanup for Event Filters and Validation
+
+**Labels**: `cleanup`, `api`, `validation`
+**Branch**: `feat/event-v2-review-cleanups`
+
+**Description**:
+Apply the concrete Phase 2B follow-up improvements identified during implementation review without expanding scope into broader authorization work.
+
+**Technical Details**:
+
+- Confirm that the canonical `EventType` seed rows from `2B.7` are already backed by a real `RunPython` migration
+- Replace `EventLayer.unique_together` with `UniqueConstraint`
+- Move `VALID_WEEKDAYS` ahead of `EventSeries` for clarity
+- Add serializer-level GeoJSON `Point` validation for event-series template `location`
+- Auto-assign `EventSeriesDate.display_order` when omitted
+- Add `event_type_id` to the shared event filter contract used by list/map/within endpoints
+- Avoid unnecessary FK object comparison in series-occurrence exception detection
+
+#### Acceptance Criteria
+
+- [x] Event-series preview/create returns clear 400 errors for malformed or non-point location GeoJSON
+- [x] Shared event filtering supports `event_type_id`
+- [x] `EventLayer` uniqueness is expressed with `UniqueConstraint`
+- [x] `EventSeriesDate` can be created without explicitly setting `display_order`
+- [x] Cleanup tests pass
+
+**Implementation Notes**:
+
+- The `2B.7` event type seeds are confirmed in `events/migrations/0007_eventtype_is_active_eventtype_profile_key_and_more.py` through `RunPython(seed_event_types, unseed_event_types)`.
+- The `event_type_id` filter now flows through the shared filter serializers and `apply_event_filters()`, so legacy list, list v2, map v2, and geometry-based endpoints all share the same contract.
+- Queryset deletion in recurrence sync remains as-is because `Event` still does not implement custom delete-side cleanup.
+- Role-based permissions remain intentionally out of scope for this cleanup and should be handled as a separate authorization task.
+
+---
+
+### Issue: Task 2B.15 - Add Admin Event-Series Authoring and Occurrence Generation
+
+**Labels**: `feature`, `admin`, `recurrence`, `testing`
+**Branch**: `feat/event-series-admin-generation`
+
+**Description**:
+Extend Django admin so admins can create and update event series from the admin UI and have occurrence events generated or synchronized with the same semantics already used by the recurrence API.
+
+**Technical Details**:
+
+- Treat this as admin parity for the existing recurrence feature, not a second independent recurrence implementation.
+- Extend the `EventSeries` admin authoring surface to collect the required event-template fields currently only provided through `POST /api/v1/event-series/` and `PATCH /api/v1/event-series/{id}/`.
+- Required admin template coverage should include at least:
+  - `title`
+  - `description`
+  - `location_mode`
+  - `location`
+  - `online_url`
+  - `online_platform`
+  - `access_notes`
+  - `provider_name`
+  - `provider_url`
+  - `provider_contact`
+  - `status`
+  - `visibility`
+  - `context`
+  - taxonomy term selection for generated occurrences
+- Reuse the existing recurrence generation and sync logic instead of duplicating recurrence math or exception-handling rules inside admin code.
+- Extract or introduce a shared orchestration layer if needed so admin and API can both call the same validation/generation flow without fabricating a fake API request.
+- Ensure admin create runs generation only after inline `EventSeriesDate` rows have been saved, because manual-batch series depend on inline explicit dates.
+- Ensure admin update synchronizes future non-exception occurrences by default, matching the existing API semantics.
+- Preserve the current rule that `campaign` and `event_type` cannot change once occurrences already exist.
+- Prevent duplicate occurrence creation when an existing generated series is re-saved from admin; synchronization must remain keyed by `occurrence_index`.
+- Surface validation failures in the admin form flow rather than partially saving a series without its generated events.
+- Wrap series save, inline date persistence, and occurrence generation/synchronization in one transaction so admin does not leave half-written data behind on failure.
+- Support editing existing series whose template must be derived from an existing non-exception occurrence because `EventSeries` itself does not persist the full event template.
+- Define the fallback behavior for legacy series rows that have no occurrences yet:
+  - either require admins to supply the missing template fields before generation
+  - or block sync with a clear admin validation error
+- Keep raw model saves side-effect free outside the explicit admin/API authoring flows; do not silently generate events on every `EventSeries.save()` call.
+
+**Edge Cases / Risks**:
+
+- Manual-batch admin create with no inline dates.
+- Manual-batch admin update that adds, removes, or reorders explicit dates.
+- Weekly recurrence missing `by_weekday`.
+- Monthly recurrence with incomplete rule inputs.
+- Online, physical, and hybrid template validation mismatches.
+- Invalid or non-point GeoJSON for admin-entered location data.
+- Existing future exception occurrences must remain untouched during admin bulk edits.
+- Existing past occurrences must not be recreated or overwritten during admin sync.
+- Timezone or start-time edits across DST boundaries must preserve local wall-time recurrence behavior.
+- Existing API-created series re-saved in admin must not create duplicate events.
+- Existing series with no remaining events must still produce predictable validation behavior.
+- Taxonomy term selections must still enforce single-select dimension rules.
+
+#### Acceptance Criteria
+
+- [x] Admin can create a recurring or manual-batch series and immediately get generated `Event` rows
+- [x] Admin can edit a generated series and synchronize future non-exception occurrences without duplicating rows
+- [x] Manual-batch admin authoring supports inline explicit dates
+- [x] Admin validation enforces the same event-template and recurrence rules as the API flow
+- [x] Exception occurrences remain preserved by default during admin bulk edits
+- [x] Legacy or incomplete series states fail with clear admin errors instead of silent partial saves
+- [x] Admin generation and sync behavior is covered by automated tests
+
+**Implementation Notes**:
+
+- The current recurrence API is the only path that creates/synchronizes occurrence rows today; admin currently saves only the `EventSeries` model and its inline dates.
+- `EventSeries` is intentionally lightweight and does not store all event-template fields, so admin update behavior must derive defaults from an existing occurrence or require explicit replacement input.
+- The admin hook should likely run after `save_related()` rather than only in `save_model()` so inline explicit dates are available for manual-batch generation.
+- If sharing the current serializer logic directly proves awkward, extract the orchestration currently embedded in `EventSeriesWriteSerializer` into a service that both the API and admin can call.
+
+---
+
+### Issue: Task 2B.16 - Replace Term-Centric Event Taxonomy Writes with Dimension Assignments
+
+**Labels**: `feature`, `api`, `taxonomy`, `testing`
+**Branch**: `feat/event-taxonomy-dimension-assignments`
+
+**Description**:
+Refactor event and event-series taxonomy writes from raw `taxonomy_term_ids` lists to a grouped `taxonomy_assignments` contract so taxonomy behaves like optional event attributes rather than a low-level join-table payload.
+
+**Technical Details**:
+
+- This task should build on the shared authoring flow extracted or stabilized in `2B.15`.
+- Replace `taxonomy_term_ids` on event and event-series writes with a grouped shape keyed by dimension, for example:
+  - `taxonomy_assignments: [{dimension_id, term_ids[]}]`
+- No backward-compatibility shim is required because the taxonomy authoring contract is not yet published.
+- Introduce a shared taxonomy parser/validator that can be reused by API serializers, admin forms, and series orchestration.
+- Validation rules should include:
+  - taxonomy is optional for all event statuses
+  - each dimension appears at most once in the payload
+  - each term appears at most once within its dimension
+  - terms must belong to the stated dimension
+  - only active dimensions and active terms may be assigned in new writes
+  - only leaf terms may be assigned
+  - `single` dimensions may have at most one assigned term
+- Keep `EventTerm` as the only persistence model for event taxonomy; this task should not denormalize taxonomy onto `Event` or `EventSeries`.
+
+#### Acceptance Criteria
+
+- [x] Event writes accept grouped taxonomy assignments instead of `taxonomy_term_ids`
+- [x] Event-series writes accept the same grouped taxonomy assignment shape
+- [x] Taxonomy remains optional for draft and published events
+- [x] Leaf-only and selection-mode validation rules are enforced consistently
+- [x] `EventTerm` remains the storage layer for event taxonomy
+- [x] Automated tests cover grouped taxonomy validation for both event and event-series writes
+
+**Implementation Notes**:
+
+- The grouped assignment validator should be implemented once and reused everywhere rather than duplicating validation in multiple serializers/forms.
+- Validation errors should be phrased around dimensions and assignments, not around raw join-table operations.
+- Existing taxonomy filter semantics (`term_id`, `dimension_id`) can remain unchanged for reads unless changed by a later task.
+- The live write contract now accepts `taxonomy_assignments` on both event and event-series writes, and the old `taxonomy_term_ids` write field has been removed rather than retained behind a compatibility layer.
+
+---
+
+### Issue: Task 2B.17 - Add Dimension-Based Taxonomy Hydration for Event and Series Authoring
+
+**Labels**: `feature`, `admin`, `api`, `taxonomy`, `testing`
+**Branch**: `feat/event-taxonomy-authoring-hydration`
+
+**Description**:
+Expose grouped taxonomy assignments on event and event-series reads, and surface taxonomy in admin authoring flows as dimension-based optional attributes instead of direct `EventTerm` maintenance.
+
+**Technical Details**:
+
+- This task depends on `2B.15` for shared series-authoring orchestration and on `2B.16` for the grouped taxonomy-assignment contract.
+- Add read helpers/serializers so event detail responses return grouped taxonomy assignments for edit hydration.
+- Add the same grouped taxonomy representation to event-series retrieve responses, deriving values from the base non-exception occurrence/template rather than adding new taxonomy columns to `EventSeries`.
+- Extend `EventAdminForm` to render taxonomy grouped by active dimension and write through the shared grouped-assignment validator.
+- Extend `EventSeriesAdminForm` to expose the same taxonomy authoring section for generated occurrences.
+- Keep `EventTermAdmin` as a low-level maintenance/debug entry point only; it should no longer represent the intended authoring flow.
+- Define clear failure behavior for legacy series with no usable base occurrence/template from which taxonomy defaults can be derived.
+- Preserve the `2B.15` recurrence sync semantics:
+  - future non-exception occurrences are updated
+  - future exceptions are preserved by default
+  - past occurrences remain untouched
+
+#### Acceptance Criteria
+
+- [x] Event detail responses expose grouped taxonomy assignments suitable for edit hydration
+- [x] Event-series retrieve responses expose grouped taxonomy assignments derived from the series template/base occurrence
+- [x] Admin event create/edit manages taxonomy by dimension rather than through direct `EventTerm` editing
+- [x] Admin event-series create/edit manages taxonomy by dimension for generated occurrences
+- [x] Legacy series states without a usable base occurrence/template fail with actionable errors
+- [x] Automated tests cover grouped taxonomy hydration and admin authoring behavior
+
+**Implementation Notes**:
+
+- `EventSeries` should remain lightweight; do not introduce a second persistent taxonomy representation on the series row unless a later task explicitly changes that decision.
+- Responses should use the same grouped taxonomy shape as writes so admin/frontend hydration is straightforward.
+- When an event or series references inactive already-assigned terms, edit flows should display those assignments predictably even if new writes reject newly selecting inactive terms.
+- Admin now renders taxonomy as dynamic per-dimension fields on event and event-series forms while leaving `EventTermAdmin` as a low-level maintenance surface.
+
+---
+
+## Phase 3: GeoFeedback Feature
+
+### Issue: Task 3.1 - Create `feedback` App with Core Models
+
+**Labels**: `feature`, `models`
+**Branch**: `feat/feedback-models`
+
+**Description**:
+Create `feedback` app. Implement the `GeoFeedback` container linking to dynamic forms and setting configuration flags for ratings and drawings.
+
+**Technical Details**:
+
+- **App**: `tosca_api/apps/feedback`.
+- **Dependencies**: Install `django-basic-form-builder` and add to INSTALLED_APPS.
+- **Model: `GeoFeedback`**:
+  - `rating_enabled` (bool).
+  - `form_enabled` (bool).
+  - `allow_drawings` (bool).
+  - `custom_form`: FK to `formbuilder.CustomForm` (nullable).
+  - `campaign`: FK to `Campaign`.
+- **Constraints**: At least one mode (rating or form) must be enabled. If form is enabled, `custom_form` must not be null.
+
+#### Acceptance Criteria
+
+- [ ] Admin can create CustomForms via form builder and link them to GeoFeedback
+- [ ] GeoFeedback model supports configuration flags and proper validation
+- [ ] Tests pass (in `apps/feedback/tests/`)
+
+---
+
+### Issue: Task 3.2 - Add FeedbackSubmission Model
+
+**Labels**: `feature`, `models`, `geodjango`
+**Branch**: `feat/feedback-submission`
+
+**Description**:
+Implement `FeedbackSubmission` model to store user responses. This stores dynamic data, optional geometry, and strict native ratings.
+
+**Technical Details**:
+
+- **Model: `FeedbackSubmission`**:
+  - `feedback`: FK to `GeoFeedback`.
+  - `rating`: Integer (1-5).
+  - `form_data`: JSONB (for dynamic answers matching CustomForm).
+  - `geometry`: GeometryField (Point/Line/Poly) - user sketch.
+  - `is_anonymized`: Boolean.
+
+#### Acceptance Criteria
+
+- [ ] Can store submissions with or without User
+- [ ] Can store geometry (Point/Line/Poly)
+- [ ] JSONB field accepts arbitrary dict for formbuilder schema answers
+- [ ] Tests pass (in `apps/feedback/tests/`)
+
+---
+
+### Issue: Task 3.3 - GeoFeedback API Endpoints
+
+**Labels**: `feature`, `api`
+**Branch**: `feat/feedback-api`
+
+**Description**:
+Implement API for managing Feedback definitions and accepting submissions.
+
+**Technical Details**:
+
+- **Endpoints**:
+  - `GET /api/v1/feedback/` (List active feedback forms). Include linked `CustomForm` API endpoint URL.
+  - `POST /api/v1/feedback/{id}/submit/` (Custom Action).
+- **Submission Logic**:
+  - Validate `rating` if `rating_enabled`.
+  - Validate `form_data` matching form schema if `form_enabled`.
+  - Validate `geometry` if `allow_drawings`.
+
+#### Acceptance Criteria
+
+- [ ] Admin can create/update Feedback forms
+- [ ] Anonymous user can submit if allowed
+- [ ] Submission validates against configuration (strictly enforcing the config flags)
+- [ ] CursorPagination for Feedback list
+- [ ] Tests pass (in `apps/feedback/tests/`)
+
+---
+
+### Issue: Task 3.4 - Extend FeatureLink for Feedback
+
+**Labels**: `feature`, `testing`
+**Branch**: `feat/featurelinks-feedback`
+
+**Description**:
+Ensure `FeatureLink` works with `GeoFeedback`. This allows connecting a User Story to a Feedback form (e.g., "Rate this proposal").
+
+**Technical Details**:
+
+- Add validation to `FeatureLink` to allow `GeoFeedback` content type.
+
+#### Acceptance Criteria
+
+- [ ] Can link Story -> Feedback
+- [ ] Tests pass (in `apps/featurelinks/tests/`)
+- [ ] Admin UI generic relation picker includes GeoFeedback
+
+---
+
+## Phase 4: Production Readiness
+
+### Issue: Task 4.1a - Configure PgBouncer
+
+**Labels**: `infrastructure`, `performance`
+**Branch**: `chore/pgbouncer-infra`
+
+**Description**:
+Add PgBouncer to the production Docker stack to pool database connections. PostGIS connections are heavy; pooling is essential for scale.
+
+**Technical Details**:
+
+- **Docker**: Add `pgbouncer` container.
+- **Config**: Mount `pgbouncer.ini`.
+- **Django**: Update `DATABASE_URL` to point to pgbouncer port (6432) in `settings/prod.py`.
+
+#### Acceptance Criteria
+
+- [ ] `docker compose -f docker-compose.prod.yml config` is valid
+- [ ] Application connects via pooler
+
+---
+
+### Issue: Task 4.1b - Verify Spatial Indexes
+
+**Labels**: `infrastructure`, `performance`
+**Branch**: `chore/verify-indexes`
+
+**Description**:
+Create a management command to audit the database and ensure all geometry columns have a GIST index. Missing indexes ruin spatial query performance.
+
+**Technical Details**:
+
+- **Command**: `manage.py check_spatial_indexes`.
+- **Logic**: Inspect `pg_indexes` system view for columns implementing `models.GeometryField`.
+
+#### Acceptance Criteria
+
+- [ ] Command reports OK for current schema
+- [ ] Fails if we drop an index manually
+
+---
+
+### Issue: Phase 7 - GeoContext Editor.js Migration
+
+**Labels**: `epic`, `content`, `admin`, `migration`
+
+**Goal**: Replace the legacy GeoContext text-plus-`content_type` authoring model with canonical Editor.js JSON, deterministic validation and normalization, Django admin authoring, and a staged migration path.
+
+**Context**:
+The original GeoContext design stored either simple text or rich HTML in a single text field with a `content_type` discriminator. Future implementation will supersede that approach with canonical Editor.js JSON so content structure is explicit, normalization is deterministic, admin authoring is improved, and staged migration can proceed without ambiguity.
+
+**Key Outcomes**:
+
+- **Canonical JSON Contract**: GeoContext content is structured Editor.js JSON instead of text-plus-`content_type`.
+- **Deterministic Validation**: Future writes pass through strict block-schema validation and normalization.
+- **Admin Authoring**: Django admin gains Editor.js progressive enhancement with a raw JSON fallback.
+- **Safe Migration**: Preflight scanning and staged releases handle legacy content safely, aborting on media-bearing rows.
+
+#### Task List
+
+- [x] Task 7.1: Canonical GeoContext Editor.js Contract
+- [x] Task 7.2: Editor.js Validation and Normalization Layer
+- [x] Task 7.3: Django Admin Editor.js Authoring
+- [x] Task 7.4: GeoContext Preflight and HTML-to-Blocks Backfill
+- [x] Task 7.5: Release 2 Switch to `content_json`
+- [x] Task 7.6: Release 3 Drop Legacy GeoContext Fields
+
+---
+
+### Issue: Task 7.1 - Canonical GeoContext Editor.js Contract
+
+**Labels**: `feature`, `content`, `api`
+**Branch**: `feat/geocontext-editorjs-contract`
+
+**Description**:
+Replace the legacy `GeoContext` string-plus-`content_type` contract with canonical Editor.js JSON. `GeoContext.content` becomes JSON-backed content, `content_type` disappears from the future contract, and all nested read surfaces expose `context.content` as JSON.
+
+**Technical Details**:
+
+- **Model Surface**: `GeoContext.content` becomes the canonical Editor.js JSON field for future implementation.
+- **Removed Field**: `content_type` is removed from the future model, serializer, admin, and schema contract.
+- **Read Surfaces**: Update nested GeoContext serializer contracts in `geostories`, `events`, and `feedback`.
+- **Empty State**: Empty documents must be represented as `{ "blocks": [] }`, not `null`, blank strings, or omitted fields.
+- **Supersession Note**: This issue supersedes the original GeoContext `content` + `content_type` design for future implementation.
+
+#### Acceptance Criteria
+
+- [x] `GeoContext.content` is defined as JSON-backed content rather than freeform text
+- [x] `content_type` is removed from the future model, serializers, admin, and schema
+- [x] All nested `GeoContext` read surfaces in events, geostories, and feedback describe `context.content` as JSON
+- [x] Empty content is represented as `{ "blocks": [] }`, not `null`, `""`, or omitted
+- [x] Historical `content_type` references in future-oriented docs for this feature are removed or marked superseded
+
+---
+
+### Issue: Task 7.2 - Editor.js Validation and Normalization Layer
+
+**Labels**: `feature`, `content`, `security`
+**Branch**: `feat/editorjs-validation`
+
+**Description**:
+Introduce a dedicated `core/editorjs.py` validation and normalization layer for GeoContext Editor.js documents. This layer is responsible for block schema enforcement, semantic tag normalization, inline HTML sanitization, and deterministic canonical storage.
+
+**Technical Details**:
+
+- **Module**: `tosca_api/apps/core/editorjs.py`.
+- **Allowed Blocks**: `paragraph`, `header`, `list`, `quote`, `delimiter`, `code`.
+- **Allowed Inline Formatting**: `a`, `strong`, `em`, `code`, `br`.
+- **Normalization Rules**:
+  - Strip `time`, `version`, and block `id` from stored content.
+  - Normalize `<b>` to `<strong>` and `<i>` to `<em>`.
+  - Reject `quote.alignment`.
+  - Allow `list.meta` only as `{}` for MVP.
+- **Validation Behavior**: Unsafe URLs and malformed block shapes fail validation explicitly.
+
+#### Acceptance Criteria
+
+- [x] Validation logic lives in a dedicated Editor.js module, not in the legacy HTML sanitizer router
+- [x] Only the MVP block set is accepted: `paragraph`, `header`, `list`, `quote`, `delimiter`, `code`
+- [x] Only allowed inline formatting survives in text-bearing fields: `a`, `strong`, `em`, `code`, `br`
+- [x] `<b>` normalizes to `<strong>` and `<i>` normalizes to `<em>`
+- [x] Full Editor.js save payloads may be accepted as input, but stored documents strip `time`, `version`, and block `id`
+- [x] `quote.alignment` is rejected
+- [x] `list.meta` is allowed only as `{}` for MVP
+- [x] Invalid block shapes or unsafe URLs fail validation
+
+---
+
+### Issue: Task 7.3 - Django Admin Editor.js Authoring
+
+**Labels**: `feature`, `admin`, `content`
+**Branch**: `feat/geocontext-editorjs-admin`
+
+**Description**:
+Add Editor.js authoring to Django admin for GeoContext as progressive enhancement. The admin retains a JSON textarea fallback, while vendored JavaScript upgrades it into an Editor.js editing surface and mirrors content back before submit.
+
+**Technical Details**:
+
+- **Admin Integration**: Use Django admin `Media` to load vendored Editor.js assets.
+- **Fallback**: Keep the raw textarea as the no-JS submission path.
+- **Submission Path**: Mirror editor state into the textarea; no custom AJAX write flow.
+- **Static Assets**: Vendor Editor.js assets under Django static files and include required upstream licenses.
+- **Preview Behavior**: Extract plain text from block JSON for admin changelist preview, truncate long values, and show `(empty)` for empty documents.
+
+#### Acceptance Criteria
+
+- [x] GeoContext admin uses an Editor.js-powered editing surface when JS loads successfully
+- [x] The non-JS fallback remains a plain textarea containing canonical JSON
+- [x] Form submission relies on standard Django POST behavior; no custom AJAX write path is introduced
+- [x] Editor.js assets are vendored into static files, not loaded from a CDN
+- [x] Required upstream license files are included alongside vendored assets
+- [x] Changelist preview shows extracted plain text, truncated, and displays `(empty)` for empty documents
+
+---
+
+### Issue: Task 7.4 - GeoContext Preflight and HTML-to-Blocks Backfill
+
+**Labels**: `feature`, `migration`, `management-command`
+**Branch**: `feat/geocontext-editorjs-preflight`
+
+**Description**:
+Add a read-only preflight command and Release 1 backfill logic for converting existing GeoContext rows from legacy text or HTML content into canonical Editor.js blocks. The process must be deterministic and must abort explicitly on rows that contain media-bearing markup.
+
+**Technical Details**:
+
+- **Command**: Add a preflight management command that reports exact sorted blocking IDs.
+- **Conversion Logic**: Share detection and conversion logic between preflight and migration code.
+- **Supported Mapping**:
+  - blank simple content -> `{ "blocks": [] }`
+  - simple text -> paragraph block
+  - rich HTML headers/paragraphs/nested lists/blockquotes/code/inline code/`<br>` -> supported blocks
+- **Abort Rule**: Rows containing `img`, `figure`, or `figcaption` abort with explicit IDs.
+- **Behavior Guarantees**: Preflight must be read-only and idempotent.
+
+#### Acceptance Criteria
+
+- [x] A preflight command scans existing GeoContext rows and reports the exact sorted IDs that cannot be migrated
+- [x] The preflight command is read-only and idempotent
+- [x] Legacy simple content maps to paragraph blocks or `{ "blocks": [] }` when blank
+- [x] Legacy rich content is sanitized first, then parsed into blocks
+- [x] Supported HTML mappings are fixed and documented: headers, paragraphs, nested lists, blockquotes, code blocks, inline code, `<br>`
+- [x] Rows containing `img`, `figure`, or `figcaption` abort migration with explicit IDs
+- [x] The data migration uses the same detection logic as the preflight command
+
+**Implementation**:
+
+- Converter lives in `tosca_api/apps/core/legacy_html.py`. Exports
+  `convert_legacy_html(html)` and `LegacyHtmlMediaError`. Uses stdlib
+  `html.parser.HTMLParser` (no bs4/lxml dependency).
+- Preflight command lives at
+  `tosca_api/apps/geocontext/management/commands/geocontext_preflight.py`.
+  Read-only: scans existing rows through
+  `tosca_api.apps.core.editorjs.validate_and_normalize` and reports
+  failures by UUID in sorted order for deterministic diffs across runs.
+- `--legacy-input-json PATH` dry-runs the converter against a
+  `{id: html}` JSON map so operators can preview which legacy rows
+  would be blocked by media before any migration is attempted.
+- Media detection runs before sanitization so `<img>`, `<figure>`, and
+  `<figcaption>` abort with explicit IDs even though `sanitize_rich`
+  would otherwise preserve them.
+- Since Release 1 (Task 7.1) was destructive, the preflight + converter
+  land as reusable migration tooling; future releases that ingest
+  legacy HTML can reuse the same detection logic, satisfying the
+  "migration and preflight agree" acceptance bullet.
+- Tests: 25 in `tosca_api/apps/core/tests/test_legacy_html.py`
+  (including nested list shape, `<pre><code>` → code block, `<br>`
+  preservation, orphan-text folding, media rejection, idempotency),
+  plus 8 in `tosca_api/apps/geocontext/tests/test_preflight.py` (clean
+  dataset, invalid-row reporting, run-to-run stability, no-mutation
+  guarantee, legacy input dry-run with sorted media IDs, missing/
+  malformed legacy file).
+
+---
+
+### Issue: Task 7.5 - Release 2 Switch to `content_json`
+
+**Labels**: `feature`, `migration`, `api`
+**Branch**: `feat/geocontext-editorjs-switch`
+
+**Description**:
+Switch application reads and writes to the new JSON-backed GeoContext field while keeping the legacy columns in place for rollback safety during Release 2.
+
+**Technical Details**:
+
+- **Source of Truth**: Switch serializer, admin, and model codepaths to `content_json`.
+- **Read Surfaces**: Geostories, events, and feedback nested serializers emit JSON-backed context content.
+- **Write Surfaces**: GeoContext validation and admin writes use `content_json`.
+- **Rollback Strategy**: Legacy columns remain present but inactive during this release.
+- **Contract Cleanup**: Active read/write paths no longer depend on `content_type`.
+
+#### Acceptance Criteria
+
+- [x] All application reads use `content_json` as the source of truth *(`GeoContext.content` is the canonical JSON column post-7.1)*
+- [x] All application writes populate and validate `content_json` *(`GeoContext.save()` routes through `validate_and_normalize`)*
+- [~] Legacy columns remain present but are no longer the active read/write path *(N/A — 7.1 destructive reset dropped them)*
+- [x] Events, geostories, and feedback nested serializers all emit the JSON-backed content contract
+- [~] Rollback remains possible because legacy columns are still available during this release *(N/A — 7.1 destructive reset)*
+
+**Implementation**:
+
+- Task 7.1 collapsed the phased plan by dropping `content_type` and the
+  legacy text column outright in migration
+  `tosca_api/apps/geocontext/migrations/0002_editorjs_canonical_contract.py`.
+  There is no parallel `content_json` field — `GeoContext.content` is
+  already the canonical Editor.js JSON column. See decisions.md §[7.5].
+- Nested serializers expose the JSON contract:
+  `geostories.serializers.GeoContextSerializer`,
+  `events.serializers.EventGeoContextSerializer` (with
+  `effective_context` series-default resolution) and
+  `feedback.serializers.FeedbackGeoContextSerializer`, each emitting
+  `{id, content}` with `content` as a dict.
+- Removed the dead `tosca_api.apps.core.sanitization.sanitize_content`
+  helper and its lone unit test — the helper dispatched on the retired
+  `content_type` string discriminator and had no remaining production
+  callers.
+- Final regression guard lives at
+  `tosca_api/apps/geocontext/tests/test_json_contract.py` (14 cases)
+  covering geostory/event/feedback detail contract, empty-context →
+  `{"blocks": []}`, admin save round-trip, and absence of
+  `content_type` on model + `sanitize_content` in code.
+
+---
+
+### Issue: Task 7.6 - Release 3 Drop Legacy GeoContext Fields
+
+**Labels**: `feature`, `migration`, `cleanup`
+**Branch**: `feat/geocontext-editorjs-cleanup`
+
+**Description**:
+Complete the GeoContext migration by dropping the legacy text-based fields, renaming `content_json` back to `content`, and finalizing the codebase on the canonical Editor.js contract.
+
+**Technical Details**:
+
+- **Schema Cleanup**: Drop legacy text `content` and `content_type`.
+- **Rename**: Rename `content_json` back to `content`.
+- **Code Cleanup**: Remove obsolete references in models, serializers, admin, migration helpers, and updated docs.
+- **Regression Scope**: Verify model, admin, and nested serializer behavior after the final rename.
+
+#### Acceptance Criteria
+
+- [x] Legacy `content` text column and `content_type` are dropped *(Task 7.1 migration `0002_editorjs_canonical_contract`)*
+- [~] `content_json` is renamed to `content` *(N/A — `content_json` was never introduced; see decision §[7.5b])*
+- [x] No model, serializer, admin, migration helper, or doc for the new path refers to the old fields
+- [x] The final schema and codebase align exactly with the canonical Editor.js contract
+- [x] Regression coverage confirms behavior is unchanged after the rename
+
+**Implementation**:
+
+- Task 7.6 is almost entirely superseded by the destructive Task 7.1
+  reset and Task 7.5 regression coverage. No schema changes ship in
+  this task.
+- Final regression locks in
+  `tosca_api/apps/geocontext/tests/test_models.py`:
+  - `test_geocontext_final_schema_snapshot` pins
+    `{id, title, content, created_by, created_at, updated_at}` as the
+    authoritative field set and explicitly rejects re-introduction of
+    `content_type` or `content_json`.
+  - `test_geocontext_crud_round_trip` exercises
+    create / read / update / delete against the canonical JSON
+    pipeline.
+- Admin and nested-serializer regressions live in Task 7.3
+  (`test_admin.py`) and Task 7.5 (`test_json_contract.py`) and continue
+  to pass.
+- Full-repo sweep confirms no residual references to `content_json` in
+  production code, and remaining `content_type` matches elsewhere in
+  the codebase (`featurelinks`, `events`, `geostories`) all refer to
+  Django's unrelated `contenttypes.ContentType` generic-relations —
+  not to the retired GeoContext discriminator.
+
+---
+
+### Issue: Phase 8 - GeoData Provider Integration & LayerRef Refactor
+
+**Labels**: `epic`, `architecture`, `integration`
+
+**Goal**: Replace the standalone `layerrefs` indirection with direct foreign keys to `geodata_providers.Layer` so GeoStory, Event, and GeoFeedback consume canonical layer metadata from one source of truth, and stop maintaining a parallel layer registry.
+
+**Context**:
+The `geodata_providers` app is the canonical layer registry: it owns `GeodataEngine → Workspace → Store → Layer → Style`, exposes CRUD and publish/unpublish actions, and reconciles state with GeoServer / Martin / pg_tileserv via `GeoServerSyncService` and `EngineClientFactory`. The legacy `layerrefs.LayerRef` model holds only a free-form `"workspace:layername"` string and is referenced by `GeoStory.layers`, `Event.layers`, and `GeoFeedback.layers` through per-app through models with `display_order`. There is no FK or resolver connecting the two: consumers cannot verify a layer exists, is public, is published, or read its geometry/SRID/published URL without parsing the string.
+
+The system is not yet in production. Backward-compatible shims are not required. A destructive schema reset for the affected through tables is acceptable.
+
+**Key Outcomes**:
+
+- **Direct FK to `Layer`**: `GeoStoryLayer`, `EventLayer`, `FeedbackLayer` reference `geodata_providers.Layer` directly; `display_order` semantics preserved per parent.
+- **`layerrefs` Removal**: The `layerrefs` app, `LayerRefSerializer`, and string-based layer references are deleted.
+- **Public + Published Validation**: Through-model `clean()` rejects non-public or non-published layers across all three consuming apps.
+- **Layer Metadata in Detail Responses**: A shared `LayerSummarySerializer` exposes `geometry_type`, `srid`, `published_url`, `is_public`, `publishing_state` on GeoStory / Event / GeoFeedback detail responses.
+- **UUID-based Writes**: Nested layer writes accept `Layer.id` UUIDs instead of `layer_name` strings; this supersedes the layer sub-bullet of Task 1.3b.
+- **Pre-delete Usage Warning**: Admin and API surface usage counts before deleting a `Layer` referenced by GeoStory / Event / GeoFeedback.
+- **Supersede Legacy Sync Tasks**: Task 1.4a (LayerRef Sync Client) and Task 1.4b (LayerRef Sync Endpoint) are superseded by `GeoServerSyncService` already shipped in `geodata_providers`.
+
+#### Task List
+
+- [ ] Task 8.1: Replace `LayerRef` FK with `geodata_providers.Layer` FK
+- [ ] Task 8.2: Remove `layerrefs` App
+- [ ] Task 8.3: Public + Published Validation on Layer Assignment
+- [ ] Task 8.4: `LayerSummarySerializer` and Detail Response Hydration
+- [ ] Task 8.5: Replace String Layer Writes With UUID-Based Writes
+- [ ] Task 8.6: Pre-delete Usage Warning for `Layer`
+- [ ] Task 8.7: Supersede Task 1.4a and Task 1.4b
+
+---
+
+### Issue: Task 8.1 - Replace `LayerRef` FK with `geodata_providers.Layer` FK
+
+**Labels**: `feature`, `models`, `migration`, `geodata`
+**Branch**: `feat/layerref-direct-fk`
+
+**Description**:
+Swap the FK target on `GeoStoryLayer.layer`, `EventLayer.layer`, and `FeedbackLayer.layer` from `layerrefs.LayerRef` to `geodata_providers.Layer`. Re-declare the M2M `layers` field on `GeoStory`, `Event`, and `GeoFeedback` to point at `geodata_providers.Layer` through the existing through models. Preserve `display_order`, the auto-increment `save()` behavior, and the `(parent, layer)` uniqueness constraint on each through model.
+
+**Technical Details**:
+
+- **Models touched**: `GeoStoryLayer`, `EventLayer`, `FeedbackLayer`, `GeoStory.layers`, `Event.layers`, `GeoFeedback.layers`.
+- **FK target**: `geodata_providers.Layer`, `on_delete=CASCADE`.
+- **Related names**: `geostory_uses`, `event_uses`, `feedback_uses`.
+- **Migration**: Destructive — pre-production, no row preservation required.
+- **Preserved invariants**:
+  - `display_order` ordering and `Meta.ordering`.
+  - Auto-increment `display_order` on save when not specified.
+  - `(parent, layer)` uniqueness via `unique_together` / `UniqueConstraint`.
+  - The same `Layer` may be assigned to multiple parents at different `display_order` values.
+
+#### Acceptance Criteria
+
+- [ ] All three through models reference `geodata_providers.Layer` directly
+- [ ] `display_order` ordering still works the same way per parent
+- [ ] The same `Layer` can be assigned to multiple parents at different `display_order` values
+- [ ] Migrations apply cleanly on a destructive reset
+- [ ] No `LayerRef` import remains in `geostories`, `events`, or `feedback`
+
+---
+
+### Issue: Task 8.2 - Remove `layerrefs` App
+
+**Labels**: `cleanup`, `migration`
+**Branch**: `feat/layerrefs-app-removal`
+
+**Description**:
+With no consumer referencing `LayerRef`, delete the app entirely. Drop the `layerrefs_layerref` table, remove the directory, deregister from `INSTALLED_APPS`, and delete the `LayerRefSerializer` from `geostories`.
+
+**Technical Details**:
+
+- **Schema cleanup**: Drop `layerrefs_layerref` table via migration.
+- **App removal**: Remove `tosca_api.apps.layerrefs` from `INSTALLED_APPS`; delete `tosca_api/apps/layerrefs/` directory.
+- **Code cleanup**: Remove `LayerRefSerializer` from `geostories/serializers.py`; remove residual imports.
+- **Doc updates**: Annotate the original Task 0.6 ("Create `layerrefs` App") with a "removed in Task 8.2" note.
+
+#### Acceptance Criteria
+
+- [ ] `INSTALLED_APPS` no longer lists `layerrefs`
+- [ ] `tosca_api/apps/layerrefs/` no longer exists
+- [ ] `LayerRefSerializer` no longer exists in `geostories`
+- [ ] `grep -R LayerRef tosca_api/` returns zero matches in production code
+- [ ] Migrations apply cleanly
+
+---
+
+### Issue: Task 8.3 - Public + Published Validation on Layer Assignment
+
+**Labels**: `feature`, `validation`
+**Branch**: `feat/layer-assignment-validation`
+
+**Description**:
+Add `clean()` validation on `GeoStoryLayer`, `EventLayer`, and `FeedbackLayer` so only layers with `is_public=True` and `publishing_state="PUBLISHED"` can be assigned. Errors must surface in admin forms and DRF serializers.
+
+**Technical Details**:
+
+- **Where**: Through-model `clean()`.
+- **Rule**: Reject layers where `is_public=False` or `publishing_state != "PUBLISHED"`.
+- **Surfaces**: Admin inline saves and DRF write serializers must surface the error as a 400 with a clear message.
+- **Docs**: Update each through model's docstring with the rule.
+
+#### Acceptance Criteria
+
+- [ ] Assigning a non-public layer is rejected from API and admin
+- [ ] Assigning a non-published layer is rejected from API and admin
+- [ ] Assigning a public + published layer succeeds
+- [ ] Existing valid through-rows continue to round-trip without revalidation errors
+
+---
+
+### Issue: Task 8.4 - `LayerSummarySerializer` and Detail Response Hydration
+
+**Labels**: `feature`, `api`
+**Branch**: `feat/layer-summary-serializer`
+
+**Description**:
+Add a slim, reusable `LayerSummarySerializer` exposing only the fields consumers need, then wire it into GeoStory, Event, and GeoFeedback detail responses so the frontend gets full layer metadata in one call.
+
+**Technical Details**:
+
+- **Fields**: `id`, `name`, `workspace` (nested `{id, name}`), `geometry_type`, `srid`, `published_url`, `is_public`, `publishing_state`.
+- **Where**: Lives in `geodata_providers` (or a shared serializers module) and is imported by the three consuming apps.
+- **Detail responses**: Replace nested layer output in GeoStory detail; add equivalent layer output to Event and GeoFeedback detail.
+- **Per-link metadata**: Each linked-layer entry must include `display_order`.
+- **Performance**: `select_related("workspace")` and `prefetch_related` on the through tables to avoid N+1 queries.
+
+#### Acceptance Criteria
+
+- [ ] GeoStory / Event / GeoFeedback detail responses include `LayerSummary` per linked layer with `display_order`
+- [ ] No N+1 queries on detail endpoints (verified via `assertNumQueries`)
+- [ ] OpenAPI schema reflects the new layer summary contract
+
+---
+
+### Issue: Task 8.5 - Replace String Layer Writes With UUID-Based Writes
+
+**Labels**: `feature`, `api`, `breaking-change`
+**Branch**: `feat/layer-uuid-writes`
+
+**Description**:
+Update the write contract for GeoStory, Event, and GeoFeedback so the `layers` payload accepts a list of `Layer.id` UUIDs (with optional `display_order`) instead of `layer_name` strings. Validation flows through the through-model `clean()` introduced in Task 8.3. This supersedes the layer sub-bullet of Task 1.3b.
+
+**Technical Details**:
+
+- **Contract shape**: `layers: [{id: <uuid>, display_order: <int>}]` or a plain UUID list with auto-incremented order.
+- **Removed**: `layer_name` string parsing path.
+- **Resolution**: UUIDs resolved to `Layer` instances and validated via through-model `clean()`.
+- **Atomicity**: Nested writes wrapped in a transaction.
+- **Schema**: Update OpenAPI for the three consumer apps.
+
+#### Acceptance Criteria
+
+- [ ] POST/PATCH bodies accept layers by UUID and persist them through the existing through models
+- [ ] Unknown / non-public / non-published UUIDs return clear 400 errors
+- [ ] String-based `layer_name` payloads are no longer accepted
+- [ ] Nested writes remain atomic
+- [ ] OpenAPI schema reflects the UUID contract
+
+---
+
+### Issue: Task 8.6 - Pre-delete Usage Warning for `Layer`
+
+**Labels**: `feature`, `admin`, `api`, `safety`
+**Branch**: `feat/layer-delete-usage-warning`
+
+**Description**:
+Before a `Layer` is deleted (admin or API), surface a count of GeoStory / Event / GeoFeedback rows that reference it via the new `geostory_uses`, `event_uses`, `feedback_uses` related managers. Admins must confirm the cascade. API deletes return the usage count in the response.
+
+**Technical Details**:
+
+- **Helper**: `Layer.usage_summary() -> dict[str, int]` using the new related managers.
+- **Admin**: Override the `Layer` delete confirmation template (or `delete_view` / `delete_selected`) to show usage counts and a warning banner.
+- **API**: `LayerViewSet.destroy` returns `409 Conflict` with the usage breakdown if usage is non-zero and `?confirm=true` is not supplied. With `?confirm=true`, cascade deletion proceeds.
+- **Schema**: Document the confirmation behavior in OpenAPI.
+
+#### Acceptance Criteria
+
+- [ ] Admin delete confirmation shows usage counts for each consuming app
+- [ ] API delete without `?confirm=true` against a referenced layer returns 409 with usage counts
+- [ ] API delete with `?confirm=true` against a referenced layer cascades and removes through-rows
+- [ ] API delete against an unused layer succeeds without requiring confirmation
+
+---
+
+### Issue: Task 8.7 - Supersede Task 1.4a and Task 1.4b
+
+**Labels**: `docs`, `cleanup`
+**Branch**: `chore/supersede-layerref-sync`
+
+**Description**:
+Mark the legacy LayerRef sync tasks as superseded by `geodata_providers`. The `geodata_providers` app already exposes `GeoServerSyncService`, `EngineClientFactory`, admin sync actions, and an `engines/{id}/sync` API path. There is no remaining work for a separate LayerRef sync client or endpoint.
+
+**Technical Details**:
+
+- **Docs only**: No code changes.
+- **Touch**: Annotate Task 1.4a and Task 1.4b entries in `tasks.md` and `issues.md` with a "Superseded by Phase 8" pointer.
+- **Phase 1 epic**: Update the `1.4a` / `1.4b` checkboxes in the Phase 1 epic to reflect supersession rather than open status.
+
+#### Acceptance Criteria
+
+- [ ] Task 1.4a and Task 1.4b are clearly marked superseded with a pointer to `GeoServerSyncService`
+- [ ] Phase 1 epic reflects the change
+
+---
+
+### Issue: Phase 9 - GeoStory Hero Image + EditorJS Image Support
+
+**Labels**: `epic`, `content`, `media`, `admin`, `api`
+
+**Goal**: Add strict image support across GeoStory and GeoContext Editor.js with authenticated backend uploads, canonical validation, and non-destructive rollout documentation.
+
+**Context**:
+GeoStories need a dedicated hero image surface for cards/details, while GeoContext Editor.js content needs first-class image block support. This phase introduces strict image policy enforcement (mime, size, dimensions, alt text), adds upload infrastructure for EditorJS images, and documents contract changes without forcing unrelated task closure.
+
+**Key Outcomes**:
+
+- **Hero Image Contract**: `GeoStory` gains Django `ImageField`-backed hero image support with required alt text.
+- **Strict Validation Policy**: Unified server-side validation across hero and EditorJS image ingestion.
+- **EditorJS Image Block Support**: Canonical `image` block validation + normalization in `core/editorjs.py`.
+- **Authenticated Upload Flow**: Backend endpoint provides EditorJS-compatible upload response.
+- **Admin Integration**: Django admin EditorJS includes image tool with vendored assets.
+- **Non-destructive Task Hygiene**: Existing open tasks are not auto-closed by this phase.
+
+#### Task List
+
+- [ ] Task 9.1: GeoStory Hero Image Storage Contract
+- [ ] Task 9.2: Strict Image Validation Policy
+- [ ] Task 9.3: Hero Image API and Admin Surface
+- [ ] Task 9.4: Extend EditorJS Contract With `image` Block
+- [ ] Task 9.5: EditorJS Image Upload Endpoint and Storage Contract
+- [ ] Task 9.6: Admin EditorJS Image Tool Integration
+- [ ] Task 9.7: Regression and Security Test Coverage
+- [ ] Task 9.8: Schema, Docs, and Supersession Notes
+
+#### Open Task Closure Notes
+
+- [x] No currently-open legacy tasks are auto-closed by Phase 9 by default.
+- [ ] If Task 9.8 updates stale image-related placeholders in older docs, mark those entries as **"Superseded by Phase 9"** (docs-only, non-destructive).
+- [x] Existing open Phase 8 tasks remain untouched unless concretely completed by separate implementation.
+
+---
+
+### Issue: Task 9.1 - GeoStory Hero Image Storage Contract
+
+**Labels**: `feature`, `media`, `model`, `migration`
+**Branch**: `feat/geostory-hero-image-model`
+
+**Description**:
+Add first-class hero image support to `GeoStory` using Django `ImageField` and required alt text. Storage must remain backend-agnostic (local or S3 via Django storage settings).
+
+**Technical Details**:
+
+- **Model fields**: `hero_image` + `hero_image_alt`.
+- **Path strategy**: namespaced upload path under `geostories/hero/...`.
+- **Storage backend**: Django storage abstraction only; no S3-specific code required in this task.
+- **Migration**: add fields to `GeoStory`.
+
+#### Acceptance Criteria
+
+- [ ] GeoStory persists hero image files via Django storage
+- [ ] Hero image alt text is required when image is set
+- [ ] Upload paths are deterministic and GeoStory-scoped
+- [ ] Migration applies cleanly
+
+---
+
+### Issue: Task 9.2 - Strict Image Validation Policy
+
+**Labels**: `feature`, `validation`, `security`, `media`
+**Branch**: `feat/image-validation-policy`
+
+**Description**:
+Implement strict server-side image validation shared by hero image and EditorJS image upload flows.
+
+**Technical Details**:
+
+- **Allowed mime**: `image/jpeg`, `image/png`, `image/webp`
+- **Max size**: `8 MB`
+- **Dimensions**: min `800x450`, max `6000x6000`
+- **Alt text**: required for hero image and EditorJS image blocks
+- **Errors**: clear per-rule failure messages
+
+#### Acceptance Criteria
+
+- [ ] Invalid mime/size/dimensions/alt fail validation with clear errors
+- [ ] Shared policy is reused by all image ingestion paths
+- [ ] Boundary values are covered by tests
+
+---
+
+### Issue: Task 9.3 - Hero Image API and Admin Surface
+
+**Labels**: `feature`, `api`, `admin`, `media`
+**Branch**: `feat/geostory-hero-image-surfaces`
+
+**Description**:
+Expose hero image fields in GeoStory serializers and admin so editors can manage hero images and API consumers can render them.
+
+**Technical Details**:
+
+- **Write surface**: serializer accepts hero image + alt
+- **Read surface**: list/detail include hero image URL + alt
+- **Admin**: hero image upload/edit + preview
+- **Validation**: policy from Task 9.2 enforced on write
+
+#### Acceptance Criteria
+
+- [ ] Create/update supports hero image and alt
+- [ ] List/detail include hero image fields
+- [ ] Invalid payloads return 400 with actionable errors
+- [ ] Admin form supports edit/preview paths
+
+---
+
+### Issue: Task 9.4 - Extend EditorJS Contract With `image` Block
+
+**Labels**: `feature`, `content`, `validation`, `security`
+**Branch**: `feat/editorjs-image-block-validation`
+
+**Description**:
+Extend canonical EditorJS validation to support strict `image` blocks with deterministic normalization.
+
+**Technical Details**:
+
+- **Module**: `tosca_api/apps/core/editorjs.py`
+- **Canonical image shape**: includes `file.url`, `alt`, `mime`, `width`, `height`, optional caption and tool booleans
+- **Validation**: URL scheme checks + strict metadata checks + key stripping
+- **Compatibility**: non-image blocks must remain unaffected
+
+#### Acceptance Criteria
+
+- [ ] Valid image blocks normalize deterministically
+- [ ] Invalid URL/mime/dimensions/alt fail validation
+- [ ] Unknown keys are stripped
+- [ ] Existing block test suite remains green
+
+---
+
+### Issue: Task 9.5 - EditorJS Image Upload Endpoint and Storage Contract
+
+**Labels**: `feature`, `api`, `media`, `security`
+**Branch**: `feat/editorjs-image-upload-endpoint`
+
+**Description**:
+Add authenticated upload endpoint for EditorJS image tool with strict validation and EditorJS-compatible response payload.
+
+**Technical Details**:
+
+- **Auth**: endpoint restricted to authorized users
+- **Storage path**: `geocontext/editorjs/...`
+- **Validation**: strict policy from Task 9.2
+- **Response**: EditorJS tool-compatible JSON contract with URL + metadata
+
+#### Acceptance Criteria
+
+- [ ] Authorized uploads succeed for valid files
+- [ ] Unauthorized requests fail with 401/403
+- [ ] Invalid uploads fail with structured 400 responses
+- [ ] Response shape is integration-compatible with EditorJS image tool
+
+---
+
+### Issue: Task 9.6 - Admin EditorJS Image Tool Integration
+
+**Labels**: `feature`, `admin`, `content`, `media`
+**Branch**: `feat/editorjs-admin-image-tool`
+
+**Description**:
+Integrate image tool into Django admin EditorJS workflow using vendored static assets and backend uploader wiring.
+
+**Technical Details**:
+
+- **Assets**: vendor image tool scripts under static vendor path
+- **Licensing**: include required upstream LICENSE files
+- **Widget media**: include image tool assets in `EditorJsWidget.Media`
+- **Init wiring**: configure tool + uploader endpoint in `init.js`
+- **Fallback**: keep no-JS textarea path intact
+
+#### Acceptance Criteria
+
+- [ ] Admin loads image tool without CDN references
+- [ ] Upload flow works through backend endpoint
+- [ ] Saved output contains canonical image blocks
+- [ ] Fallback mode remains usable
+
+---
+
+### Issue: Task 9.7 - Regression and Security Test Coverage
+
+**Labels**: `test`, `security`, `media`, `api`, `admin`
+**Branch**: `test/image-support-regressions`
+
+**Description**:
+Add broad regression coverage for new image features, including strict negative-path tests and non-image behavior safeguards.
+
+**Technical Details**:
+
+- **Model/API tests**: hero image positive + negative paths
+- **Validator tests**: valid/invalid EditorJS image blocks
+- **Upload tests**: auth + contract + malformed inputs
+- **Admin tests**: asset inclusion + canonical persistence
+- **Security tests**: unsupported schemes and malformed metadata
+
+#### Acceptance Criteria
+
+- [ ] All new image flows are covered by automated tests
+- [ ] Security-relevant negative paths are explicitly tested
+- [ ] Existing non-image functionality remains green
+
+---
+
+### Issue: Task 9.8 - Schema, Docs, and Supersession Notes
+
+**Labels**: `docs`, `schema`, `api`, `cleanup`
+**Branch**: `docs/phase9-image-contract`
+
+**Description**:
+Update OpenAPI/docs for hero image and EditorJS image contracts, and add scoped supersession notes for stale image placeholders in older docs without closing unrelated open tasks.
+
+**Technical Details**:
+
+- **OpenAPI**: include hero image fields and upload endpoint contract
+- **Examples**: add request/response payloads for hero image and EditorJS image block
+- **Migration notes**: local media storage rollout notes with Django storage backend compatibility
+- **Task hygiene**: mark stale image placeholders as "Superseded by Phase 9" only when touched
+- **Non-destructive**: do not auto-close unrelated open tasks (especially Phase 8)
+
+#### Acceptance Criteria
+
+- [ ] OpenAPI includes hero image and image-upload contract updates
+- [ ] Docs include canonical EditorJS image block examples
+- [ ] Supersession notes are scoped and non-destructive
+- [ ] Unrelated open tasks remain unchanged

--- a/docs/features-to-add_local/narrative-concept.md
+++ b/docs/features-to-add_local/narrative-concept.md
@@ -1,0 +1,158 @@
+# **Narrative Concept Document: Geostories × Calendar × Participation**
+
+---
+
+## **1. Introduction**
+
+Across cities, local challenges such as heat stress, social inequality, or disaster preparedness are often well documented — but rarely connected to direct citizen action.
+
+Digital participation tools exist, yet most focus on _either_ storytelling _or_ engagement, not both. The result is a fragmented participation landscape: people learn about problems but lack pathways to act; institutions collect feedback but miss the human story behind it.
+
+**Geostories × Calendar × Participation** proposes to close this gap. It creates a continuous loop that connects **awareness, action, and reflection** — linking place-based storytelling with participatory events and feedback cycles under a shared **Campaign** umbrella.
+
+---
+
+## **2. Campaigns: Framing Collective Missions**
+
+Every initiative begins with a **Campaign** — a strategic umbrella that sets goals, geography, partners, and success metrics.
+
+Campaigns gather all participation assets (stories, events, feedback) into one container, making it easy to understand the full scope of activity and report on holistic impact.
+
+Within a campaign, relationships operate at two levels:
+
+- **Loosely related assets**: any story, event, or feedback form tagged with the campaign is discoverable together, providing a broad view of what is happening.
+- **Direct links**: editors can explicitly connect individual assets (e.g., a story highlighting the exact events or surveys that relate to it), enabling curated experiences without losing the wider campaign context.
+
+This framing keeps the system adaptable: some campaigns may revolve around one flagship story, while others orchestrate multiple narratives, dozens of events, and specialized feedback touchpoints.
+
+## **3. From Awareness to Action: The Role of Geostories**
+
+At the heart of the system are **Geostories** — spatial narratives that combine maps, media, and data.
+
+Embedded within a Campaign, each Geostory becomes a thematic chapter: one campaign may host multiple stories that speak to different neighborhoods, demographics, or interventions, while still reinforcing the same mission.
+
+Each Geostory describes a local issue or opportunity in an accessible, story-driven way.
+
+It might show the rising heat risks in a neighborhood, patterns of green space inequality, or examples of local resilience.
+
+Unlike static reports, Geostories invite participation: they embed a call-to-action, encouraging others to respond within the same geographic and thematic frame — and, through direct links, highlight the exact events or feedback forms that continue the story.
+
+This approach reframes maps from _data displays_ to _conversation starters_. It allows institutions, companies, or researchers to share evidence-based insights while leaving space for local voices to expand and contest them.
+
+---
+
+## **4. Mobilizing Collective Action: The Calendar Connection**
+
+The **Calendar** component translates stories into organized action while keeping every activity anchored to the campaign that inspired it.
+
+When a Geostory highlights a challenge, local actors can propose **events** — workshops, discussions, or community initiatives — directly linked to that story’s area and campaign.
+
+On the public map, stories and events are visualized together: people can move seamlessly from reading about an issue to finding or creating activities that address it. Even when an event is broadly relevant to the whole campaign, direct links can surface it inside specific stories for clarity.
+
+This not only lowers the barrier for participation but also fosters collaboration between institutions and citizens.
+
+A single digital environment now hosts both _context_ (why this matters) and _opportunity_ (how to get involved).
+
+---
+
+## **5. Participation and Reflection: Integrating Feedback Loops**
+
+Meaningful participation does not end when an event concludes.
+
+The system integrates **feedback mechanisms** at multiple points inside each campaign:
+
+- **Pre-event feedback** captures perceptions about the issue introduced by a Geostory.
+- **Post-event feedback** gathers experiences and assesses whether the actions taken were perceived as helpful.
+- **Outcome analysis** aggregates results and links them back to the original story.
+- **Layer customization** allows authors to manage which map layers are visible for each story, event, or feedback form, synced on-demand from GeoServer.
+
+This structure allows both citizens and decision-makers to reflect on outcomes and adapt their next steps, and campaign dashboards aggregate the signals so that partners can evaluate the whole initiative.
+
+For example, after a series of heat-risk workshops, feedback can reveal whether residents feel more informed or prepared — turning qualitative insights into measurable learning.
+
+---
+
+## **6. The Participation Loop: A Living Knowledge Cycle**
+
+Together, these components create a **living participation loop**:
+
+1. **Campaign Framing:** an organization defines the shared mission, KPIs, and relationships it wants to nurture.
+2. **Storytelling:** the team publishes one or more Geostories to raise awareness.
+3. **Engagement:** citizens or partners create events in response.
+4. **Feedback:** participants evaluate experiences and effectiveness.
+5. **Learning:** aggregated results update the Geostory and campaign insights, closing the loop.
+
+This cyclical process transforms participation from one-off interaction into a continuous dialogue — a self-learning system that grows richer with every contribution.
+
+---
+
+## **7. Societal and Institutional Impact**
+
+### **7.1 Empowering Citizens**
+
+Citizens move from passive information consumers to active co-creators of knowledge.
+
+The ability to comment, organize, and evaluate actions builds local ownership and trust.
+
+### **7.2 Supporting Institutions**
+
+Institutions gain access to structured, location-based insights about how their initiatives are received and what real-world changes occur — not only at the story level, but across the entire campaign portfolio.
+
+This data supports evidence-based policy design, communication, and funding evaluation, while clear campaign framing simplifies governance between departments or partner organizations.
+
+### **7.3 Enabling Collaboration**
+
+Because the system is modular and open, different sectors — municipalities, insurers, NGOs, and researchers — can all work within a shared campaign environment, avoiding redundant tools and fostering joint impact.
+
+---
+
+## **8. Example Scenario**
+
+Imagine an insurance company and a city department co-author a Campaign on _urban flood resilience_ in a specific district and publish a Geostory as its opening chapter.
+
+The story presents flood maps, interviews with residents, and preventive tips.
+
+Local schools and NGOs respond by adding calendar events such as _awareness days_ or _home-protection workshops_; the most relevant ones are directly linked to the flagship story so residents can navigate easily.
+
+Participants later fill out short feedback forms describing how useful the events were and whether they changed preparedness behavior, contributing both to the story’s “Reflection” section and the campaign dashboard.
+
+These insights feed back into the original story, which now includes an “Outcome” section summarizing community response and progress.
+
+What emerges is a participatory ecosystem where **data inspires action, and action generates new data** — all connected through place and narrative.
+
+---
+
+## **9. Challenges and Caveats**
+
+While the concept promises inclusivity and adaptability, several challenges require careful design:
+
+- **Participation Sustainability:** engagement tends to decline without strong facilitation; partnerships with local intermediaries are crucial.
+- **Data Governance:** feedback collection must comply with privacy regulations and ethical standards.
+- **Content Quality:** Geostories require editorial oversight to remain accurate and representative.
+- **Equity of Voice:** ensure that under-represented communities are not overshadowed by institutional narratives.
+- **Moderation Load:** feedback moderation and spam prevention need scalable workflows.
+
+These caveats underline that technological design must go hand-in-hand with social facilitation and governance frameworks.
+
+---
+
+## **10. Future Outlook**
+
+The framework can expand in several directions:
+
+- **Cross-Domain Adaptation:** apply to health promotion, cultural heritage, climate adaptation, or education.
+- **AI-Assisted Insights:** summarize feedback trends or suggest follow-up actions automatically.
+- **Partnership Networks:** allow multiple organizations to co-author stories and share outcome analytics.
+- **Gamified Recognition:** acknowledge active contributors through badges or impact scores.
+
+Ultimately, the concept serves as a **foundation for participatory urban intelligence** — where spatial narratives, collective action, and citizen feedback continuously inform each other.
+
+---
+
+## **11. Conclusion**
+
+**Geostories × Calendar × Participation** represents a new model of civic engagement: one that blends storytelling, collective action, and evidence-based reflection into a single participatory cycle, orchestrated through campaigns.
+
+It transforms digital participation from static input collection into a dynamic, learning process — bridging the gap between data and lived experience.
+
+By embedding this cycle in an open, modular platform, cities and organizations can create living narratives that evolve with every event, every voice, and every insight contributed by the community.

--- a/docs/features-to-add_local/one-pager.md
+++ b/docs/features-to-add_local/one-pager.md
@@ -1,0 +1,75 @@
+# **🌍 One-Pager: Geostories × Calendar × Participation**
+
+### **Vision**
+
+Empower communities and institutions to move from **awareness to action to reflection** through an integrated, map-based storytelling and participation platform.
+
+---
+
+### **Concept Summary**
+
+**Geostories × Calendar × Participation** connects three layers of engagement that sit under a shared **Campaign** umbrella:
+
+1. **Campaigns** provide the strategic mission that groups related stories, events, and feedback into one participatory effort.
+2. **Geostories** communicate local challenges and opportunities through narratives, data, and maps inside that campaign.
+3. **Calendar events** translate these stories into real-world actions — workshops, clean-ups, health sessions, or citizen initiatives.
+4. **Feedback cycles** capture community experience and measure outcomes, allowing stories (and the campaign) to evolve based on collective input.
+
+Together, they create a **continuous participation loop** where insight leads to engagement, and engagement leads to learning — all tracked at the campaign level.
+
+---
+
+### **How It Works**
+
+1. **Awareness** – An organization launches a Campaign and publishes one or more Geostories describing a specific regional issue (e.g., heat risks, flood zones, social well-being).
+2. **Action** – Local actors or citizens organize events linked to that story’s area and Campaign.
+3. **Reflection** – Participants and residents give feedback before and after events to evaluate impact.
+4. **Iteration** – The Geostory and Campaign dashboard are updated with results, showing how interventions make a difference.
+
+---
+
+### **Why It Matters**
+
+- Turns **static information** into **living collaboration**.
+- Enables **evidence-based participation** by combining storytelling, events, and analytics.
+- Strengthens **cross-sector cooperation** among public institutions, researchers, NGOs, and citizens.
+- Builds **trust and transparency** through open data and feedback integration.
+
+---
+
+### **Example Use Case**
+
+A health insurer launches a *Heat Resilience Campaign* for Hamburg districts and publishes two Geostories spotlighting vulnerable neighborhoods.
+
+Community groups respond by organizing *cooling workshops* and *tree-planting events* inside the same campaign.
+
+Afterward, participants submit feedback on outcomes — forming a measurable link between **campaign, stories, action, and improvement**.
+
+---
+
+### **Impact**
+
+✅ Engages citizens in context-aware ways
+
+✅ Helps organizations evaluate interventions at both story and campaign levels
+
+✅ Promotes continuous learning in cities
+
+✅ Strengthens community resilience and collaboration
+
+---
+
+**Tagline:**
+
+> “From story to action — and from action back to insight.”
+> 
+
+## Read More
+
+---
+
+[**Analytical Concept Document: Geostories × Calendar × Participation**](analytical-concept.md)
+
+[**🌍 Narrative Concept Document: Geostories × Calendar × Participation**](narrative-concept.md)
+
+[**⚙️ Technical Architecture Document: Geostories × Calendar × Participation**](technical-architecture.md)

--- a/docs/features-to-add_local/performance-review.md
+++ b/docs/features-to-add_local/performance-review.md
@@ -1,0 +1,79 @@
+# Architecture & Performance Review
+
+Comparing our implementation plan against `postgis-checklist.md`.
+
+---
+
+## 🛑 Required Changes (We must fix these)
+
+### 1. Pagination Strategy
+
+**Checklist**: "No OFFSET pagination on spatial endpoints"
+**Current Plan**: `StandardResultsSetPagination` (PageNumberPagination uses OFFSET/LIMIT)
+**Why Change**: `OFFSET` becomes extremely slow on large datasets because the DB must verify visibility for all skipped rows. For spatial data, this performance hit is magnified.
+**Action**:
+
+- Switch all list endpoints (`/stories/`, `/events/`, `/feedback/`) to `CursorPagination`.
+- **Note**: This prevents "Jump to page 5" UI, but enables infinite scroll which is standard for feeds.
+
+### 2. Infrastructure (Production Phase)
+
+**Checklist**: "PgBouncer in front of Postgres"
+**Current Plan**: Direct Docker Compose connection.
+**Why Change**: Django opens a new connection per request. PostGIS connections are heavy memory consumers.
+**Action**: Add `pgbouncer` service to `docker-compose.prod.yml` (not critical for dev/MVP, but required before Load Testing).
+
+### 3. Spatial Indexes
+
+**Checklist**: "Every geometry column has a GiST index"
+**Current Plan**: Django creates these automatically, but we must verify.
+**Action**: Explicitly check migrations ensure `spatial_index=True` (default).
+
+---
+
+## 🛡️ Defending Our Approach (Deviations from Checklist)
+
+### 1. Primary Keys: UUID vs. BigInt
+
+**Checklist**: "Tables use BIGINT / BIGSERIAL as internal primary keys... UUIDs are external identifiers"
+**Our Approach**: Use `UUID` as the Primary Key.
+**Defense**:
+
+- **Complexity**: Dual-ID systems (internal Int ID + external UUID) add significant complexity to the application layer, serializers, and frontend logic.
+- **Distributed Identity**: Events/Stories might be synched from external systems or pushed to mobile offline caches. UUIDs guarantee uniqueness without central coordination.
+- **Performance**: For datasets under 50-100M rows, the performance penalty of UUID joins vs BigInt joins is negligible for our use case.
+- **Security**: Prevents ID enumeration attacks (scanning `/api/campaigns/1/`, `/api/campaigns/2/`).
+
+### 2. JSONB Usage
+
+**Checklist**: "No EAV tables... No JSONB filtering in hot paths"
+**Our Approach**: `GeoFeedback` uses `form_schema` (JSONB) and `FeedbackSubmission` uses `form_data` (JSONB), effectively an EAV pattern.
+**Defense**:
+
+- **Requirement Flexibility**: Administrators need to build custom forms (text, checkboxes) dynamically. Rigid columns cannot support "Survey A has Question 1" vs "Survey B has Question 2".
+- **Mitigation**: We will **NOT** filter on `form_data` values in hot paths. List API will filter by standard columns (`campaign_id`, `created_at`, `user_id`). If analytics on JSON answers are needed, we will do it via the async Analytics/Celery pipeline (read-only), not the OLTP API.
+
+### 3. Geometry SRID
+
+**Checklist**: "No runtime ST_Transform required for common queries"
+**Our Approach**: Store `SRID=4326` (Lat/Lon).
+**Defense**:
+
+- **Standard**: JSON/REST APIs standard is WGS84 (4326).
+- **Client-Side**: Modern frontend clients (MapLibre/Leaflet) handle 4326 natively. Vector tiles (MVT) do require 3857, but PostGIS `ST_AsMVT` functions handle this transformation efficiently with indexes.
+
+---
+
+## Use of "Triggers" (Checklist Point 6)
+
+**Checklist**: "No business logic implemented via triggers"
+**Our Plan**: We considered a Trigger for `FeatureLink` cross-campaign validation.
+**Defense**: Validating constraints (Data Integrity) is NOT business logic; it is schema logic. A trigger enforcing "Source and Target must share Campaign ID" is a strong consistency guarantee. However, following your earlier guidance, we will stick to **Django `clean()`** for Phase 1/2 to keep logic in Python, and only move to Triggers if we have raw SQL importers.
+
+---
+
+## Action Plan Updates
+
+1. **Update Task 0.2**: Ensure `CursorPagination` is configured as default or per-view.
+2. **Update Task 3.1**: Add note about performant JSONB usage (no deep filtering).
+3. **Infrastructure**: Add Phased task for PgBouncer setup (Phase 4 / Prod).

--- a/docs/features-to-add_local/platform-architecture.md
+++ b/docs/features-to-add_local/platform-architecture.md
@@ -1,0 +1,61 @@
+# TOSCA Platform Technical Architecture
+
+This high-level schematic illustrates the structural relationships between the core entity, the three primary feature modules (`GeoStory`, `Calendar Event`, `GeoFeedback Map`), and the shared integration data models within the backend ecosystem.
+
+```mermaid
+flowchart TD
+    %% Custom Styling
+    classDef core fill:#29b6f6,stroke:#0288d1,stroke-width:3px,color:#fff,rx:15,ry:15
+    classDef feature fill:#66bb6a,stroke:#388e3c,stroke-width:2px,color:#fff,rx:20,ry:20
+    classDef data fill:#ab47bc,stroke:#7b1fa2,stroke-width:2px,color:#fff,rx:5,ry:5
+    classDef poly fill:#ffb74d,stroke:#f57c00,stroke-width:2px,color:#000
+
+    %% Core Parent Entity
+    C{{"**Campaign**<br/><i>The Core Parent Container</i>"}}:::core
+
+    %% Feature Domains
+    subgraph Features ["Primary Feature Modules"]
+        direction LR
+        S(["**GeoStory**<br/><i>Narrative Focus</i>"]):::feature
+        E(["**Calendar Event**<br/><i>Temporal/Location Focus</i>"]):::feature
+        F(["**GeoFeedback Map**<br/><i>Citizen Engagement Focus</i>"]):::feature
+    end
+
+    %% Shared Integration Models
+    subgraph DataIntegration ["Shared Data Layers & Media Context"]
+        direction LR
+        G["**GeoContext**<br/><i>1:1 Rich Text & Media Content</i>"]:::data
+        L["**LayerRefs**<br/><i>M:N OGC Spatial Overlays</i>"]:::data
+    end
+
+    %% Polymorphic Networking
+    P[["**FeatureLinks**<br/><i>Polymorphic Generic Relationships</i>"]]:::poly
+
+    %% Relationships - Core to Features
+    C -->|Scopes & Contains| S
+    C -->|Scopes & Contains| E
+    C -->|Scopes & Contains| F
+
+    %% Relationships - Features to Data Integrations
+    S -.->|Uses 1:1| G
+    E -.->|Uses 1:1| G
+    F -.->|Uses 1:1| G
+
+    S -.->|Stacks M:N| L
+    E -.->|Stacks M:N| L
+    F -.->|Stacks M:N| L
+
+    %% Relationships - Polymorphic Cross-linking
+    S <==>|Links to/from via| P
+    E <==>|Links to/from via| P
+    F <==>|Links to/from via| P
+```
+
+### Architectural Breakdown
+
+Based on the system's database schema:
+
+1. **The Campaign Node**: All structural data must originate from a `Campaign`. It acts as the definitive scope boundary for stories, events, and feedback campaigns.
+2. **The 3 Independent Modules**: `GeoStory`, `CalendarEvent`, and `GeoFeedback` exist as independent relational nodes directly underneath the central Campaign footprint.
+3. **Shared Data Layers**: To ensure DRY (Don't Repeat Yourself) database architecture, all three core feature modules share identical structures for embedding rich HTML text (`GeoContext`) and spatial WMS mappings (`LayerRefs`).
+4. **The FeatureLink Graph**: Because the modules are horizontally separated from each other inside the database tree, the system relies on the `FeatureLinks` model, acting as a polymorphic relational graph, to let any story point natively to any event or feedback map, and vice versa.

--- a/docs/features-to-add_local/postgis-checklist.md
+++ b/docs/features-to-add_local/postgis-checklist.md
@@ -1,0 +1,210 @@
+# PostGIS Performance Checklist
+
+## Production Readiness & Incident Review
+
+### 1. Data Model & Schema
+
+Primary Keys & IDs
+• Tables use BIGINT / BIGSERIAL as internal primary keys
+• UUIDs (if any) are external identifiers, not PKs
+• No composite PKs involving geometry columns
+
+Geometry Columns
+• Geometry column has a fixed SRID
+• Geometry type is explicit (POLYGON, MULTIPOLYGON, etc.)
+• No mixed geometry types in the same column
+• No runtime ST_Transform required for common queries
+
+JSONB & Attributes
+• JSONB used only for optional metadata
+• All frequently filtered attributes are real columns
+• No EAV tables for core spatial entities
+
+⸻
+
+### 2. Spatial Indexing
+
+GiST / SP-GiST Indexes
+• Every geometry column has a GiST or SP-GiST index
+• Index created after bulk loads, not before
+• Index size reviewed (pg_relation_size)
+
+Bounding Box Usage
+• Queries use bounding box pre-filtering (&&)
+• No spatial predicate without index support
+
+Correct pattern:
+
+geom && envelope
+AND ST_Intersects(geom, envelope)
+
+Composite Indexes
+• Attribute + geometry composite indexes exist where needed
+• Index order matches query filter order
+• No unused indexes on spatial tables
+
+⸻
+
+### 3. Query Design
+
+Spatial Predicates
+• ST_Intersects used only after bounding box filtering
+• ST_DWithin preferred for proximity queries
+• No ST_Buffer or ST_Union in WHERE clauses
+
+Reprojection
+• No ST_Transform in WHERE or JOIN
+• Data stored in query SRID, not display SRID
+• Reprojection happens at ingest or output stage
+
+SELECT Shape
+• No SELECT \* in hot paths
+• Geometry only selected when needed
+• MVT queries return minimal attributes
+
+⸻
+
+### 4. Pagination & APIs
+
+Pagination Strategy
+• No OFFSET pagination on spatial endpoints
+• Keyset / cursor pagination implemented
+• Stable ordering guaranteed
+
+Tile Pipelines
+• Tile envelope filtering happens before geometry ops
+• MVT queries avoid unnecessary joins
+• Geometry simplified per zoom level
+
+⸻
+
+### 5. Transactions & Concurrency
+
+Transaction Scope
+• No long-running transactions involving spatial reads
+• Map queries are read-only and auto-commit
+• Bulk writes are batched
+
+Writes & Updates
+• Geometry updates are rare and isolated
+• No mass geometry updates in OLTP tables
+• HOT updates not assumed for geometry columns
+
+⸻
+
+### 6. Triggers & Derived Data
+
+Trigger Usage
+• No business logic implemented via triggers
+• Triggers only used for:
+• Auditing
+• Cached derived values (area, centroid)
+• Lightweight validation
+
+Derived Geometry
+• Derived geometry columns are precomputed
+• No cascading geometry recomputation
+
+⸻
+
+### 7. Partitioning & Retention
+
+Partitioning Strategy
+• Time-series spatial data is partitioned
+• Partition pruning verified with EXPLAIN
+• Partitions dropped, not deleted
+
+Retention
+• TTL or partition-drop policy exists
+• No “we’ll clean it later” data paths
+
+⸻
+
+### 8. Scaling & Infrastructure
+
+Connection Management
+• PgBouncer in front of Postgres
+• Pool size bounded and tested
+• No unbounded connection growth from map clients
+
+Read Scaling
+• Read replicas used only for read-safe queries
+• Replica lag acceptable for map use cases
+• No writes routed to replicas
+
+⸻
+
+### 9. EXPLAIN & Observability
+
+Query Analysis
+• Slow spatial queries captured
+• EXPLAIN (ANALYZE, BUFFERS) reviewed
+• Row estimate accuracy checked
+• Index usage confirmed
+
+Monitoring
+• Slow query logging enabled
+• Index bloat monitored
+• Vacuum activity observed
+• Replication lag tracked
+
+⸻
+
+### 10. Migrations & Schema Changes
+
+Spatial Migrations
+• Geometry changes follow expand / backfill / contract
+• Dual geometry columns used when needed
+• Index rebuild cost accounted for
+
+Deployment Safety
+• Migrations tested on production-sized data
+• Rollback plan exists
+• No blocking DDL in peak hours
+
+⸻
+
+### 11. Backup & Recovery
+
+Backups
+• PITR enabled
+• WAL archive tested
+• Restore tested on spatial integrity
+
+Validation
+• Geometry validity checks after restore
+• SRIDs verified
+• Indexes rebuilt if needed
+
+⸻
+
+### 12. Search & Caching
+
+Text Search
+• No LIKE '%foo%' on large tables
+• Trigram or full-text indexes used
+• Search combined safely with spatial filters
+
+Caching
+• Cache is derived state
+• Cache invalidation strategy exists
+• Tiles cached, not raw spatial queries
+
+⸻
+
+🚨 High-Risk Red Flags (Immediate Action)
+• ❌ ST_Transform in WHERE
+• ❌ Spatial query without GiST index
+• ❌ OFFSET pagination on feature APIs
+• ❌ JSONB filtering in hot paths
+• ❌ Long transactions holding spatial locks
+• ❌ Geometry updates inside OLTP traffic
+• ❌ No tested restore process
+
+⸻
+
+Recommended Usage
+• ✅ Run before production deploys
+• ✅ Use during incident response
+• ✅ Use for code reviews
+• ✅ Attach to architecture reviews

--- a/docs/features-to-add_local/proposed-event-model.md
+++ b/docs/features-to-add_local/proposed-event-model.md
@@ -1,0 +1,1692 @@
+# Proposed Event Model
+
+This document proposes the next event model for TOSCA-Backend based on:
+
+- the current `CalendarEvent` implementation
+- the existing campaign / context / layer / feature link architecture
+- the more complex field structure extracted from `Kategoriensystem.xlsx`
+- the requirement that location and provider stay inside the event core
+- the requirement that taxonomy dimensions remain dynamic for open source reuse
+
+Implementation note:
+
+- the current codebase still uses `CalendarEvent`
+- the final v2 implementation replaces `CalendarEvent` with `Event` after schema freeze
+- because the system is not yet in production, rollout may use a destructive DB reset instead of row-level backfill
+
+## Goals
+
+- Keep one stable `Event` aggregate for all event domains.
+- Keep event creation practical: one record should contain the data needed to publish an event.
+- Support richer classification without hardcoding every category into schema columns.
+- Allow different application owners to define their own taxonomy dimensions and terms.
+- Allow future domain-specific extensions such as public health, sports, culture, and politics.
+- Keep map semantics simple: only events with real spatial location appear on the map.
+
+## Core Design Decisions
+
+### 1. Event is the aggregate root
+
+`Event` owns:
+
+- schedule
+- title and description
+- location fields
+- provider fields
+- campaign and organizer references
+- visibility and lifecycle state
+- rich `GeoContext`
+
+This keeps event creation simple and avoids creating premature `Location`, `Provider`, or `Venue` models.
+
+`GeoContext` is optional enrichment rather than required identity data.
+
+For recurring content, shared context lives on `EventSeries.default_context_id`.
+
+Per-occurrence context lives on optional `Event.context_id` as an override.
+
+Effective context resolution is:
+
+- `event.context`
+- else `series.default_context`
+- else no context
+
+This keeps one shared default for a series without making multiple events point at the same mutable content row directly.
+
+Map behavior is intentionally simplified:
+
+- `physical` events appear on the map
+- `hybrid` events appear on the map
+- `online` events do not render as spatial markers on the map
+- map-screen responses still include `online` events as a separate non-spatial collection
+- spatial filters apply only to `physical` and `hybrid`
+- `online` events still honor all non-spatial filters such as campaign, date, taxonomy, status, and search
+
+### 2. Taxonomy is normalized, but dimensions are dynamic
+
+Instead of hardcoding dimensions like `topic`, `language`, or `cost_type` as an enum inside `TaxonomyTerm`, the proposal introduces:
+
+- `TaxonomyDimension`: the bucket definition
+- `TaxonomyTerm`: a term inside one dimension
+- `EventTerm`: the assignment from event to term
+
+This avoids baking one product owner's vocabulary into the schema.
+
+### 3. Hierarchy is supported inside a dimension
+
+`TaxonomyTerm.parent_term_id` allows:
+
+- broad-to-specific trees
+- roll-up analytics
+- cleaner filter UIs
+- mapping workbook pairs like `topic` -> `topicFocus`
+
+### 4. Domain-specific data lives in extension profiles
+
+`Event` remains stable. Special fields live in 1:1 extension tables such as:
+
+- `core` (no extension table required)
+- `PublicHealthEventProfile`
+- `SportsEventProfile`
+- `CultureEventProfile`
+
+The intended implementation is a combination of:
+
+- application-level validation
+- an `EventType` registry that declares which profile mode is allowed
+
+This makes the binding explicit instead of relying only on convention.
+
+### 5. Recurring and batch creation use a lightweight EventSeries model
+
+Recurring events are not modeled through `Campaign`.
+
+`Campaign` answers:
+
+- which initiative this belongs to
+
+`EventSeries` answers:
+
+- which event occurrences belong together
+- which occurrences were generated from one recurring or batch definition
+- which event is session 3 of 8
+- which occurrences were later edited as exceptions
+
+The proposal keeps all normal event data on `Event`. `EventSeries` stores only:
+
+- grouping identity
+- generation mode
+- recurrence parameters
+- explicit selected dates for manual batches
+- management metadata
+
+This keeps `Event` as the source of truth while still supporting recurring workflows.
+
+## Proposed ER Diagram
+
+```mermaid
+erDiagram
+    CAMPAIGN {
+        UUID id PK
+        VARCHAR title
+    }
+
+    USER {
+        UUID id PK
+        VARCHAR username
+    }
+
+    GEOCONTEXT {
+        UUID id PK
+        TEXT content
+        VARCHAR content_type
+    }
+
+    LAYERREF {
+        UUID id PK
+        VARCHAR layer_name UK
+    }
+
+    EVENT_TYPE {
+        UUID id PK
+        VARCHAR code UK
+        VARCHAR label
+        VARCHAR profile_mode
+        VARCHAR profile_key
+        BOOL is_active
+    }
+
+    EVENT {
+        UUID id PK
+        UUID campaign_id FK
+        UUID series_id FK
+        UUID event_type_id FK
+        UUID organizer_id FK
+        UUID context_id FK
+        VARCHAR external_id
+        VARCHAR title
+        TEXT description
+        TIMESTAMPTZ start_datetime
+        TIMESTAMPTZ end_datetime
+        VARCHAR timezone
+        VARCHAR status
+        VARCHAR visibility
+        VARCHAR location_mode
+        GEOMETRY location
+        VARCHAR venue_name
+        VARCHAR address_text
+        VARCHAR online_url
+        VARCHAR online_platform
+        VARCHAR access_notes
+        VARCHAR provider_name
+        VARCHAR provider_url
+        VARCHAR provider_contact
+        INT occurrence_index
+        BOOL is_exception
+        TIMESTAMPTZ original_start_datetime
+        JSONB metadata
+        TIMESTAMPTZ created_at
+        TIMESTAMPTZ updated_at
+    }
+
+    EVENT_SERIES {
+        UUID id PK
+        UUID campaign_id FK
+        UUID event_type_id FK
+        UUID created_by_id FK
+        UUID default_context_id FK
+        VARCHAR name
+        VARCHAR series_mode
+        VARCHAR recurrence_type
+        DATE start_date
+        DATE end_date
+        INT occurrence_count
+        INT interval
+        TIME start_time
+        TIME end_time
+        VARCHAR timezone
+        VARCHAR monthly_rule_type
+        INT day_of_month
+        INT week_of_month
+        VARCHAR weekday_of_month
+        JSONB by_weekday
+        TEXT notes
+        TIMESTAMPTZ created_at
+        TIMESTAMPTZ updated_at
+    }
+
+    EVENT_SERIES_DATE {
+        UUID id PK
+        UUID series_id FK
+        DATE occurrence_date
+        INT display_order
+    }
+
+    EVENT_LAYER {
+        UUID id PK
+        UUID event_id FK
+        UUID layer_id FK
+        INT display_order
+    }
+
+    TAXONOMY_DIMENSION {
+        UUID id PK
+        VARCHAR code UK
+        VARCHAR label
+        TEXT description
+        VARCHAR selection_mode
+        BOOL is_active
+        BOOL is_system
+        INT sort_order
+        JSONB config
+    }
+
+    TAXONOMY_TERM {
+        UUID id PK
+        UUID dimension_id FK
+        UUID parent_term_id FK
+        VARCHAR code
+        VARCHAR label
+        TEXT description
+        BOOL is_active
+        INT sort_order
+        JSONB metadata
+    }
+
+    EVENT_TERM {
+        UUID id PK
+        UUID event_id FK
+        UUID term_id FK
+        TIMESTAMPTZ created_at
+    }
+
+    PUBLIC_HEALTH_EVENT_PROFILE {
+        UUID event_id PK
+        BOOL referral_required
+        BOOL insurance_eligible
+        BOOL clinical_setting
+        JSONB health_metadata
+        TIMESTAMPTZ created_at
+        TIMESTAMPTZ updated_at
+    }
+
+    SPORTS_EVENT_PROFILE {
+        UUID event_id PK
+        JSONB sports_metadata
+        TIMESTAMPTZ created_at
+        TIMESTAMPTZ updated_at
+    }
+
+    CULTURE_EVENT_PROFILE {
+        UUID event_id PK
+        JSONB culture_metadata
+        TIMESTAMPTZ created_at
+        TIMESTAMPTZ updated_at
+    }
+
+    FEATURELINK {
+        UUID id PK
+        UUID campaign_id FK
+        INT source_content_type_id FK
+        UUID source_object_id
+        INT target_content_type_id FK
+        UUID target_object_id
+        VARCHAR link_type
+    }
+
+    CAMPAIGN ||--o{ EVENT : contains
+    CAMPAIGN ||--o{ EVENT_SERIES : contains
+    USER ||--o{ EVENT : organizes
+    USER ||--o{ EVENT_SERIES : creates
+    EVENT_TYPE ||--o{ EVENT : classifies
+    EVENT_TYPE ||--o{ EVENT_SERIES : classifies
+    GEOCONTEXT ||--o{ EVENT : enriches
+    GEOCONTEXT ||--o{ EVENT_SERIES : defaults_for
+    EVENT_SERIES ||--o{ EVENT : groups
+    EVENT_SERIES ||--o{ EVENT_SERIES_DATE : stores_dates
+
+    EVENT ||--o{ EVENT_LAYER : orders_layers
+    LAYERREF ||--o{ EVENT_LAYER : referenced_by
+
+    TAXONOMY_DIMENSION ||--o{ TAXONOMY_TERM : owns
+    TAXONOMY_TERM ||--o{ TAXONOMY_TERM : parent_of
+    EVENT ||--o{ EVENT_TERM : classified_by
+    TAXONOMY_TERM ||--o{ EVENT_TERM : assigned_to
+
+    EVENT ||--o| PUBLIC_HEALTH_EVENT_PROFILE : extends_if_public_health
+    EVENT ||--o| SPORTS_EVENT_PROFILE : extends_if_sports
+    EVENT ||--o| CULTURE_EVENT_PROFILE : extends_if_culture
+
+    EVENT ||--o{ FEATURELINK : links_to_or_from
+```
+
+## Event Type to Profile Binding
+
+`EventType` is the registry that tells the system how an event should be shaped beyond the core table.
+
+Suggested fields on `EventType`:
+
+- `code`: stable type key such as `public_health`
+- `label`: human-readable label
+- `profile_mode`: one of `core` or `extension`
+- `profile_key`: nullable key such as `public_health`, `sports`, `culture`
+
+Recommended semantics:
+
+- `profile_mode=core` means the event is fully represented by `Event` core fields and no extension table is expected.
+- `profile_mode=extension` means exactly one matching extension profile may exist.
+- `profile_key` identifies which extension profile is valid.
+
+Examples:
+
+| event_type.code | profile_mode | profile_key | meaning |
+| --- | --- | --- | --- |
+| `general` | `core` | `NULL` | no extension table needed |
+| `public_health` | `extension` | `public_health` | use `PublicHealthEventProfile` |
+| `sports` | `extension` | `sports` | use `SportsEventProfile` |
+| `culture` | `extension` | `culture` | use `CultureEventProfile` |
+
+This is intentionally a combination of:
+
+- application-level validation
+- a data-driven registry
+
+That combination gives:
+
+- clear platform behavior
+- explicit configuration in data
+- flexibility for open source deployments
+
+## Profile Binding Flow
+
+```mermaid
+flowchart TD
+    A["EventType"] --> B["profile_mode = core"]
+    A --> C["profile_mode = extension"]
+    B --> D["Event uses only core fields"]
+    C --> E["profile_key decides valid extension"]
+    E --> F["PublicHealthEventProfile"]
+    E --> G["SportsEventProfile"]
+    E --> H["CultureEventProfile"]
+```
+
+## Recurring Events and Event Series
+
+### Why we need this
+
+Without a series model, the system can create multiple events in bulk, but it cannot reliably answer:
+
+- which events belong to the same course or recurring offering
+- which event is occurrence 4 of 8
+- whether one event was manually changed after generation
+- how to update future occurrences without overwriting edited ones
+
+That leads to weak UX and weak data semantics:
+
+- bulk-created rows become unrelated events
+- stakeholders cannot track a course as a unit
+- developers cannot safely implement "edit this occurrence" versus "edit all future occurrences"
+
+`EventSeries` fixes that by giving the system a stable relation model for grouped events.
+
+### What problem it fixes
+
+It fixes the gap between:
+
+- one-off event creation
+- batch creation of multiple dates
+- recurring event generation
+
+The feature is not just "create many rows faster". It creates explicit structure for:
+
+- recurring courses
+- workshop series
+- scheduled multi-session programs
+- manually batched events that should still be treated as related
+
+### How it works
+
+Workflow:
+
+1. User starts event series creation.
+2. User enters series-level information:
+   - `name`
+   - `series_mode`
+   - recurrence fields or explicit dates
+3. User enters the common event information that should be copied into occurrences.
+4. System creates one `EventSeries` row.
+5. System creates one `Event` row per occurrence.
+6. Each generated event gets:
+   - `series_id`
+   - `occurrence_index`
+   - `original_start_datetime`
+   - `is_exception=False`
+   - inherited `campaign_id` and `event_type_id` from the series
+
+Later, if an individual occurrence is edited in a way that diverges from the generated series definition, the event becomes an exception.
+
+While an occurrence remains attached to a series, it stays bound to that series for:
+
+- `campaign_id`
+- `event_type_id`
+
+If an occurrence needs a different campaign or event type, it should be detached from the series first.
+
+### Why event data stays on Event
+
+The proposal does not make `EventSeries` a template copy of all event fields.
+
+That is intentional because:
+
+- `Event` remains the authoritative entity shown in list and map APIs
+- per-occurrence edits stay simple
+- event-specific content, status, and geometry do not need to be synchronized from a template table
+- the series model stays focused on relation and generation semantics
+
+Series exceptions may diverge on:
+
+- schedule
+- content
+- location
+
+Series exceptions should not diverge on `campaign_id` or `event_type_id` while still attached to the series.
+
+### EventSeries fields
+
+Recommended fields:
+
+- identity:
+  - `id`
+  - `campaign_id`
+  - `event_type_id`
+  - `created_by_id`
+  - `default_context_id`
+  - `name`
+- generation mode:
+  - `series_mode`
+    - `manual_batch`
+    - `recurring`
+- recurrence definition:
+  - `recurrence_type`
+    - `daily`
+    - `weekly`
+    - `monthly`
+  - `start_date`
+  - `end_date`
+  - `occurrence_count`
+  - `interval`
+  - `start_time`
+  - `end_time`
+  - `timezone`
+  - `by_weekday`
+  - `monthly_rule_type`
+  - `day_of_month`
+  - `week_of_month`
+  - `weekday_of_month`
+- explicit date definition for manual batches:
+  - one `EventSeriesDate` row per selected date
+- management:
+  - `notes`
+  - `created_at`
+  - `updated_at`
+
+### Why regular form fields instead of JSON
+
+Users should not configure recurrence with raw JSON.
+
+They should use normal form fields such as:
+
+- date picker
+- weekday selector
+- time picker
+- occurrence count input
+- interval input
+
+The recurrence model is still structured, but the authoring interface remains understandable.
+
+### Recommended form behavior
+
+For `manual_batch`:
+
+- user selects multiple explicit dates
+- user enters common event details
+- system creates one occurrence per selected date
+- selected dates are stored in `EventSeriesDate`
+
+For `recurring`:
+
+- user selects recurrence type
+- form reveals only the relevant fields for that type
+
+Examples:
+
+- weekly:
+  - every `N` weeks
+  - weekdays
+  - start date
+  - end date or occurrence count
+- monthly:
+  - every `N` months
+  - by day-of-month or nth weekday
+
+### Suggested recurring-events diagram
+
+```mermaid
+flowchart TD
+    A["Create EventSeries"] --> B["Choose series mode"]
+    B --> C["Manual batch"]
+    B --> D["Recurring"]
+    C --> E["Pick explicit dates"]
+    D --> F["Pick recurrence fields"]
+    E --> G["Fill common event data"]
+    F --> G
+    G --> H["Create EventSeries row"]
+    H --> I["Generate Event rows"]
+    I --> J["Link events with series_id"]
+    J --> K["Occurrence edits can mark is_exception=true"]
+```
+
+## Entity Responsibilities
+
+### Event
+
+`Event` is the main domain entity. It should be sufficient to create, edit, publish, and query events without forcing joins to secondary tables for basic operations.
+
+Recommended core fields:
+
+- identification: `id`, `external_id`
+- ownership: `campaign_id`, `organizer_id`
+- typing: `event_type_id`
+- content: `title`, `description`, `context_id`
+- schedule: `start_datetime`, `end_datetime`, `timezone`
+- computed: `duration_minutes` (derived from `start_datetime` and `end_datetime`)
+- lifecycle: `status`, `visibility`
+- location: `location_mode`, `location`, `venue_name`, `address_text`, `online_url`, `online_platform`, `access_notes`
+- provider: `provider_name`, `provider_url`, `provider_contact`
+- flexible extras: `metadata`
+
+Spatial semantics:
+
+- `location` is the real map geometry
+- `location_mode=online` means the event is non-spatial for map rendering
+- no target-area geometry or target-area relation is used in this simplified proposal
+- map responses return online events separately from spatial GeoJSON
+- `series_id` links an event to a recurring or batch group when applicable
+- `occurrence_index` stores series ordering
+- `is_exception` marks an occurrence that diverged from the original generated series definition
+
+### EventSeries
+
+`EventSeries` is a grouping and recurrence-definition model.
+
+It is not the canonical event data store. Its job is to:
+
+- express relation between occurrences
+- persist how the series was generated
+- support batch and recurring creation
+- enable "edit this event" versus "edit future events" workflows
+- hold the default shared context for the series
+
+Examples:
+
+- 8-week self-awareness course
+- 6-session Pilates class
+- manually selected set of open-house dates
+
+### EventSeriesDate
+
+`EventSeriesDate` stores explicit chosen dates for `manual_batch` series.
+
+This avoids:
+
+- losing the original user selection after events are generated
+- storing a raw JSON date list
+- treating manual batches as opaque one-time generation requests
+
+### Time and Timezone Rules
+
+Concrete event datetimes use `TIMESTAMPTZ`.
+
+Recurrence definitions use:
+
+- local wall-clock fields such as `start_time` and `end_time`
+- a required IANA timezone such as `Europe/Berlin`
+
+Recurring expansion happens in `EventSeries.timezone`, not in UTC.
+
+DST rule:
+
+- recurring occurrences keep the same local time in the series timezone across DST transitions
+- UTC instants may shift when DST changes
+
+### TaxonomyDimension
+
+`TaxonomyDimension` defines a classification bucket.
+
+Examples:
+
+- `topic`
+- `target_group`
+- `language`
+- `accessibility`
+- `cost_type`
+- `provider_type`
+- `custom_audience_segment`
+
+This is dynamic on purpose so different deployments can define their own dimensions.
+
+Suggested fields:
+
+- `code`: stable machine key such as `topic`
+- `label`: human-readable label
+- `selection_mode`: `single` or `multiple`
+- `is_system`: whether the dimension is platform-provided and protected
+- `config`: optional UI and validation settings
+
+### TaxonomyTerm
+
+`TaxonomyTerm` defines one allowed value in one dimension.
+
+Examples:
+
+- dimension `topic` -> term `physical_health`
+- dimension `topic` -> term `cardiovascular`
+- dimension `target_group` -> term `seniors`
+- dimension `language` -> term `german`
+
+### EventTerm
+
+`EventTerm` is the join table that attaches taxonomy terms to events.
+
+It exists because:
+
+- an event can have many terms
+- the same term can be used by many events
+- terms remain reusable and manageable
+
+### Extension Profiles
+
+Extension profiles hold only fields that do not belong in all events.
+
+Examples:
+
+- no profile row for `profile_mode=core`
+- `PublicHealthEventProfile.insurance_eligible`
+- `PublicHealthEventProfile.referral_required`
+
+The enforcement rule should be:
+
+- `EventType.profile_mode=core` -> no extension profile row is expected
+- `EventType.profile_mode=extension` -> only the matching profile table is valid
+- mismatched profile rows must be rejected
+
+## Why Dynamic Dimensions Instead of an Enum
+
+An enum-based `dimension` field assumes the product team already knows every dimension the platform will ever need.
+
+That assumption is too narrow for an open source platform. Different adopters may need:
+
+- public health dimensions
+- culture-specific dimensions
+- sports-specific dimensions
+- custom local categories
+- domain-specific filters that do not exist today
+
+Dynamic dimensions let owners add those categories without a schema migration.
+
+Use a table instead of an enum when:
+
+- the platform is meant to be adapted by third parties
+- administrators may define new classification buckets
+- the same backend should support multiple domains
+
+## Why Support Parent / Child Terms
+
+Hierarchy solves three real problems:
+
+- broad filters: searching for `physical_health` can include all subtopics
+- analytics rollups: `cardiovascular` events can count under `physical_health`
+- workbook mapping: pairs like `topic` / `topicFocus` map naturally to parent / child terms
+
+Examples:
+
+- `physical_health`
+  - `cardiovascular`
+  - `respiratory`
+- `provider_type`
+  - `hospital`
+  - `ngo`
+  - `insurance`
+
+Hierarchy is optional per term. Flat dimensions can still exist.
+
+## Constraints
+
+### Event constraints
+
+- `campaign_id` is required.
+- `event_type_id` is required.
+- `organizer_id` is required.
+- `title` is required and sanitized.
+- `end_datetime >= start_datetime`.
+- `duration_minutes` is a computed property (not stored).
+- `status` must be one of the supported lifecycle values.
+- `visibility` must be one of the supported access values.
+- `location_mode` must be one of `physical`, `online`, `hybrid`.
+- `online_url` is required when `location_mode` is `online`.
+- `location` is required when `location_mode` is `physical`.
+- `location` and `online_url` are required when `location_mode` is `hybrid`.
+- `location` should be empty or ignored when `location_mode` is `online`.
+- if `series_id` is present, `occurrence_index >= 1`.
+- `(series_id, occurrence_index)` should be unique when `series_id` is not null.
+- if `is_exception=True`, `series_id` must be present.
+- if `is_exception=True` because of a datetime override, `original_start_datetime` should be preserved.
+
+### TaxonomyDimension constraints
+
+- `code` must be globally unique.
+- `selection_mode` must be one of `single` or `multiple`.
+- `sort_order >= 0`.
+
+### TaxonomyTerm constraints
+
+- `dimension_id` is required.
+- `(dimension_id, code)` must be unique.
+- parent and child must belong to the same dimension.
+- cycles in the parent chain must be rejected (enforced via parent chain traversal with a max depth of 10).
+- `sort_order >= 0`.
+
+### EventTerm constraints
+
+- `(event_id, term_id)` must be unique.
+- a term from an inactive dimension should not be assignable.
+- if the dimension has `selection_mode=single`, only one term from that dimension may be attached to the event.
+
+### Extension profile constraints
+
+- profile row must exist only for matching `event_type`.
+- `event_type.profile_mode=core` must not have an extension profile row.
+- `event_type.profile_mode=extension` may require exactly one matching profile row, depending on product rules.
+- `event_id` is both PK and FK to `Event.id`.
+
+### EventSeries constraints
+
+- `campaign_id` is required.
+- `event_type_id` is required.
+- `created_by_id` is required.
+- `series_mode` must be one of `manual_batch` or `recurring`.
+- `recurrence_type` is required when `series_mode=recurring`.
+- `manual_batch` series must have at least one `EventSeriesDate`.
+- exactly one termination strategy should be used for recurring series:
+  - `end_date`
+  - or `occurrence_count`
+- `interval >= 1`.
+- `occurrence_count >= 1` when present.
+- same-day events: `end_time > start_time`. Multi-day events: `end_date` combined with `end_time` must be after `start_date` combined with `start_time`.
+- weekly recurrence requires at least one weekday.
+- `by_weekday` values must be valid day names (`monday` through `sunday`).
+- monthly recurrence requires a `monthly_rule_type`:
+  - `day_of_month` requires `day_of_month` value
+  - `nth_weekday` requires `week_of_month` and `weekday_of_month` values
+
+Note:
+
+- the "must have at least one `EventSeriesDate`" rule is best enforced in the service layer or serializer transaction, because related dates may not yet exist during the first `EventSeries.clean()` call.
+
+### EventSeriesDate constraints
+
+- `(series_id, occurrence_date)` must be unique.
+- `display_order >= 1`.
+
+## Validation Rules
+
+Validation should exist at two levels:
+
+- database constraints for integrity
+- Django `clean()` / serializer validation for user-facing errors
+
+Recommended validation logic:
+
+1. Validate schedule consistency.
+2. Validate location consistency based on `location_mode`.
+3. Validate taxonomy assignments against `selection_mode`.
+4. Validate taxonomy parent-child dimension consistency.
+5. Detect and reject cycles in taxonomy parent chains (max depth 10).
+6. Validate extension profile existence against `event_type.profile_mode` and `event_type.profile_key`.
+7. Validate series recurrence definition including weekday values and monthly rules.
+8. Validate generated occurrences against the series.
+9. Sanitize all simple text fields before persistence.
+
+Recurring-specific validation rules:
+
+- `manual_batch` must provide at least one persisted `EventSeriesDate`.
+- selected explicit dates must be unique.
+- generated occurrence datetimes must be unique within one series unless duplicate sessions are explicitly allowed.
+- a generated event moved to a different datetime should be marked `is_exception=True`.
+- if a user edits an individual occurrence datetime, the system should preserve `original_start_datetime`.
+- if a future series update would overwrite an exception occurrence, the exception must be skipped unless the user explicitly chooses to reset it.
+
+## Example Data
+
+### Example dimensions
+
+| code | label | selection_mode |
+| --- | --- | --- |
+| `topic` | Topic | `multiple` |
+| `target_group` | Target Group | `multiple` |
+| `language` | Language | `multiple` |
+| `cost_type` | Cost Type | `single` |
+| `provider_type` | Provider Type | `single` |
+
+### Example terms
+
+| dimension | code | label | parent |
+| --- | --- | --- | --- |
+| `topic` | `physical_health` | Physical Health | `NULL` |
+| `topic` | `cardiovascular` | Cardiovascular | `physical_health` |
+| `target_group` | `seniors` | Seniors | `NULL` |
+| `language` | `german` | German | `NULL` |
+| `provider_type` | `insurance` | Insurance Provider | `NULL` |
+
+### Example event
+
+| field | value |
+| --- | --- |
+| `title` | Heart Health Screening Day |
+| `event_type` | `public_health` |
+| `location_mode` | `physical` |
+| `address_text` | Example Clinic, Hamburg |
+| `provider_name` | Health Insurance A |
+| `start_datetime` | `2026-05-12T09:00:00+02:00` |
+| `end_datetime` | `2026-05-12T13:00:00+02:00` |
+| `visibility` | `public` |
+
+### Example event-term assignments
+
+| event | term |
+| --- | --- |
+| Heart Health Screening Day | `cardiovascular` |
+| Heart Health Screening Day | `seniors` |
+| Heart Health Screening Day | `german` |
+| Heart Health Screening Day | `insurance` |
+
+### Example recurring series
+
+| field | value |
+| --- | --- |
+| `name` | Self-Awareness Course Spring 2026 |
+| `series_mode` | `recurring` |
+| `recurrence_type` | `weekly` |
+| `interval` | `1` |
+| `start_date` | `2026-04-07` |
+| `occurrence_count` | `8` |
+| `by_weekday` | `["tuesday"]` |
+| `start_time` | `18:00` |
+| `end_time` | `19:30` |
+| `timezone` | `Europe/Berlin` |
+
+Generated occurrences:
+
+| occurrence_index | start_datetime | end_datetime |
+| --- | --- | --- |
+| `1` | `2026-04-07T18:00:00+02:00` | `2026-04-07T19:30:00+02:00` |
+| `2` | `2026-04-14T18:00:00+02:00` | `2026-04-14T19:30:00+02:00` |
+| `3` | `2026-04-21T18:00:00+02:00` | `2026-04-21T19:30:00+02:00` |
+
+### Example manual batch series dates
+
+| display_order | occurrence_date |
+| --- | --- |
+| `1` | `2026-05-03` |
+| `2` | `2026-05-17` |
+| `3` | `2026-06-01` |
+
+## How the Workbook Maps to This Model
+
+The extracted workbook structure maps cleanly:
+
+- `offerType` -> taxonomy dimension
+- `offerFocus` -> child term or secondary term in the same dimension
+- `topic` -> taxonomy dimension
+- `topicFocus` -> child term in the same dimension
+- `targetGroup` -> taxonomy dimension
+- `setting` -> taxonomy dimension
+- `participationMode` -> taxonomy dimension
+- `costType` -> taxonomy dimension
+- `accessibility` -> taxonomy dimension
+- `languageSupport` -> taxonomy dimension
+- `providerType` -> taxonomy dimension
+- `providerTypeFocus` -> child term
+
+Free-text fields from the workbook belong in `Event` core:
+
+- `name` -> `title`
+- `description` -> `description`
+- `location` -> `address_text` or `venue_name`
+- `startDate`, `endDate`, `Time`, `Duration` -> schedule fields
+- `provider`, `URL / Social Media`, `contact` -> provider fields
+
+## Python Model Snippets
+
+These are proposal snippets, not drop-in production code.
+
+Implementation sequencing notes after 2B.4:
+
+- The live code already includes minimal placeholder `EventType` and `EventSeries` models because `2B.2` referenced them before `2B.7` and `2B.12`.
+- `Event.context` is already implemented as a nullable override `ForeignKey`, and effective context resolution already follows `event.context -> series.default_context -> none`.
+- The GiST requirement for `Event.location` is currently satisfied by GeoDjango's implicit spatial index.
+- Later tasks should extend the existing placeholder `EventType` and `EventSeries` models in place instead of reintroducing them.
+- Because the new event rollout allows destructive resets, schema tightening can prefer direct reshaping over compatibility backfills.
+
+```python
+import uuid
+
+from django.conf import settings
+from django.contrib.contenttypes.fields import GenericRelation
+from django.contrib.gis.db import models as gis_models
+from django.core.exceptions import ValidationError
+from django.core.validators import MinValueValidator
+from django.db import models
+
+from tosca_api.apps.core.models import TimeStampedModel
+from tosca_api.apps.core.sanitization import sanitize_simple
+
+
+class EventType(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    code = models.SlugField(unique=True)
+    label = models.CharField(max_length=255)
+    profile_mode = models.CharField(max_length=20, default="core")
+    profile_key = models.SlugField(blank=True, default="")
+    is_active = models.BooleanField(default=True)
+
+
+class TaxonomyDimension(models.Model):
+    class SelectionMode(models.TextChoices):
+        SINGLE = "single", "Single"
+        MULTIPLE = "multiple", "Multiple"
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    code = models.SlugField(unique=True)
+    label = models.CharField(max_length=255)
+    description = models.TextField(blank=True, default="")
+    selection_mode = models.CharField(
+        max_length=20,
+        choices=SelectionMode.choices,
+        default=SelectionMode.MULTIPLE,
+    )
+    is_active = models.BooleanField(default=True)
+    is_system = models.BooleanField(default=False)
+    sort_order = models.PositiveIntegerField(default=0)
+    config = models.JSONField(default=dict, blank=True)
+
+
+class TaxonomyTerm(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    dimension = models.ForeignKey(
+        TaxonomyDimension,
+        on_delete=models.CASCADE,
+        related_name="terms",
+    )
+    parent = models.ForeignKey(
+        "self",
+        on_delete=models.PROTECT,
+        null=True,
+        blank=True,
+        related_name="children",
+    )
+    code = models.SlugField()
+    label = models.CharField(max_length=255)
+    description = models.TextField(blank=True, default="")
+    is_active = models.BooleanField(default=True)
+    sort_order = models.PositiveIntegerField(default=0)
+    metadata = models.JSONField(default=dict, blank=True)
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["dimension", "code"],
+                name="uq_taxonomy_term_dimension_code",
+            ),
+        ]
+
+    def clean(self):
+        errors = {}
+
+        if self.parent and self.parent.dimension_id != self.dimension_id:
+            errors["parent"] = "Parent must be in the same dimension."
+
+        # Cycle detection: walk the parent chain up to a max depth
+        if self.parent:
+            MAX_DEPTH = 10
+            visited = {self.pk}
+            current = self.parent
+            depth = 0
+            while current is not None and depth < MAX_DEPTH:
+                if current.pk in visited:
+                    errors["parent"] = "Circular parent chain detected."
+                    break
+                visited.add(current.pk)
+                current = current.parent
+                depth += 1
+            if depth >= MAX_DEPTH:
+                errors["parent"] = f"Parent chain exceeds maximum depth of {MAX_DEPTH}."
+
+        if errors:
+            raise ValidationError(errors)
+
+
+class Event(TimeStampedModel):
+    class Status(models.TextChoices):
+        DRAFT = "draft", "Draft"
+        PUBLISHED = "published", "Published"
+        CANCELLED = "cancelled", "Cancelled"
+        ARCHIVED = "archived", "Archived"
+
+    class Visibility(models.TextChoices):
+        PUBLIC = "public", "Public"
+        PRIVATE = "private", "Private"
+
+    class LocationMode(models.TextChoices):
+        PHYSICAL = "physical", "Physical"
+        ONLINE = "online", "Online"
+        HYBRID = "hybrid", "Hybrid"
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    external_id = models.CharField(max_length=255, blank=True, default="")
+    campaign = models.ForeignKey(
+        "campaigns.Campaign",
+        on_delete=models.CASCADE,
+        related_name="events",
+    )
+    event_type = models.ForeignKey(EventType, on_delete=models.PROTECT)
+    organizer = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.PROTECT,
+        related_name="organized_events",
+    )
+    title = models.CharField(max_length=255)
+    description = models.TextField(blank=True, default="")
+    context = models.ForeignKey(
+        "geocontext.GeoContext",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="events",
+    )
+    start_datetime = models.DateTimeField()
+    end_datetime = models.DateTimeField()
+    timezone = models.CharField(max_length=64, default="UTC")
+    status = models.CharField(
+        max_length=20,
+        choices=Status.choices,
+        default=Status.DRAFT,
+        db_index=True,
+    )
+    visibility = models.CharField(
+        max_length=20,
+        choices=Visibility.choices,
+        default=Visibility.PUBLIC,
+    )
+    location_mode = models.CharField(
+        max_length=20,
+        choices=LocationMode.choices,
+        default=LocationMode.PHYSICAL,
+    )
+    location = gis_models.PointField(srid=4326, null=True, blank=True)
+    venue_name = models.CharField(max_length=255, blank=True, default="")
+    address_text = models.TextField(blank=True, default="")
+    online_url = models.URLField(blank=True, default="")
+    online_platform = models.CharField(max_length=255, blank=True, default="")
+    access_notes = models.TextField(blank=True, default="")
+    provider_name = models.CharField(max_length=255, blank=True, default="")
+    provider_url = models.URLField(blank=True, default="")
+    provider_contact = models.TextField(blank=True, default="")
+    series = models.ForeignKey(
+        "EventSeries",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="events",
+    )
+    occurrence_index = models.PositiveIntegerField(null=True, blank=True)
+    is_exception = models.BooleanField(default=False)
+    original_start_datetime = models.DateTimeField(null=True, blank=True)
+    metadata = models.JSONField(default=dict, blank=True)
+
+    layers = models.ManyToManyField(
+        "layerrefs.LayerRef",
+        through="EventLayer",
+        related_name="events",
+        blank=True,
+    )
+
+    # Reverse generic relations for cascading deletes of FeatureLinks
+    feature_links_source = GenericRelation(
+        "featurelinks.FeatureLink",
+        content_type_field="source_content_type",
+        object_id_field="source_object_id",
+        related_query_name="event_source",
+    )
+    feature_links_target = GenericRelation(
+        "featurelinks.FeatureLink",
+        content_type_field="target_content_type",
+        object_id_field="target_object_id",
+        related_query_name="event_target",
+    )
+
+    @property
+    def duration_minutes(self):
+        """Computed from start_datetime and end_datetime."""
+        if self.start_datetime and self.end_datetime:
+            delta = self.end_datetime - self.start_datetime
+            return int(delta.total_seconds() / 60)
+        return None
+
+    def clean(self):
+        errors = {}
+
+        if self.end_datetime < self.start_datetime:
+            errors["end_datetime"] = "End must be after start."
+
+        if self.location_mode == self.LocationMode.ONLINE and not self.online_url:
+            errors["online_url"] = "Online events require an online URL."
+
+        if self.location_mode == self.LocationMode.ONLINE and self.location:
+            errors["location"] = "Online events should not have map geometry."
+
+        if self.location_mode == self.LocationMode.PHYSICAL and not (
+            self.location or self.address_text or self.venue_name
+        ):
+            errors["location_mode"] = "Physical events require a physical location."
+
+        if self.location_mode == self.LocationMode.HYBRID:
+            if not self.online_url:
+                errors["online_url"] = "Hybrid events require an online URL."
+            if not (self.location or self.address_text or self.venue_name):
+                errors["location_mode"] = "Hybrid events require a physical location."
+
+        if self.is_exception and not self.series_id:
+            errors["is_exception"] = "Only series events can be marked as exceptions."
+
+        if self.series_id and self.occurrence_index is None:
+            errors["occurrence_index"] = "Series events require an occurrence index."
+
+        if errors:
+            raise ValidationError(errors)
+
+    def save(self, *args, **kwargs):
+        self.title = sanitize_simple(self.title)
+        self.description = sanitize_simple(self.description)
+        self.full_clean()
+        super().save(*args, **kwargs)
+
+
+VALID_WEEKDAYS = frozenset(
+    ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"]
+)
+
+
+class EventSeries(TimeStampedModel):
+    class SeriesMode(models.TextChoices):
+        MANUAL_BATCH = "manual_batch", "Manual Batch"
+        RECURRING = "recurring", "Recurring"
+
+    class RecurrenceType(models.TextChoices):
+        DAILY = "daily", "Daily"
+        WEEKLY = "weekly", "Weekly"
+        MONTHLY = "monthly", "Monthly"
+
+    class MonthlyRuleType(models.TextChoices):
+        DAY_OF_MONTH = "day_of_month", "Day of Month"
+        NTH_WEEKDAY = "nth_weekday", "Nth Weekday"
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    campaign = models.ForeignKey(
+        "campaigns.Campaign",
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+    )
+    event_type = models.ForeignKey(
+        EventType,
+        on_delete=models.PROTECT,
+        null=True,
+        blank=True,
+    )
+    created_by = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.PROTECT)
+    default_context = models.ForeignKey(
+        "geocontext.GeoContext",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="default_for_event_series",
+    )
+    name = models.CharField(max_length=255)
+    series_mode = models.CharField(max_length=20, choices=SeriesMode.choices)
+    recurrence_type = models.CharField(
+        max_length=20,
+        choices=RecurrenceType.choices,
+        blank=True,
+        default="",
+    )
+    start_date = models.DateField()
+    end_date = models.DateField(null=True, blank=True)
+    occurrence_count = models.PositiveIntegerField(null=True, blank=True)
+    interval = models.PositiveIntegerField(default=1)
+    start_time = models.TimeField()
+    end_time = models.TimeField()
+    timezone = models.CharField(max_length=64, default="Europe/Berlin")
+    monthly_rule_type = models.CharField(
+        max_length=20,
+        choices=MonthlyRuleType.choices,
+        blank=True,
+        default="",
+    )
+    day_of_month = models.PositiveSmallIntegerField(null=True, blank=True)
+    week_of_month = models.PositiveSmallIntegerField(null=True, blank=True)
+    weekday_of_month = models.CharField(max_length=20, blank=True, default="")
+    by_weekday = models.JSONField(default=list, blank=True)
+    notes = models.TextField(blank=True, default="")
+
+    def clean(self):
+        import datetime
+
+        errors = {}
+
+        if self.interval < 1:
+            errors["interval"] = "Interval must be at least 1."
+
+        # Validate using combined date + time to support multi-day events
+        if self.start_date and self.start_time and self.end_time:
+            start_dt = datetime.datetime.combine(self.start_date, self.start_time)
+            # If end_time <= start_time, the event spans into the next day
+            if self.end_date:
+                end_dt = datetime.datetime.combine(self.end_date, self.end_time)
+            else:
+                end_dt = datetime.datetime.combine(self.start_date, self.end_time)
+            if end_dt <= start_dt and not self.end_date:
+                errors["end_time"] = (
+                    "End time must be after start time for same-day events. "
+                    "Use end_date for multi-day events."
+                )
+
+        if self.series_mode == self.SeriesMode.RECURRING:
+            if not self.recurrence_type:
+                errors["recurrence_type"] = "Recurring series require a recurrence type."
+            if bool(self.end_date) == bool(self.occurrence_count):
+                errors["end_date"] = "Use either end_date or occurrence_count."
+            if self.recurrence_type == self.RecurrenceType.WEEKLY and not self.by_weekday:
+                errors["by_weekday"] = "Weekly recurrence requires at least one weekday."
+
+            # Validate by_weekday values
+            if self.by_weekday:
+                invalid = set(self.by_weekday) - VALID_WEEKDAYS
+                if invalid:
+                    errors["by_weekday"] = (
+                        f"Invalid weekday values: {invalid}. "
+                        f"Allowed: {sorted(VALID_WEEKDAYS)}."
+                    )
+
+            # Validate monthly recurrence rules
+            if self.recurrence_type == self.RecurrenceType.MONTHLY:
+                if not self.monthly_rule_type:
+                    errors["monthly_rule_type"] = (
+                        "Monthly recurrence requires a monthly rule type."
+                    )
+                elif self.monthly_rule_type == self.MonthlyRuleType.DAY_OF_MONTH:
+                    if not self.day_of_month:
+                        errors["day_of_month"] = (
+                            "Day-of-month rule requires day_of_month."
+                        )
+                elif self.monthly_rule_type == self.MonthlyRuleType.NTH_WEEKDAY:
+                    if not self.week_of_month or not self.weekday_of_month:
+                        errors["monthly_rule_type"] = (
+                            "Nth-weekday rule requires week_of_month and weekday_of_month."
+                        )
+
+        if self.series_mode == self.SeriesMode.MANUAL_BATCH and self.recurrence_type:
+            errors["recurrence_type"] = "Manual batches must not define a recurrence type."
+
+        if errors:
+            raise ValidationError(errors)
+
+
+class EventSeriesDate(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    series = models.ForeignKey(
+        EventSeries,
+        on_delete=models.CASCADE,
+        related_name="dates",
+    )
+    occurrence_date = models.DateField()
+    display_order = models.PositiveIntegerField(validators=[MinValueValidator(1)])
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["series", "occurrence_date"],
+                name="uq_event_series_date",
+            ),
+        ]
+
+
+class EventTerm(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    event = models.ForeignKey(Event, on_delete=models.CASCADE, related_name="event_terms")
+    term = models.ForeignKey(
+        TaxonomyTerm,
+        on_delete=models.CASCADE,
+        related_name="event_terms",
+    )
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["event", "term"],
+                name="uq_event_term",
+            ),
+        ]
+```
+
+## Example Test Cases
+
+```python
+import pytest
+from django.core.exceptions import ValidationError
+
+
+@pytest.mark.django_db
+def test_online_event_requires_online_url(event_factory):
+    event = event_factory(location_mode="online", online_url="")
+    with pytest.raises(ValidationError):
+        event.full_clean()
+
+
+@pytest.mark.django_db
+def test_online_event_rejects_map_geometry(event_factory, point_factory):
+    event = event_factory(
+        location_mode="online",
+        online_url="https://example.org/live",
+        location=point_factory(),
+    )
+    with pytest.raises(ValidationError):
+        event.full_clean()
+
+
+@pytest.mark.django_db
+def test_event_rejects_end_before_start(event_factory):
+    event = event_factory(
+        start_datetime="2026-05-12T10:00:00Z",
+        end_datetime="2026-05-12T09:00:00Z",
+    )
+    with pytest.raises(ValidationError):
+        event.full_clean()
+
+
+@pytest.mark.django_db
+def test_hybrid_event_requires_location_and_online_url(event_factory, point_factory):
+    event = event_factory(
+        location_mode="hybrid",
+        location=point_factory(),
+        online_url="",
+    )
+    with pytest.raises(ValidationError):
+        event.full_clean()
+
+
+@pytest.mark.django_db
+def test_series_event_requires_occurrence_index(event_factory, series_factory):
+    series = series_factory()
+    event = event_factory(series=series, occurrence_index=None)
+    with pytest.raises(ValidationError):
+        event.full_clean()
+
+
+@pytest.mark.django_db
+def test_exception_requires_series(event_factory):
+    event = event_factory(is_exception=True, series=None)
+    with pytest.raises(ValidationError):
+        event.full_clean()
+
+
+@pytest.mark.django_db
+def test_taxonomy_term_parent_must_share_dimension(term_factory, dimension_factory):
+    topic = dimension_factory(code="topic")
+    language = dimension_factory(code="language")
+    parent = term_factory(dimension=topic, code="physical_health")
+    child = term_factory.build(dimension=language, parent=parent, code="german")
+
+    with pytest.raises(ValidationError):
+        child.full_clean()
+
+
+@pytest.mark.django_db
+def test_event_term_is_unique(event, term):
+    EventTerm.objects.create(event=event, term=term)
+    with pytest.raises(Exception):
+        EventTerm.objects.create(event=event, term=term)
+
+
+@pytest.mark.django_db
+def test_single_select_dimension_allows_only_one_term(
+    event, term_factory, dimension_factory
+):
+    cost_type = dimension_factory(code="cost_type", selection_mode="single")
+    free = term_factory(dimension=cost_type, code="free")
+    paid = term_factory(dimension=cost_type, code="self_pay")
+
+    EventTerm.objects.create(event=event, term=free)
+
+    with pytest.raises(ValidationError):
+        validate_dimension_assignment(event=event, new_term=paid)
+
+
+@pytest.mark.django_db
+def test_public_health_profile_requires_public_health_event_type(
+    public_health_profile_factory, event_factory, event_type_factory
+):
+    culture_type = event_type_factory(code="culture")
+    event = event_factory(event_type=culture_type)
+
+    with pytest.raises(ValidationError):
+        public_health_profile_factory.build(event=event).full_clean()
+
+
+@pytest.mark.django_db
+def test_core_profile_mode_rejects_extension_profile(
+    public_health_profile_factory, event_factory, event_type_factory
+):
+    general_type = event_type_factory(code="general", profile_mode="core")
+    event = event_factory(event_type=general_type)
+
+    with pytest.raises(ValidationError):
+        public_health_profile_factory.build(event=event).full_clean()
+
+
+@pytest.mark.django_db
+def test_weekly_series_requires_weekday(series_factory):
+    series = series_factory(
+        series_mode="recurring",
+        recurrence_type="weekly",
+        by_weekday=[],
+    )
+    with pytest.raises(ValidationError):
+        series.full_clean()
+
+
+@pytest.mark.django_db
+def test_recurring_series_requires_one_end_strategy(series_factory):
+    series = series_factory(
+        series_mode="recurring",
+        recurrence_type="weekly",
+        end_date="2026-06-01",
+        occurrence_count=8,
+    )
+    with pytest.raises(ValidationError):
+        series.full_clean()
+
+
+@pytest.mark.django_db
+def test_manual_batch_dates_must_be_unique(series_factory, series_date_factory):
+    series = series_factory(series_mode="manual_batch")
+    series_date_factory(series=series, occurrence_date="2026-05-03", display_order=1)
+
+    with pytest.raises(Exception):
+        series_date_factory(series=series, occurrence_date="2026-05-03", display_order=2)
+```
+
+## Edge Cases
+
+- imported events may have only free-text location and no coordinates
+- online events may have no physical address at all
+- hybrid events require both physical location and URL
+- an event type may switch from `core` to `extension` after data already exists
+- a recurring series may contain an occurrence moved to another date or time
+- a recurring series may contain one cancelled occurrence
+- a user may edit one event in a series after generation
+- a user may edit the series after some events have already been manually changed
+- daylight saving time may shift perceived local event times
+- manual batch creation may contain duplicate dates
+- a manual batch series may later add or remove one explicit date
+- taxonomy terms may become inactive after events were already tagged
+- a parent term may be removed while children still exist
+- two deployments may want different dimensions with the same label but different semantics
+- imported source data may use inconsistent vocabulary that needs term mapping before ingestion
+- `duration_minutes` is computed from `start_datetime` and `end_datetime` and cannot disagree
+- events may exist without taxonomy terms during draft creation
+- taxonomy parent chain may form cycles if validation is bypassed (enforced at max depth 10)
+
+## Recommended Handling of Edge Cases
+
+- allow draft events with incomplete taxonomy
+- require stronger validation only at publish time
+- treat `EventType` changes as controlled admin actions, not casual edits
+- if imported physical events have no coordinates, keep them out of the map endpoint until geocoded or manually corrected
+- when an occurrence datetime is changed manually, set `is_exception=True`
+- store the generated datetime in `original_start_datetime` before manual override
+- future series updates should update only non-exception future events by default
+- provide an explicit reset action if the user wants to re-align an exception with the series
+- validate generated datetimes against timezone-aware recurrence rules
+- for manual batches, added dates should generate new occurrences and removed dates should only delete untouched future occurrences
+- use `PROTECT` or soft-deactivation for taxonomy parents that still have children
+- keep imported source IDs in `external_id`
+- `duration_minutes` is always computed from `start_datetime` and `end_datetime`; no stored field to drift
+- treat `metadata` as non-critical extension data, not as a substitute for first-class fields
+
+## API and Query Implications
+
+This proposal supports:
+
+- a dedicated map API returning GeoJSON
+- a dedicated list API returning paginated JSON
+- recurring and manual-batch event generation
+- linked event occurrences through `EventSeries`
+- filter events by campaign
+- filter events by time range
+- spatial filtering by point geometry
+- filter by one or more taxonomy dimensions
+- aggregate by parent taxonomy terms for dashboards
+
+Recommended endpoint split:
+
+- `GET /api/v1/events/map/`
+  - returns `spatial_events` as GeoJSON and `online_events` as a plain JSON collection
+  - includes `physical` and `hybrid` events in `spatial_events`
+  - includes `online` events in `online_events`
+  - supports the same query parameters as the list endpoint
+- `GET /api/v1/events/list/`
+  - returns one chronological mixed paginated JSON stream
+  - supports the same query parameters as the map endpoint
+  - uses `location_mode` to distinguish `physical`, `hybrid`, and `online`
+  - powers the floating online-event card and standard list view
+
+Shared filter model:
+
+- both endpoints accept the same filters
+- only the response structure changes
+- map endpoint returns GeoJSON features
+- list endpoint returns list/detail-friendly JSON
+
+Recommended shared filters:
+
+- `campaign_id`
+- `status`
+- `visibility`
+- `start_after`
+- `start_before`
+- `include_past`
+- `location_mode`
+- taxonomy filters such as `dimension`, `term`
+- search filters such as free-text title or provider search
+- geometry filters such as `bbox` or polygon `within`
+
+Recommended semantics:
+
+- map API and list API use the same filtering contract
+- map API returns:
+  - `spatial_events` as GeoJSON
+  - `online_events` as a separate JSON collection
+- list API returns one chronological mixed stream in non-GeoJSON form
+- clients use `location_mode` to distinguish `physical`, `hybrid`, and `online`
+- the frontend can render spatial features from `spatial_events` and render online events in the floating card or side-panel component
+- when a geometry filter is present, spatial events are filtered by geometry and online events remain included
+- non-spatial filters such as campaign, date, taxonomy, status, and search still apply to online events
+
+Example behavior with `bbox`:
+
+- `physical` and `hybrid` events must intersect the `bbox` to be included
+- `online` events are still included in the separate non-spatial collection
+- final result set = spatial matches plus online events that pass the other filters
+
+Likely API patterns:
+
+- `GET /api/v1/events/map/?campaign_id=...`
+- `GET /api/v1/events/map/?bbox=...`
+- `GET /api/v1/events/list/?campaign_id=...`
+- `GET /api/v1/events/list/?term=cardiovascular`
+- `GET /api/v1/events/list/?dimension=topic&term=cardiovascular`
+- `GET /api/v1/events/list/?location_mode=online`
+- `POST /api/v1/event-series/preview/`
+- `POST /api/v1/event-series/`
+- `PATCH /api/v1/event-series/{id}/`
+
+Current implementation note:
+
+- the `event-series` preview/create/update endpoints above are now implemented as the canonical recurrence authoring surface
+- `PATCH /api/v1/event-series/{id}/` updates only future non-exception occurrences by default
+- direct edits to generated occurrences through `/api/v1/events/{id}/` mark the row as `is_exception=true`
+- recurring generation currently assumes same-day occurrence duration because `EventSeries.end_date` is already serving as the recurrence termination field; multi-day recurring occurrences would require explicit schema support later
+- the shared event filter layer now supports `event_type_id` in addition to campaign/date/status/visibility/taxonomy filters
+- event-series template `location` input is now validated as GeoJSON `Point` data at the serializer layer before model save
+
+## Index Recommendations
+
+- `event(campaign_id)`
+- `event(start_datetime, end_datetime)`
+- `event(event_type_id, status)`
+- `event USING GIST(location)`
+- `taxonomy_dimension(code)` unique
+- `taxonomy_term(dimension_id, code)` unique
+- `event_term(event_id, term_id)` unique
+- `event_term(term_id)` for reverse filtering
+
+## Migration Notes from Current CalendarEvent
+
+The current implementation in [events/models.py](/Users/gokturkburakkose/Documents/dev/TOSCA-Backend/tosca_api/apps/events/models.py) can evolve incrementally:
+
+1. Rename or conceptually replace `CalendarEvent` with `Event`.
+2. Add `event_type`.
+3. Add location mode and online/provider fields.
+4. Split map and list API behavior by `location_mode`.
+5. Add `EventSeries` plus `series_id`, `occurrence_index`, `is_exception`, and `original_start_datetime` on events.
+6. Add `EventSeries.default_context` plus optional `Event.context` override, and keep `EventLayer` and `FeatureLink` patterns.
+7. Introduce `TaxonomyDimension`, `TaxonomyTerm`, and `EventTerm`.
+8. Add `PublicHealthEventProfile` after the core event migration is stable.
+
+This avoids overloading the first migration with too many conceptual changes.
+
+Practical note for local test environments: the repository uses a reusable `test_tosca` database in some workflows. After destructive event-schema changes, reset or repair that reusable test DB before treating failures involving old event tables or content types as current regressions.
+
+## Summary
+
+The proposed model keeps the parts that need to be simple inside `Event` core:
+
+- location
+- provider
+- schedule
+- basic content
+
+It externalizes only the parts that need reuse, flexibility, or hierarchy:
+
+- taxonomy dimensions
+- taxonomy terms
+- event-term assignments
+- domain-specific extension profiles
+- recurring relation and generation metadata in `EventSeries`
+
+It also makes event type behavior explicit:
+
+- some event types are `core` only
+- some event types require an extension profile
+- the allowed profile is declared by `EventType`
+
+And it keeps spatial behavior simple:
+
+- only `physical` and `hybrid` events have real geometry
+- `online` events remain non-spatial and are returned separately from map GeoJSON
+- map and list retrieval use separate APIs with the same filter contract
+
+It also makes recurring behavior explicit:
+
+- related occurrences are grouped by `EventSeries`
+- each occurrence is still a normal `Event`
+- per-occurrence edits are supported through exception tracking
+
+That is the balance that best fits the conversation so far:
+
+- simple authoring
+- extensible classification
+- open source adaptability
+- future event domain support without repeated schema redesign

--- a/docs/features-to-add_local/providerapi.md
+++ b/docs/features-to-add_local/providerapi.md
@@ -1,0 +1,266 @@
+# API List
+
+Full layer detayları olan `featuretype & coverage` objeleri kabarık olduğu için bütün providerların bütün layerlarını tek apide çekmek doğru olmayacak. O yüzden önce providerları ve altlarındaki workspaceleri listeleyelim sonra da bu workspaceler ile layer detaylarını çekelim. Bunun için gerekenler:
+
+## 1. Provider List
+
+`provider/list`
+
+Providerları listeler. Buradan provider id'lerini, diğer attributelarını ve özellikle workspace listesini çekeriz. Buradan alınan workspace bilgileri (muhtemelen id) ile de layer detaylarına gideriz. Tahmini payload şöyle olabilir:
+
+```json
+{
+    "providers": [
+        {
+            "name": "Provider name",
+            "id": 1,
+            "url": "belki gerekir",
+            "type": "geoserver ya da martin",
+            "workspaces": [
+                {
+                    "name": "hamburg",
+                    "id": 1,
+                },
+                {
+                    "name": "poi",
+                    "id": 2
+                }
+            ]
+        }
+    ]
+}
+```
+
+## 2. Workspace Detail
+
+`provider/{providerID}/workspaces/{workspaceID}`
+
+Burada workspace altındaki layerların detaylarını çekeriz. Bu layer objeleri sende vardı not olarak. Yine tahmini şöyle bişey olabilir.
+
+```json
+{
+    "name": "hamburg",
+    "id": 1,
+    "layers": [
+        {
+            "type": "RASTER | VECTOR",
+            "coverage": "eğer rastersa",
+            "featureType": "eğer vectorse",
+            "layerInfo": "ilk layer apisinden çektiğimiz şeyler burada"
+        }
+    ]
+}
+```
+
+Bunlar da `coverage`, `featureType` ve `layerInfo` objelerinin typeları. Bu objelerin içinde geoserver urlleri var onları bi düşünüp çıkartmak gerekir.
+
+```ts
+/**
+ * Buradan name, title, attributelist, keywords gibi bilgileri alıyoruz ama fazlasını da kullanabiliriz. Covarege için de aynısı geçerli sadece obje değiştiği için iki farklı type var.
+ */
+export interface GeoServerVectorTypeLayerDetail {
+  featureType: {
+    name: string;
+    nativeName: string;
+    namespace: {
+      name: string;
+      href: string;
+    };
+    title: string;
+    abstract: string;
+    keywords: {
+      string: string[];
+    };
+    nativeCRS: string;
+    srs: string;
+    nativeBoundingBox: {
+      minx: number;
+      maxx: number;
+      miny: number;
+      maxy: number;
+      crs: string;
+    };
+    latLonBoundingBox: {
+      minx: number;
+      maxx: number;
+      miny: number;
+      maxy: number;
+      crs: string;
+    };
+    projectionPolicy: string;
+    enabled: boolean;
+    store: {
+      "@class": string;
+      name: string;
+      href: string;
+    };
+    serviceConfiguration: boolean;
+    simpleConversionEnabled: boolean;
+    internationalTitle: string;
+    internationalAbstract: string;
+    maxFeatures: number;
+    numDecimals: number;
+    padWithZeros: boolean;
+    forcedDecimal: boolean;
+    overridingServiceSRS: boolean;
+    skipNumberMatched: boolean;
+    circularArcPresent: boolean;
+    attributes: {
+      attribute: GeoServerFeatureTypeAttribute[];
+    };
+  };
+}
+```
+
+```ts
+export interface GeoserverRasterTypeLayerDetail {
+  coverage: {
+    name: string,
+    nativeName: string,
+    namespace: {
+      name: string,
+      href: string
+    },
+    title: string,
+    description: string,
+    keywords: {
+      string: string[]
+    },
+    nativeCRS: string
+    srs: string,
+    nativeBoundingBox: {
+      minx: number,
+      maxx: number,
+      miny: number,
+      maxy: number,
+      crs: string
+    },
+    latLonBoundingBox: {
+      minx: number,
+      maxx: number,
+      miny: number,
+      maxy: number,
+      crs: string
+    },
+    projectionPolicy: string,
+    enabled: boolean,
+    metadata: {
+      entry: Array<Record<string, unknown>>
+    },
+    store: {
+      "@class": string,
+      name: string,
+      href: string
+    },
+    serviceConfiguration: boolean,
+    simpleConversionEnabled: boolean,
+    internationalTitle: string,
+    internationalAbstract: string,
+    nativeFormat: string,
+    grid: {
+      "@dimension": number,
+      range: {
+        low: string,
+        high: string
+      },
+      transform: {
+        scaleX: string,
+        scaleY: string,
+        shearX: number,
+        shearY: number,
+        translateX: number,
+        translateY: number
+      },
+      crs: string
+    },
+    supportedFormats: {
+      string: string[]
+    },
+    interpolationMethods: {
+      string: string[]
+    },
+    defaultInterpolationMethod: string,
+    dimensions: {
+      coverageDimension: Array<Record<string, unknown>>
+    },
+    requestSRS: {
+      string: string
+    },
+    responseSRS: {
+      string: string
+    },
+    parameters: {
+      entry: Array<Record<string, unknown>>
+    },
+    nativeCoverageName: string
+  }
+}
+```
+
+```ts
+/**
+ * Buradan özellikle default stili ve varsa diğer stilleri alıyoruz. Ama created, updated gibi alanları da storeda layerları listelerken kullanabiliriz.
+ */
+export interface GeoserverLayerInfo {
+  name: string;
+  type: string;
+  defaultStyle: {
+    name: string;
+    href: string;
+  };
+  resource: {
+    "@class": string;
+    name: string;
+    href: string;
+  };
+  attribution: {
+    logoWidth: number;
+    logoHeight: number;
+  };
+  dateCreated: string;
+  dateModified: string
+  styles: {
+  "@class": string;
+  style: [
+    {
+        name: string;
+        href: string;
+    },
+    {
+        name: string;
+        href: string;
+    }
+  ]
+}
+}
+```
+
+## 3. Style List
+
+`styles/list`
+
+Bütün stilleri listeler. Şu an için mbstyle'lar ana hedef ama sonrasında sld işine de bakmak lazım raster layerların stillerini değiştirmek için. layer requestini o stille atmalık
+
+```json
+{
+    "styles":[
+        {
+            "name": "Parcel",
+            "id": 1,
+            "type": "mbstyle",
+        }
+    ]
+}
+```
+
+## 4. Style Detail
+
+`styles/{styleID}`
+
+İstenen stili verir.
+
+```json
+{
+    "mbstyleobjesi":"direkt olarak mbstyle objesini response dönelim."
+}
+```

--- a/docs/features-to-add_local/tasks.md
+++ b/docs/features-to-add_local/tasks.md
@@ -1,0 +1,3255 @@
+# Implementation Tasks: Geostories × Calendar × Participation
+
+> Each task is a separate branch/PR. Merge to main before starting next task.
+
+---
+
+## Open Questions — Decision Guide
+
+### 1. FeatureLink Validation: PostgreSQL Trigger vs Django `clean()`
+
+| Approach                  | Pros                                                                                                | Cons                                                                     |
+| ------------------------- | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| **PostgreSQL Trigger**    | Enforced at DB level (impossible to bypass), works even for raw SQL imports, single source of truth | Harder to debug, requires SQL knowledge, logic duplicated outside Django |
+| **Django `clean()` only** | Pythonic, easier to test, all logic in one place, better error messages for API                     | Can be bypassed by raw SQL, bulk operations may skip validation          |
+| **Hybrid** (recommended)  | Best of both: Django provides UX-friendly errors, DB prevents data corruption                       | Slightly more maintenance                                                |
+
+**Recommendation**: Start with **Django `clean()` only** for Phase 2. Add DB trigger in a later hardening phase if needed. Rationale: Easier to iterate, all operations go through Django anyway, and we can add the trigger later without breaking changes.
+
+---
+
+### 3. Media Assets: MediaAsset Model vs FileField
+
+| Approach                        | Pros                                                                               | Cons                                                  |
+| ------------------------------- | ---------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| **FileField directly on model** | Simple, no extra models, Django handles storage                                    | No reusability, no metadata, harder to manage orphans |
+| **Dedicated MediaAsset model**  | Reusable across features, supports metadata (alt text, dimensions), easier cleanup | More complexity, extra joins                          |
+
+**Recommendation**: Use **FileField for MVP** (`cover_image = models.ImageField(...)`). Create MediaAsset in a future "Media Management" phase when we need shared assets, galleries, or video support.
+
+---
+
+## Phase 0: Infrastructure (Tech Stack Fixes)
+
+> **Goal**: Prepare the codebase for GeoDjango and PostGIS features.
+
+---
+
+### Task 0.1: Add GDAL to Docker Image
+
+**Branch**: `feat/gdal-docker`
+
+**Description**: Install GDAL/GEOS/PROJ libraries in the Django Docker image to enable GeoDjango.
+
+**Changes**:
+
+- [x] Update `docker/django/Dockerfile` to install `gdal-bin`, `libgdal-dev`, `libgeos-dev`, `libproj-dev`
+- [x] Rebuild image and verify GDAL is accessible
+
+**Acceptance Criteria**:
+
+- [x] `docker compose build django` succeeds
+- [x] Inside container: `python -c "from django.contrib.gis.gdal import HAS_GDAL; print(HAS_GDAL)"` prints `True`
+- [x] Inside container: `gdalinfo --version` returns version info
+
+**Tests**:
+
+```bash
+# Manual verification after container starts
+docker compose exec django python -c "from django.contrib.gis.gdal import HAS_GDAL; print('GDAL available:', HAS_GDAL)"
+docker compose exec django gdalinfo --version
+```
+
+**Commit Message**:
+
+```text
+feat(docker): add GDAL/GEOS/PROJ to Django image
+
+Install geospatial libraries required for GeoDjango:
+- gdal-bin, libgdal-dev
+- libgeos-dev
+- libproj-dev
+
+This enables django.contrib.gis for PostGIS geometry fields.
+```
+
+---
+
+### Task 0.2: Configure GeoDjango in Settings
+
+**Branch**: `feat/geodjango-config`
+
+**Description**: Enable GeoDjango by updating Django settings to use PostGIS backend.
+
+**Changes**:
+
+- [x] Add `django.contrib.gis` to `INSTALLED_APPS` in `settings/base.py`
+- [x] Change database engine from `django.db.backends.postgresql` to `django.contrib.gis.db.backends.postgis`
+
+**Acceptance Criteria**:
+
+- [x] `make up` starts without errors
+- [x] `python manage.py check` passes
+- [x] `python manage.py dbshell` connects and `SELECT PostGIS_Version();` returns version
+
+**Tests**:
+
+```bash
+docker compose exec django python manage.py check
+docker compose exec django python -c "from django.contrib.gis.db import models; print('GeoDjango OK')"
+docker compose exec django python manage.py dbshell -c "SELECT PostGIS_Version();"
+```
+
+**Commit Message**:
+
+```
+feat(settings): configure GeoDjango with PostGIS backend
+
+- Add django.contrib.gis to INSTALLED_APPS
+- Switch database engine to django.contrib.gis.db.backends.postgis
+
+Enables use of PointField, GeometryField for spatial models.
+
+- **Check**: Ensure `CursorPagination` is configured as the default pagination class in settings or for spatial viewsets (avoids OFFSET performance issues).
+
+```
+
+---
+
+### Task 0.3: Verify PostGIS Extension
+
+**Branch**: `feat/postgis-verify`
+
+**Description**: Verify PostGIS extension is enabled and document verification in tests.
+
+**Changes**:
+
+- [x] Add a simple test in `tosca_api/apps/core/tests/test_postgis.py` to verify PostGIS
+- [x] Verify `init001.sh` has `CREATE EXTENSION IF NOT EXISTS postgis;` (already present ✓)
+
+**Acceptance Criteria**:
+
+- [x] Test passes: `pytest tosca_api/apps/core/tests/test_postgis.py -v --ds=tosca_api.settings.base`
+- [x] PostGIS version query works from Django
+
+**Tests**:
+
+```python
+# tosca_api/apps/core/tests/test_postgis.py
+import pytest
+from django.db import connection
+
+@pytest.mark.django_db
+def test_postgis_extension_enabled():
+    """Verify PostGIS extension is available."""
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT PostGIS_Version();")
+        version = cursor.fetchone()[0]
+        assert version is not None
+        assert "3." in version  # PostGIS 3.x
+```
+
+**Commit Message**:
+
+```
+test(core): add PostGIS extension verification test
+
+Add test to ensure PostGIS is enabled and accessible.
+This catches misconfiguration early in CI/CD.
+```
+
+---
+
+### Task 0.4: Create `campaigns` App Skeleton
+
+**Branch**: `feat/campaigns-app`
+
+**Description**: Create the campaigns app with Campaign model (no API yet).
+
+**Changes**:
+
+- [x] Create `tosca_api/apps/campaigns/` directory structure
+- [x] Add `Campaign` model with fields: id (UUID), title, summary, status, visibility, created_by, timestamps
+- [x] Register in `INSTALLED_APPS`
+- [x] Create and apply migrations
+- [x] Register in Django Admin
+
+**Acceptance Criteria**:
+
+- [x] `python manage.py makemigrations campaigns` succeeds
+- [x] `python manage.py migrate` succeeds
+- [x] Campaign model visible in Django Admin
+- [x] Can create Campaign via Admin UI
+
+**Tests**:
+
+```python
+# tosca_api/apps/campaigns/tests/test_models.py
+import pytest
+from django.contrib.auth import get_user_model
+from tosca_api.apps.campaigns.models import Campaign
+
+User = get_user_model()
+
+@pytest.mark.django_db
+def test_campaign_creation():
+    user = User.objects.create_user(username="testuser", password="testpass")
+    campaign = Campaign.objects.create(
+        title="Test Campaign",
+        created_by=user
+    )
+    assert campaign.id is not None
+    assert campaign.status == Campaign.Status.DRAFT
+    assert campaign.visibility == Campaign.Visibility.PRIVATE
+
+@pytest.mark.django_db
+def test_campaign_str():
+    user = User.objects.create_user(username="testuser", password="testpass")
+    campaign = Campaign.objects.create(title="My Campaign", created_by=user)
+    assert str(campaign) == "My Campaign"
+```
+
+**Commit Message**:
+
+```
+feat(campaigns): add Campaign model
+
+Create campaigns app with core Campaign model:
+- UUID primary key
+- title, summary fields
+- status enum (draft/active/archived)
+- visibility enum (public/private)
+- created_by FK to User
+- timestamps (created_at, updated_at)
+
+Includes Django Admin registration and model tests.
+```
+
+---
+
+### Task 0.5: Create `geocontext` App
+
+**Branch**: `feat/geocontext-app`
+
+**Description**: Create the geocontext app for shared rich text content.
+
+**Changes**:
+
+- [x] Create `tosca_api/apps/geocontext/` with GeoContext model
+- [x] Fields: id (UUID), content, content_type (simple/rich), created_by, timestamps
+- [x] Register in `INSTALLED_APPS`, Admin, migrations
+
+**Acceptance Criteria**:
+
+- [x] Migrations apply successfully
+- [x] Model visible in Admin
+- [x] Tests pass
+
+**Tests**:
+
+```python
+# tosca_api/apps/geocontext/tests/test_models.py
+import pytest
+from django.contrib.auth import get_user_model
+from tosca_api.apps.geocontext.models import GeoContext
+
+User = get_user_model()
+
+@pytest.mark.django_db
+def test_geocontext_creation():
+    user = User.objects.create_user(username="testuser", password="testpass")
+    ctx = GeoContext.objects.create(
+        content="Sample content",
+        created_by=user
+    )
+    assert ctx.id is not None
+    assert ctx.content_type == GeoContext.ContentType.SIMPLE
+```
+
+**Commit Message**:
+
+```
+feat(geocontext): add GeoContext model
+
+Create geocontext app for shareable content blocks:
+- UUID primary key
+- content TextField
+- content_type enum (simple/rich)
+- created_by FK
+- timestamps
+
+Will be linked 1:1 to GeoStory, CalendarEvent, GeoFeedback.
+```
+
+---
+
+### Task 0.6: Create `layerrefs` App
+
+**Branch**: `feat/layerrefs-app`
+
+**Description**: Create the layerrefs app for GeoServer layer pointers.
+
+**Changes**:
+
+- [x] Create `tosca_api/apps/layerrefs/` with LayerRef model
+- [x] Fields: id (UUID), layer_name (unique), created_at
+- [x] Register in `INSTALLED_APPS`, Admin, migrations
+
+**Acceptance Criteria**:
+
+- [x] Migrations apply
+- [x] LayerRef enforces unique layer_name
+- [x] Tests pass
+
+**Tests**:
+
+```python
+# tosca_api/apps/layerrefs/tests/test_models.py
+import pytest
+from django.db import IntegrityError
+from tosca_api.apps.layerrefs.models import LayerRef
+
+@pytest.mark.django_db
+def test_layerref_creation():
+    ref = LayerRef.objects.create(layer_name="workspace:roads")
+    assert ref.id is not None
+
+@pytest.mark.django_db
+def test_layerref_unique_name():
+    LayerRef.objects.create(layer_name="workspace:roads")
+    with pytest.raises(IntegrityError):
+        LayerRef.objects.create(layer_name="workspace:roads")
+```
+
+**Commit Message**:
+
+```
+feat(layerrefs): add LayerRef model
+
+Create layerrefs app for GeoServer layer references:
+- UUID primary key
+- layer_name (unique, format: workspace:layer)
+- created_at timestamp
+
+Minimal model - just a pointer for M2M with features.
+```
+
+---
+
+## Phase 1: GeoStory Feature
+
+> **Goal**: First complete feature with CRUD API.
+
+---
+
+### Task 1.1: Create `geostories` App with GeoStory Model
+
+**Branch**: `feat/geostories-model`
+
+**Description**: Create geostories app with GeoStory model and M2M to LayerRef.
+
+**Changes**:
+
+- [x] Create `tosca_api/apps/geostories/` with GeoStory, GeoStoryLayer models
+- [x] Fields: id, campaign (FK), title, summary, status, author (FK), context (OneToOne), layers (M2M), timestamps
+- [x] Register in `INSTALLED_APPS`, Admin, migrations
+
+**Acceptance Criteria**:
+
+- [x] GeoStory links to Campaign and GeoContext
+- [x] GeoStoryLayer junction table with display_order
+- [x] Tests pass
+
+**Tests**:
+
+```python
+@pytest.mark.django_db
+def test_geostory_with_layers():
+    # Setup campaign, user, layers
+    story = GeoStory.objects.create(campaign=campaign, title="Test", author=user)
+    layer = LayerRef.objects.create(layer_name="workspace:test")
+    GeoStoryLayer.objects.create(geostory=story, layer=layer, display_order=1)
+    assert story.layers.count() == 1
+```
+
+**Commit Message**:
+
+```
+feat(geostories): add GeoStory and GeoStoryLayer models
+
+Create geostories app with:
+- GeoStory: FK to Campaign, OneToOne to GeoContext
+- GeoStoryLayer: M2M junction with display_order
+- Status enum (draft/published/archived)
+
+Includes Admin registration and model tests.
+```
+
+---
+
+### Task 1.2: Campaign API Endpoints (Read-Only/Basic CRUD)
+
+**Branch**: `feat/campaigns-api`
+
+**Description**: Add REST API for Campaign CRUD.
+
+**Changes**:
+
+- [x] Create `serializers.py`, `views.py`, `urls.py` in campaigns app
+- [x] Endpoints: `GET/POST /api/v1/campaigns/`, `GET/PATCH /api/v1/campaigns/{id}/`
+- [x] Wire to main urls.py
+
+**Acceptance Criteria**:
+
+- [x] API returns 401 for unauthenticated requests
+- [x] Authenticated user can create and list campaigns
+- [x] Tests pass
+
+**Tests**:
+
+```python
+@pytest.mark.django_db
+def test_campaign_list_authenticated(api_client, user):
+    api_client.force_authenticate(user=user)
+    response = api_client.get("/api/v1/campaigns/")
+    assert response.status_code == 200
+```
+
+**Commit Message**:
+
+```
+feat(campaigns): add REST API endpoints
+
+Implement Campaign API:
+- GET /api/v1/campaigns/ - list campaigns
+- POST /api/v1/campaigns/ - create campaign
+- GET /api/v1/campaigns/{id}/ - retrieve
+- PATCH /api/v1/campaigns/{id}/ - update
+
+Uses DRF ModelViewSet with authentication.
+- **Performance**: Use `CursorPagination` to avoid OFFSET scanning on large datasets.
+
+```
+
+---
+
+### Task 1.2a: API Documentation (Swagger/OpenAPI)
+
+**Branch**: `feat/api-docs`
+
+**Description**: Integrate `drf-spectacular` for auto-generated API documentation.
+
+**Changes**:
+
+- [x] Add `drf-spectacular` to dependencies via `uv add`
+- [x] Configure `SPECTACULAR_SETTINGS` in `settings/base.py`
+- [x] Add schema and documentation views to `urls.py`
+- [x] Verify `/api/schema/`, `/api/docs/` endpoints
+
+**Acceptance Criteria**:
+
+- [x] Swagger UI accessible at `/api/docs/`
+- [x] Schema downloads correctly
+- [x] Campaign API visible in documentation
+
+**Commit Message**:
+
+```
+feat(docs): integrate drf-spectacular
+
+Add OpenAPI 3.0 support via drf-spectacular:
+- /api/schema/ (YAML)
+- /api/docs/ (Swagger UI)
+- /api/redoc/ (Redoc)
+```
+
+---
+
+### Task 1.2b: Authentication API Documentation
+
+**Branch**: `feat/auth-docs-fix`
+
+**Description**:
+The `authentication` app currently generates warnings in the Swagger/OpenAPI schema generation because custom authentication classes and views are not properly annotated for `drf-spectacular`. This task is to fix those warnings and ensure `KeycloakTokenAuthentication` is properly documented in the schema.
+
+**Issues to Fix**:
+
+1. **Unresolved Authenticator**: `KeycloakTokenAuthentication` is not recognized by `drf-spectacular`.
+   - _Fix_: Implement an `OpenApiAuthenticationExtension`.
+2. **Missing Serializers**: `test_token_auth` and other function-based views lack serializer definitions.
+   - _Fix_: Use `@extend_schema` to define request/response bodies or serializers.
+
+**Implementation Plan**:
+
+1. Create `tosca_api/apps/authentication/schema.py`:
+   - Register `KeycloakTokenAuthenticationScheme` extension.
+   - Define `Bearer <token>` security scheme.
+2. Update `tosca_api/apps/authentication/views.py`:
+   - Add `@extend_schema` to `test_token_auth`.
+   - Verify other views like `KeycloakLogoutView` or `KeycloakRedirectView` if they are API views.
+
+**Acceptance Criteria**:
+
+- [ ] No warnings in `docker compose logs django` regarding `OpenApiAuthenticationExtension` or `unable to guess serializer`.
+- [ ] Swagger UI shows "Authorize" button compatible with Bearer tokens.
+- [ ] `test_token_auth` endpoint appears in documentation with correct response schema.
+
+**Commit Message**:
+
+```
+feat(auth): fix api documentation warnings
+
+- Register KeycloakTokenAuthentication with drf-spectacular.
+- Add schema annotations to authentication views.
+```
+
+---
+
+### Task 1.3a: GeoStory Basic CRUD API
+
+**Branch**: `feat/geostories-api-basic`
+
+**Description**: Add REST API for GeoStory core fields (Title, Summary, Status).
+
+**Changes**:
+
+- [x] Create serializers, views, urls in geostories app
+- [x] Standard ModelViewSet for GeoStory
+- [x] Filter by campaign_id query param
+
+**Acceptance Criteria**:
+
+- [x] Can create/list/update GeoStory objects
+- [x] Validation: Title required, Campaign valid
+- [x] Tests pass
+
+**Tests**:
+
+```python
+@pytest.mark.django_db
+def test_geostory_api_creation(api_client, user, campaign):
+    api_client.force_authenticate(user=user)
+    resp = api_client.post("/api/v1/stories/", {"title": "Story 1", "campaign": campaign.id})
+    assert resp.status_code == 201
+```
+
+**Commit Message**:
+
+```
+feat(geostories): add basic REST API endpoints
+
+Implement GeoStory API:
+- GET/POST /api/v1/stories/
+- GET/PATCH/DELETE /api/v1/stories/{id}/
+
+Basic CRUD only (no nested writes yet).
+```
+
+---
+
+### Task 1.3b: GeoStory Nested Writes (Context & Layers)
+
+**Branch**: `feat/geostories-api-nested`
+
+**Description**: Enable creating/updating GeoContext and Layer links inline with GeoStory.
+
+**Changes**:
+
+- [ ] Update `GeoStorySerializer.create/update` to handle `context` dict
+- [ ] Update `GeoStorySerializer.create/update` to handle `layers` list
+- [ ] Use atomic transaction for writes
+
+**Acceptance Criteria**:
+
+- [ ] POST includes `context: {"content": "..."}` -> Creates GeoContext
+- [ ] POST includes `layers: ["workspace:roads"]` -> Creates GeoStoryLayer links
+- [ ] Tests pass for nested creation
+
+**Tests**:
+
+```python
+@pytest.mark.django_db
+def test_nested_creation_full(api_client, user, campaign, layer):
+    payload = {
+        "title": "Full Story",
+        "campaign": campaign.id,
+        "context": {"content": "Rich text here"},
+        "layers": [layer.layer_name]
+    }
+    resp = api_client.post("/api/v1/stories/", payload)
+    assert resp.data['context']['content'] == "Rich text here"
+    assert resp.data['layers'][0] == layer.layer_name
+```
+
+**Commit Message**:
+
+```
+feat(geostories): enable nested writes for context and layers
+
+Update GeoStorySerializer to support:
+- Inline creation/update of GeoContext
+- Inline assignment of Layers via list of names
+- Atomic transactions for data integrity
+```
+
+---
+
+### Task 1.4a: LayerRef Sync Client
+
+**Branch**: `feat/layerrefs-client`
+
+**Description**: Implement the GeoServer REST client adapter.
+
+**Changes**:
+
+- [ ] Add `requests` dependency
+- [ ] Create `tosca_api/apps/layerrefs/client.py`
+- [ ] Implement `fetch_layers_from_geoserver()` function
+
+**Acceptance Criteria**:
+
+- [ ] Function returns list of layer names
+- [ ] Handles connection errors gracefully
+- [ ] Unit tests with mocked responses
+
+**Tests**:
+
+```python
+def test_fetch_layers_mocked(mocker):
+    m_get = mocker.patch('requests.get')
+    m_get.return_value.json.return_value = {'layers': {'layer': [{'name': 'ws:l1'}]}}
+    layers = fetch_layers_from_geoserver()
+    assert layers == ['ws:l1']
+```
+
+**Commit Message**:
+
+```
+feat(layerrefs): add GeoServer REST client
+
+Implement HTTP client to fetch layer list from GeoServer:
+- Handles basic auth
+- Parses JSON response
+- Error handling
+```
+
+---
+
+### Task 1.4b: LayerRef Sync Endpoint
+
+**Branch**: `feat/layerrefs-endpoint`
+
+**Description**: Add the Admin API endpoint to trigger sync.
+
+**Changes**:
+
+- [ ] Add `POST /api/v1/layers/sync/`
+- [ ] Call client, diff sets, create/delete LayerRef objects
+- [ ] Return stats
+
+**Acceptance Criteria**:
+
+- [ ] Only Admin/Editor can call
+- [ ] Returns added/removed counts
+- [ ] Tests integration
+
+**Tests**:
+
+```python
+def test_sync_action(api_client, admin_user, mocker):
+    mocker.patch('...fetch_layers', return_value=['new_layer'])
+    api_client.force_authenticate(admin_user)
+    resp = api_client.post("/api/v1/layers/sync/")
+    assert resp.data['added'] == 1
+```
+
+**Commit Message**:
+
+```
+feat(layerrefs): add manual sync endpoint
+
+Add POST /api/v1/layers/sync/:
+- Triggers fetch from GeoServer
+- Updates local LayerRef table
+- Returns sync statistics
+```
+
+---
+
+### Task 1.5: Create `featurelinks` App
+
+**Branch**: `feat/featurelinks-app`
+
+**Description**: Create featurelinks app with FeatureLink model (GenericForeignKey).
+
+**Changes**:
+
+- [x] Create `tosca_api/apps/featurelinks/` with FeatureLink model
+- [x] Use Django ContentTypes for polymorphic source/target
+- [x] Add `clean()` validation for same-campaign and no-self-link
+
+**Acceptance Criteria**:
+
+- [x] Can link GeoStory → GeoStory
+- [x] Validation rejects cross-campaign links
+- [x] Validation rejects self-links
+- [x] Tests pass
+
+**Tests**:
+
+```python
+@pytest.mark.django_db
+def test_featurelink_same_campaign():
+    # Can link two stories in same campaign
+    ...
+
+@pytest.mark.django_db
+def test_featurelink_rejects_cross_campaign():
+    # Should raise ValidationError
+    ...
+
+@pytest.mark.django_db
+def test_featurelink_rejects_self_link():
+    # Should raise ValidationError
+    ...
+```
+
+**Commit Message**:
+
+```
+feat(featurelinks): add FeatureLink model
+
+Create featurelinks app for polymorphic entity linking:
+- GenericForeignKey for source and target
+- campaign FK for boundary enforcement
+- link_type enum (direct/read_more/action)
+
+Includes clean() validation:
+- Source and target must be in same campaign
+- Entity cannot link to itself
+```
+
+---
+
+### Task 1.6: Enhanced GeoStory API (Read-Optimized)
+
+**Branch**: `feat/geostory-read-api`
+
+**Description**:
+Enhance `GeoStory` API to support public consumption with list/detail separation, nested serialization, and status filtering.
+
+**Changes**:
+
+- [x] Create `GeoContextSerializer` to expose fields `content`, `content_type`
+- [x] Create `LayerRefSerializer` to expose `id`, `layer_name`
+- [x] Create `FeatureLinkSerializer` for outgoing links (source -> target)
+- [x] Update `GeoStoryViewSet`:
+  - [x] `list` action: Filter `status=PUBLISHED` (for public users). Returns slim payload.
+  - [x] `retrieve` action: Returns full nested payload.
+  - [x] Optimize queries (`select_related`, `prefetch_related`)
+- [x] Define dual serializers in `views.py` (`get_serializer_class`)
+
+**API Specs**:
+
+1. **List API** (`GET /api/v1/geostories/`):
+   - **Filter**: `status='published'`, `campaign_id=<uuid>`
+   - **Pagination**: Inherit default (Cursor)
+   - **Fields**: `id`, `title`, `summary`, `campaign_id`, `created_at`
+
+2. **Detail API** (`GET /api/v1/geostories/<uuid>/`):
+   - **Fields**:
+     - `id`, `title`, `summary`, `status`
+     - `campaign_id`
+     - `context`: `{ content: "...", content_type: "simple" }`
+     - `layers`: `[{ id: "...", layer_name: "...", display_order: 1 }]` (Ordered)
+     - `feature_links`: `[{ id: "...", target_object_id: "...", link_type: "exact" }]` (Outgoing)
+     - `created_at`, `updated_at`
+
+**Acceptance Criteria**:
+
+- [x] List endpoint returns only published stories (unless admin)
+- [x] List endpoint returns minimal fields
+- [x] Detail endpoint returns nested Context object (not just UUID)
+- [x] Detail endpoint returns list of LayerRef objects with order
+- [x] Detail endpoint returns outgoing FeatureLinks
+- [x] Tests verify payload structure and filtering
+
+**Tests**:
+
+```python
+def test_geostory_list_published_only(api_client):
+    # Create draft and published stories
+    # Verify response contains only published
+    ...
+
+def test_geostory_detail_payload(api_client):
+    # Verify context, layers, links are present
+    ...
+```
+
+**Commit Message**:
+
+```
+feat(geostories): enhance API for read consumption
+
+- Add GeoStoryListSerializer (slim) and GeoStoryDetailSerializer (nested).
+- Implement nested serializers for GeoContext, LayerRef, FeatureLink.
+- Update GeoStoryViewSet to use dual serializers and optimize queries.
+- Enforce status=PUBLISHED filtering for list view.
+```
+
+---
+
+## Phase 2: CalendarEvent Feature
+
+> **Goal**: Add time-bound spatial events.
+
+---
+
+### Task 2.1: Create `events` App with CalendarEvent Model
+
+**Branch**: `feat/events-model`
+
+**Description**: Create events app with CalendarEvent model using PointField.
+
+**Changes**:
+
+- [x] Create `tosca_api/apps/events/` with CalendarEvent, EventLayer models
+- [x] Fields include: location (PointField), start_datetime, end_datetime
+- [x] Add CHECK constraint for end >= start
+
+**Acceptance Criteria**:
+
+- [x] PointField migration applies successfully
+- [x] Can save model with SRID 4326 point
+- [x] IntegrityError if end < start
+
+**Tests**:
+
+```python
+@pytest.mark.django_db
+def test_event_constraints():
+    # Should fail if end < start
+    with pytest.raises(IntegrityError):
+        CalendarEvent.objects.create(..., start=now, end=now-timedelta(1))
+```
+
+**Commit Message**:
+
+```
+feat(events): add CalendarEvent model
+
+Create events app with:
+- CalendarEvent: FK to Campaign, PointField for location
+- EventLayer: M2M junction with display_order
+- start_datetime, end_datetime with validation
+
+Uses GeoDjango PointField for spatial storage.
+```
+
+---
+
+### Task 2.2: CalendarEvent API Endpoints
+
+**Branch**: `feat/events-api`
+
+**Description**: Add REST API for CalendarEvent CRUD with spatial filtering support.
+
+**Changes**:
+
+- [x] Create serializers, views, urls
+- [x] Implement `GeoFeatureModelSerializer` for GeoJSON output
+- [x] Filter by campaign_id, start_date, end_date
+- [x] Add `include_past` filter (default: false, only future events)
+- [x] Add `bbox` parameter for spatial filtering
+- [x] Add `POST /events/within/` for polygon-based spatial filter
+
+**Acceptance Criteria**:
+
+- [x] GET /api/v1/events/ returns paginated JSON (calendar view)
+- [x] GET /api/v1/events/?bbox=... returns GeoJSON FeatureCollection (map view)
+- [x] POST /api/v1/events/within/ returns events inside polygon
+- [x] Can filter: ?start_after, ?start_before, ?include_past
+- [x] Map view only returns events WITH location
+- [x] CursorPagination enabled for calendar view
+
+**Tests**:
+
+```python
+@pytest.mark.django_db
+def test_event_geojson_output(api_client):
+    resp = api_client.get("/api/v1/events/?bbox=9,53,11,54")
+    assert resp.data['type'] == "FeatureCollection"
+    assert resp.data['features'][0]['geometry']['type'] == "Point"
+```
+
+**Commit Message**:
+
+```
+feat(events): add REST API endpoints with spatial filtering
+
+Implement CalendarEvent API:
+- GET /api/v1/events/ (calendar view, paginated JSON)
+- GET /api/v1/events/?bbox=... (map view, GeoJSON)
+- POST /api/v1/events/within/ (polygon filter)
+- Full CRUD support
+
+Features:
+- Default: future events only (include_past=false)
+- BBox and polygon spatial filters
+- GeoJSON FeatureCollection output for map views
+- CursorPagination for calendar view
+```
+
+---
+
+### Task 2.3: Extend FeatureLink for Events
+
+**Branch**: `feat/featurelinks-events`
+
+**Description**: Verify FeatureLink works with CalendarEvent content type.
+
+**Changes**:
+
+- [x] Add tests for Story → Event links
+- [x] Add tests for Event → Event links
+
+**Acceptance Criteria**:
+
+- [x] Tests pass for linking events to other features
+- [x] Admin UI allows selecting events in generic relation
+
+**Tests**:
+
+```python
+@pytest.mark.django_db
+def test_link_story_to_event(story, event):
+    link = FeatureLink.objects.create(
+        campaign=story.campaign,
+        source=story,
+        target=event
+    )
+    assert link.id is not None
+```
+
+**Commit Message**:
+
+```
+test(featurelinks): verify CalendarEvent linking
+
+Add tests to confirm FeatureLink supports:
+- GeoStory → CalendarEvent links
+- CalendarEvent → CalendarEvent links
+
+No model changes required (GenericFK handles it).
+```
+
+---
+
+## Phase 2B: Event Model V2
+
+> **Goal**: Evolve the existing event implementation into a flexible, typed, recurring-capable event platform while preserving the current event authoring and map/list experience.
+
+### Implementation Notes After 2B.4
+
+- `2B.2` depended on `event_type` and `series` before the original plan introduced the full `EventType` and `EventSeries` schemas. The codebase now already contains minimal placeholder `EventType` and `EventSeries` models, and later tasks must extend them in place instead of creating replacements.
+- `Event.context` is no longer 1:1. It is a nullable `ForeignKey` override so contexts can be reused across occurrences when appropriate.
+- Effective context resolution is already implemented in code as `event.context -> series.default_context -> none`, and the event detail API returns the resolved context.
+- `2B.4` satisfies the GiST requirement through GeoDjango's spatial index on `Event.location`; no duplicate explicit GiST index was added.
+- `EventSeries.campaign` and `EventSeries.event_type` are currently nullable at the DB layer for destructive-reset-friendly development, but any event attached to a series is validated against populated series values.
+- Local tests use a persistent `test_tosca` database with `--reuse-db`. After destructive event-schema changes, reset or repair the reusable test DB before trusting failures that mention old event tables or content types.
+
+---
+
+### Task 2B.1: Replace `CalendarEvent` With `Event`
+
+**Branch**: `feat/event-v2-rename`
+
+**Description**: Replace `CalendarEvent` with `Event` after schema freeze and update all direct dependencies in one sweep.
+
+**Changes**:
+
+- [x] Replace the Django model name and ORM references
+- [x] Update `FeatureLink` allowed content types and generic relation names
+- [x] Update serializers, viewsets, admin, tests, and docs that still reference `CalendarEvent`
+- [x] Use a pre-production destructive schema reset strategy; no row backfill required
+
+**Acceptance Criteria**:
+
+- [x] No `CalendarEvent` references remain in the event app or `FeatureLink`
+- [x] Event CRUD still works under the new `Event` model name
+- [x] Tests covering event creation and linking pass
+
+**Test Cases**:
+
+- [x] Event can be created and retrieved through the renamed model/API path
+- [x] `FeatureLink` can link `Event` to `GeoStory`, `GeoFeedback`, and another `Event`
+- [x] Old `CalendarEvent` content-type references are removed or rejected
+- [x] Admin and serializer layers resolve the renamed model correctly
+
+---
+
+### Task 2B.2: Add Event Core Fields and Mode Validation
+
+**Branch**: `feat/event-v2-core-fields`
+
+**Description**: Add the new core fields required for online, hybrid, and provider-aware events.
+
+**Changes**:
+
+- [x] Add `event_type`, `location_mode`, online fields, provider fields, `series`, `occurrence_index`, `is_exception`, and `original_start_datetime`
+- [x] Implement validation for `physical`, `hybrid`, and `online`
+- [x] Keep `Event.start_datetime` and `Event.end_datetime` as `TIMESTAMPTZ`
+- [x] Keep event context optional
+
+**Implementation Notes**:
+
+- `EventType` and `EventSeries` were introduced as minimal placeholders here because the original task order referenced them before `2B.7` and `2B.12`.
+- Online access validation currently accepts either `online_url` or `online_platform` as sufficient access data.
+
+**Acceptance Criteria**:
+
+- [x] Online events allow `location=NULL` and require online access data
+- [x] Hybrid events require both geometry and online access data
+- [x] Standalone events can exist without context
+- [x] Tests for mode validation pass
+
+**Test Cases**:
+
+- [x] `physical` event requires geometry and does not require online fields
+- [x] `online` event requires online URL/platform and allows null geometry
+- [x] `hybrid` event requires both geometry and online URL/platform
+- [x] `end_datetime < start_datetime` is rejected
+- [x] Standalone event with null context is valid
+
+---
+
+### Task 2B.3: Add Series Default Context and Event Overrides
+
+**Branch**: `feat/event-v2-context`
+
+**Description**: Implement the final shared-content model using series defaults plus per-occurrence overrides.
+
+**Changes**:
+
+- [x] Add `EventSeries.default_context`
+- [x] Keep `Event.context` as an optional override
+- [x] Document and implement effective context resolution as `event.context -> series.default_context -> none`
+- [x] Ensure events without effective context are valid
+
+**Implementation Notes**:
+
+- `Event.context` was changed from `OneToOneField` to `ForeignKey` so occurrence overrides can coexist with shared defaults.
+- The current detail serializer returns the resolved effective context, not only the direct override row.
+
+**Acceptance Criteria**:
+
+- [x] Series events can resolve shared context from `EventSeries.default_context`
+- [x] Individual occurrences can override shared context through `Event.context`
+- [x] Published events are valid without any effective context
+- [x] Tests for context resolution pass
+
+**Test Cases**:
+
+- [x] Event without series and without context resolves to no context
+- [x] Event with series default context and no override resolves series context
+- [x] Event with both series default and event override resolves the event override
+- [x] Editing one occurrence override does not change the series default context
+- [x] Published event without any effective context remains valid
+
+---
+
+### Task 2B.4: Add Core Constraints and Indexes
+
+**Branch**: `feat/event-v2-core-constraints`
+
+**Description**: Add the minimum production-ready constraints and indexes for event core queries.
+
+**Changes**:
+
+- [x] Add event constraints for `end_datetime >= start_datetime`
+- [x] Add series-linked invariants for `campaign` and `event_type`
+- [x] Add GiST index on `location`
+- [x] Add b-tree indexes on `(campaign_id, status, start_datetime)`, `(event_type_id, start_datetime)`, `(location_mode, start_datetime)`, `(series_id, start_datetime)`
+- [x] Add unique partial index on `(series_id, occurrence_index)` where `series_id IS NOT NULL`
+
+**Implementation Notes**:
+
+- The GiST requirement is satisfied by GeoDjango's spatial index on `Event.location`; no redundant explicit GiST index was added.
+- `EventSeries` now carries `campaign` and `event_type` so attached events can be validated against the series identity before the full recurrence schema lands.
+- `EventSeries.campaign` and `EventSeries.event_type` remain nullable in the DB schema for destructive-reset development, but series-linked event validation requires them to be populated.
+
+**Acceptance Criteria**:
+
+- [x] Series-linked events cannot change `campaign` or `event_type` while attached
+- [x] Duplicate `(series_id, occurrence_index)` values are rejected
+- [x] Schema contains the agreed minimum index set
+- [x] Constraint tests pass
+
+**Test Cases**:
+
+- [x] `end_datetime >= start_datetime` constraint accepts valid rows
+- [x] `end_datetime < start_datetime` constraint rejects invalid rows
+- [x] Series-linked event rejects `campaign` change while attached
+- [x] Series-linked event rejects `event_type` change while attached
+- [x] Duplicate `(series_id, occurrence_index)` values are rejected when `series_id` is set
+- [x] Expected GiST and b-tree indexes are present in the schema
+
+---
+
+### Task 2B.5: Add Taxonomy Schema and Admin
+
+**Branch**: `feat/event-v2-taxonomy-schema`
+
+**Description**: Add dynamic taxonomy models and admin configuration.
+
+**Changes**:
+
+- [x] Create `TaxonomyDimension`, `TaxonomyTerm`, and `EventTerm`
+- [x] Add support for `single` vs `multiple` selection modes
+- [x] Support parent-child terms inside a dimension
+- [x] Add admin configuration for dimensions and terms
+- [x] Add unique `TaxonomyTerm(dimension_id, code)` and unique `EventTerm(event_id, term_id)`
+
+**Additional Todo For Next Task**:
+
+- Reuse the existing `EventType` and `EventSeries` models already present in the app. Do not introduce replacement models while adding taxonomy support.
+- Reuse the newly added `EventTerm` table and layer `2B.6` assignment validation on top of it instead of introducing a second event-taxonomy relation path.
+
+**Implementation Notes**:
+
+- `TaxonomyDimension` now owns the `single` vs `multiple` selection mode contract, but enforcement of single-select assignment conflicts is intentionally deferred to `2B.6`.
+- Admin configuration now exists for `TaxonomyDimension`, `TaxonomyTerm`, and `EventTerm`, with inline term management under dimensions.
+
+**Acceptance Criteria**:
+
+- [x] Admin can create dimensions and terms
+- [x] Parent term validation rejects cross-dimension hierarchies
+- [x] Duplicate term assignment is rejected
+- [x] Schema and admin tests pass
+
+**Test Cases**:
+
+- [x] Admin can create active and inactive taxonomy dimensions
+- [x] Term codes are unique within a dimension
+- [x] Parent term must belong to the same dimension as the child
+- [x] Duplicate `(event_id, term_id)` assignment is rejected
+- [x] Admin lists and forms expose the taxonomy models correctly
+
+---
+
+### Task 2B.6: Add Event-Taxonomy Assignment Rules
+
+**Branch**: `feat/event-v2-taxonomy-assignment`
+
+**Description**: Implement assignment-time validation and query support for event taxonomy.
+
+**Changes**:
+
+- [x] Enforce single-select dimension rules on `EventTerm`
+- [x] Add index `EventTerm(term_id, event_id)` for filtering
+- [x] Add serializer/admin validation for event-term assignment
+- [x] Add API/query support for filtering by term and dimension
+
+**Implementation Notes**:
+
+- `EventTerm` already exists from `2B.5`; `2B.6` should add validation, filtering index, and assignment entry-point checks on that existing table.
+- The current API contract now supports `term_id` and `dimension_id` filters on the existing event endpoints.
+- Event write operations now accept `taxonomy_term_ids` and replace the event's assignments when that field is provided.
+
+**Additional Todo For Next Task**:
+
+- `2B.9` should lift the existing `term_id` and `dimension_id` semantics into the shared event filter layer instead of redefining taxonomy filter names.
+
+**Acceptance Criteria**:
+
+- [x] Single-select dimensions reject conflicting assignments
+- [x] Event-term assignment works from admin and API
+- [x] Event filtering by taxonomy terms works
+- [x] Assignment tests pass
+
+**Test Cases**:
+
+- [x] Single-select dimension rejects a second term for the same event
+- [x] Multiple-select dimension allows multiple terms for the same event
+- [x] Event-term assignment works through serializer validation
+- [x] Event-term assignment works through admin save flow
+- [x] Filtering by term returns matching events only
+- [x] Filtering by dimension/term combination returns the expected event set
+
+---
+
+### Task 2B.7: Add Event Type Registry and Seeds
+
+**Branch**: `feat/event-v2-types`
+
+**Description**: Introduce the `EventType` registry as the source of truth for event-type behavior.
+
+**Changes**:
+
+- [x] Add `EventType` with `code`, `label`, `profile_mode`, `profile_key`, and `is_active`
+- [x] Seed `general`, `public_health`, `sports`, and `culture`
+- [x] Add admin support for event type management
+
+**Additional Todo**:
+
+- Extend the existing placeholder `EventType` model in place.
+- Because event data can be reset destructively, reshaping the existing placeholder table is preferable to building compatibility-heavy backfills.
+- `2B.8` should treat the seeded `general`, `public_health`, `sports`, and `culture` rows as the canonical registry bindings for profile validation.
+
+**Implementation Notes**:
+
+- `EventType` now validates `profile_mode=core` with no `profile_key`, and `profile_mode=extension` with a required `profile_key`.
+- The seed migration populates `general=core`, and `public_health` / `sports` / `culture` as `extension` rows with matching `profile_key` values.
+
+**Acceptance Criteria**:
+
+- [x] Event types can be created and managed in admin
+- [x] Seeded event types exist and match the agreed profile bindings
+- [x] Tests for registry creation and seed data pass
+
+**Test Cases**:
+
+- [x] Seed creates `general`, `public_health`, `sports`, and `culture`
+- [x] Seeded rows use the correct `profile_mode` / `profile_key` combinations
+- [x] Duplicate event type codes are rejected
+- [x] Inactive event types can be stored without breaking existing rows
+- [x] Admin can create and edit custom event types
+
+---
+
+### Task 2B.8: Add Profile Extension Models and Compatibility Validation
+
+**Branch**: `feat/event-v2-profiles`
+
+**Description**: Add extension profile tables and validate them against `EventType`.
+
+**Changes**:
+
+- [x] Add `PublicHealthEventProfile`, `SportsEventProfile`, and `CultureEventProfile`
+- [x] Validate `profile_mode=core` vs `profile_mode=extension`
+- [x] Reject mismatched event-type/profile combinations
+
+**Implementation Notes**:
+
+- `2B.7` already established the registry contract: `general` is `core`, while `public_health`, `sports`, and `culture` are `extension` types with matching `profile_key` values.
+- The profile tables now validate against `event.event_type.profile_mode` and `event.event_type.profile_key` rather than hardcoded type-name checks scattered across the app.
+- Core event types still do not require any extension profile row, and extension event types are not yet forced to have one.
+
+**Acceptance Criteria**:
+
+- [x] Core event types work without extension rows
+- [x] Extension types reject mismatched profile rows
+- [x] Profile compatibility tests pass
+
+**Test Cases**:
+
+- [x] `general` event can exist without any extension profile
+- [x] `public_health` event accepts `PublicHealthEventProfile`
+- [x] `sports` event accepts `SportsEventProfile`
+- [x] `culture` event accepts `CultureEventProfile`
+- [x] Core event type rejects creation of any extension profile
+- [x] Mismatched event-type/profile combinations are rejected
+
+---
+
+### Task 2B.9: Add Shared Event Filter Layer
+
+**Branch**: `feat/event-v2-filters`
+
+**Description**: Centralize event filtering so list and map endpoints share one contract.
+
+**Changes**:
+
+- [x] Add shared parsing/validation for campaign, date range, status, visibility, taxonomy, `include_past`, and spatial filters
+- [x] Make spatial predicates apply only to `physical` and `hybrid`
+- [x] Keep `online` events subject to all non-spatial filters
+
+**Implementation Notes**:
+
+- Taxonomy filtering already exists on the current event endpoints via `term_id` and `dimension_id`; `2B.9` should preserve those semantics while centralizing the logic.
+- The shared filter layer now lives in a dedicated events filter helper and is used by both list and polygon/bbox spatial queries.
+- Current spatial responses still serialize through the existing GeoJSON endpoint shape, so eligible online events now surface as GeoJSON features with `null` geometry until `2B.11` introduces separate spatial and online buckets.
+
+**Additional Todo For Next Task**:
+
+- `2B.10` and `2B.11` should reuse the existing shared filter helper and preserve the current `campaign_id`, `status`, `visibility`, `include_past`, `start_after`, `start_before`, `term_id`, and `dimension_id` filter contract.
+
+**Acceptance Criteria**:
+
+- [x] List and map endpoints can reuse the same filter layer
+- [x] Spatial filters exclude out-of-area `physical`/`hybrid` events
+- [x] Eligible `online` events remain included after non-spatial filtering
+- [x] Filter-layer tests pass
+
+**Test Cases**:
+
+- [x] Campaign, status, visibility, and date filters produce the same result set for list and map queries
+- [x] `include_past=false` excludes past events across both list and map
+- [x] BBox/polygon filtering removes out-of-area `physical` and `hybrid` events
+- [x] Eligible `online` events remain after spatial filtering
+- [x] Non-spatial filters still remove `online` events when they do not match
+- [x] Taxonomy filters apply consistently in the shared filter layer
+
+---
+
+### Task 2B.10: Add Event List API V2
+
+**Branch**: `feat/event-v2-list-api`
+
+**Description**: Build the list endpoint as one chronological mixed stream using `location_mode`.
+
+**Changes**:
+
+- [x] Add `GET /api/v1/events/list/`
+- [x] Return one paginated stream ordered by `start_datetime`
+- [x] Include `location_mode` in each item
+- [x] Reuse the shared event filter layer
+
+**Implementation Notes**:
+
+- The new dedicated list endpoint now returns paginated JSON even when spatial filters like `bbox` are supplied.
+- The legacy `/api/v1/events/` route still exists for backward compatibility and still switches to GeoJSON on bbox requests; `2B.11` should target the dedicated map surface instead.
+
+**Additional Todo For Next Task**:
+
+- `2B.11` should reuse the shared filter helper and keep `/api/v1/events/list/` as the canonical mixed-stream list endpoint while introducing the separate map buckets.
+
+**Acceptance Criteria**:
+
+- [x] List endpoint returns `physical`, `hybrid`, and `online` events in one chronological stream
+- [x] Filtering semantics match the shared contract
+- [x] Pagination works as expected
+- [x] List API tests pass
+
+**Test Cases**:
+
+- [x] List endpoint returns mixed `physical`, `hybrid`, and `online` events ordered by `start_datetime`
+- [x] Each item includes `location_mode`
+- [x] Pagination cursors/page boundaries work with mixed event types
+- [x] Area-filtered list includes matching spatial events plus eligible online events
+- [x] List payload remains stable when no online events match
+
+---
+
+### Task 2B.11: Add Event Map API V2
+
+**Branch**: `feat/event-v2-map-api`
+
+**Description**: Build the map endpoint with separate spatial and online result buckets.
+
+**Changes**:
+
+- [x] Add `GET /api/v1/events/map/`
+- [x] Return `spatial_events` as GeoJSON for `physical` and `hybrid`
+- [x] Return `online_events` as a separate JSON array
+- [x] Reuse the shared event filter layer
+
+**Implementation Notes**:
+
+- The dedicated map endpoint now owns the bucketed v2 map response contract, while the legacy `/api/v1/events/` bbox behavior remains in place for backward compatibility.
+- `spatial_events` includes only mapped `physical` and `hybrid` events, and `online_events` contains the eligible `online` events that passed the same shared non-spatial filters.
+
+**Acceptance Criteria**:
+
+- [x] Map endpoint returns valid GeoJSON in `spatial_events`
+- [x] Map endpoint returns `online_events` separately from spatial GeoJSON
+- [x] Spatial filtering behavior matches the agreed semantics
+- [x] Map API tests pass
+
+**Test Cases**:
+
+- [x] Map endpoint returns valid GeoJSON FeatureCollection in `spatial_events`
+- [x] `online_events` are returned as a separate JSON array
+- [x] `spatial_events` contains only `physical` and `hybrid` events with geometry
+- [x] Area-filtered map response includes eligible online events separately
+- [x] Empty spatial result sets still return a valid GeoJSON structure
+
+---
+
+### Task 2B.12: Add EventSeries and EventSeriesDate Schema
+
+**Branch**: `feat/event-v2-series-schema`
+
+**Description**: Add the structural models required for batch and recurring event generation.
+
+**Changes**:
+
+- [x] Create `EventSeries`
+- [x] Create `EventSeriesDate`
+- [x] Add unique `EventSeriesDate(series_id, occurrence_date)` constraint
+- [x] Add recurrence field validation for daily, weekly, and monthly rules
+
+**Additional Todo**:
+
+- Extend the existing `EventSeries` table in place rather than introducing a new grouping model.
+- After the destructive reset for the new event system, revisit whether `EventSeries.campaign` and `EventSeries.event_type` should be tightened from nullable to non-nullable at the schema level.
+- `2B.13` should build on the live `EventSeries` / `EventSeriesDate` schema instead of introducing a second recurrence-definition path.
+
+**Implementation Notes**:
+
+- The existing placeholder `EventSeries` model is now the real recurrence-definition table and includes recurrence, schedule, timezone, and creator fields.
+- `EventSeries.campaign` and `EventSeries.event_type` remain nullable at the DB layer as previously documented, but the new recurrence fields are validated strictly at the model layer.
+- `manual_batch` explicit dates now persist through `EventSeriesDate`, while the "series must already have at least one date" rule remains deferred to the creation flow in `2B.13`.
+
+**Acceptance Criteria**:
+
+- [x] Manual batch series can persist explicit dates
+- [x] Weekly/monthly validation rules are enforced
+- [x] Duplicate manual batch dates are rejected
+- [x] Series schema tests pass
+
+**Test Cases**:
+
+- [x] `manual_batch` series accepts explicit dates and persists them in `EventSeriesDate`
+- [x] Duplicate `(series_id, occurrence_date)` rows are rejected
+- [x] Weekly recurrence requires at least one weekday
+- [x] Monthly recurrence requires either `day_of_month` or `week_of_month + weekday_of_month`
+- [x] Invalid combinations of `end_date` and `occurrence_count` are rejected
+
+---
+
+### Task 2B.13: Add Recurrence Generation, Exceptions, and DST Handling
+
+**Branch**: `feat/event-v2-series-generation`
+
+**Description**: Implement generation, exception behavior, and local-time recurrence semantics.
+
+**Changes**:
+
+- [x] Add preview and creation flow for manual and recurring series
+- [x] Persist generated events with `series_id`, `occurrence_index`, and `original_start_datetime`
+- [x] Mark diverging occurrences as `is_exception`
+- [x] Update only future non-exception occurrences by default
+- [x] Generate occurrences in local wall time using `EventSeries.timezone`
+
+**Implementation Notes**:
+
+- `2B.12` already added the concrete `EventSeries` and `EventSeriesDate` schema; `2B.13` should focus on generation services and exception behavior on top of that schema.
+- Implemented dedicated `POST /api/v1/event-series/preview/`, `POST /api/v1/event-series/`, and `PATCH /api/v1/event-series/{id}/` endpoints rather than overloading the existing event CRUD routes with bulk recurrence semantics.
+- Generated occurrences are synchronized by `occurrence_index`; future non-exception rows are updated or deleted by default, while exception rows are skipped and left attached to the series.
+- Direct edits to generated occurrences through the existing `/api/v1/events/{id}/` endpoint now mark the row as `is_exception=True` when schedule/content/location or taxonomy fields diverge.
+- Recurring generation is currently limited to same-day occurrence durations because the existing `EventSeries.end_date` field is already used as the recurrence termination boundary. Multi-day recurring occurrence duration still needs explicit schema support if required later.
+- Series `campaign` and `event_type` changes are now rejected once occurrences exist, because exceptions must remain aligned with the series identity while attached.
+
+**Acceptance Criteria**:
+
+- [x] Recurring weekly series generate correct occurrences
+- [x] Weekly recurring series preserve the same local wall time across DST boundaries
+- [x] Exception occurrences are skipped by default during future bulk updates
+- [x] Generation and exception-handling tests pass
+
+**Test Cases**:
+
+- [x] Manual batch preview returns one occurrence per explicit date
+- [x] Weekly recurring preview/generation returns the expected count and dates
+- [x] Generated occurrences receive `series_id`, `occurrence_index`, and `original_start_datetime`
+- [x] Editing one generated occurrence can mark it as `is_exception`
+- [x] Bulk future updates skip exception occurrences by default
+- [x] Weekly recurrence across DST preserves the same local clock time in the series timezone
+
+---
+
+### Task 2B.14: Review Cleanup for Event Filters and Validation
+
+**Branch**: `feat/event-v2-review-cleanups`
+
+**Description**: Apply the concrete follow-up improvements identified during the Phase 2B implementation review.
+
+**Changes**:
+
+- [x] Verify and document that the `2B.7` event type seed migration already exists and runs as a `RunPython` data migration
+- [x] Convert `EventLayer` uniqueness from `unique_together` to `UniqueConstraint`
+- [x] Move `VALID_WEEKDAYS` above `EventSeries` for readability
+- [x] Add serializer-level GeoJSON `Point` validation for event-series template locations
+- [x] Auto-assign `EventSeriesDate.display_order` when omitted during direct model creation
+- [x] Add `event_type_id` to the shared event filter layer used by list/map/within endpoints
+- [x] Avoid unnecessary FK object comparison when deciding whether a direct occurrence edit should become an exception
+
+**Implementation Notes**:
+
+- This cleanup task intentionally covers only the review items that are concrete, local to the events app, and low ambiguity.
+- It does not introduce role-based permissions yet; that remains a broader cross-app authorization task rather than an events-only cleanup.
+- The `2B.7` event type seeds are confirmed to live in `events/migrations/0007_eventtype_is_active_eventtype_profile_key_and_more.py` via `RunPython(seed_event_types, unseed_event_types)`.
+- Queryset deletion during occurrence sync remains unchanged because `Event` still has no custom `delete()` behavior to preserve.
+
+**Acceptance Criteria**:
+
+- [x] Event-series preview/create returns clear 400 errors for malformed or non-point location GeoJSON
+- [x] Shared event filtering supports `event_type_id` on list and map endpoints
+- [x] `EventLayer` uniqueness uses a schema-level `UniqueConstraint`
+- [x] `EventSeriesDate` can be created without manually supplying `display_order`
+- [x] Cleanup tests pass
+
+**Test Cases**:
+
+- [x] Event-series preview rejects invalid `location` GeoJSON with a clear serializer error
+- [x] Legacy list filtering works with `event_type_id`
+- [x] Map v2 filtering works with `event_type_id`
+- [x] `EventSeriesDate` auto-assigns display order when omitted
+- [x] Existing duplicate `EventLayer(event, layer)` rejection still passes after the constraint migration
+
+---
+
+### Task 2B.15: Add Admin Event-Series Authoring and Occurrence Generation
+
+**Branch**: `feat/event-series-admin-generation`
+
+**Description**: Extend Django admin so admins can author full event-series definitions, including occurrence template data, and generate or synchronize occurrence events with the same semantics as the existing recurrence API.
+
+**Changes**:
+
+- [x] Extend `EventSeriesAdminForm` to capture the event-template fields required to create valid `Event` rows
+- [x] Add admin support for taxonomy term selection that applies to generated occurrences
+- [x] Introduce a shared orchestration path for series validation, explicit-date persistence, and occurrence generation/synchronization that can be called from both admin and API
+- [x] Update the admin save flow so manual-batch generation runs only after inline `EventSeriesDate` formsets have been saved
+- [x] Generate occurrences when admins create a new series from admin
+- [x] Synchronize future non-exception occurrences when admins edit an existing generated series from admin
+- [x] Preserve existing exception occurrences during admin bulk updates by default
+- [x] Preserve the existing restriction that `campaign` and `event_type` cannot be changed after occurrences exist
+- [x] Fail admin saves transactionally if series validation, template validation, taxonomy validation, or event generation fails
+- [x] Add clear admin-facing validation errors for legacy series that have no base occurrence/template to derive update defaults from
+- [x] Prevent duplicate occurrences when a generated series is re-saved from admin
+
+**Implementation Notes**:
+
+- `2B.13` implemented recurrence generation only through `EventSeriesWriteSerializer` and the `/api/v1/event-series/` endpoints.
+- The current admin path saves only the lightweight `EventSeries` model plus inline `EventSeriesDate` rows; it never calls `create_occurrence_events()` or `sync_occurrence_events()`.
+- The implementation should not move generation into `EventSeries.save()`, signal handlers, or arbitrary `EventSeries.objects.create()` usage. Generation should remain tied to explicit authoring flows.
+- Because `EventSeries` does not persist fields like `title` or `location_mode`, admin edit behavior for an existing series must either:
+  - derive a base template from the first non-exception occurrence, matching the API update pattern
+  - or require admins to re-enter the missing template fields before sync
+- Admin orchestration should run after inline formsets are available so manual-batch series can generate from the saved explicit dates instead of stale or missing values.
+- Validation parity matters more than implementation location. If the serializer is too tightly coupled to request objects, extract the shared series-authoring logic into a dedicated service and make the serializer/admin thin wrappers around it.
+- Existing recurrence behavior should remain unchanged:
+  - future non-exception rows are updated or deleted during sync
+  - future exception rows are skipped by default
+  - past rows are left as historical records
+  - local wall time in `EventSeries.timezone` remains authoritative across DST transitions
+
+**Edge Cases**:
+
+- [x] Manual-batch admin create without any inline `EventSeriesDate`
+- [x] Manual-batch admin update that removes one explicit date and adds another
+- [x] Recurring admin create with `weekly` recurrence but empty `by_weekday`
+- [x] Recurring admin create/update with invalid monthly rule combinations
+- [x] Online template missing both `online_url` and `online_platform`
+- [x] Physical template with missing geometry
+- [x] Online template incorrectly containing geometry
+- [x] Invalid GeoJSON or non-`Point` location entered through admin
+- [x] Admin update after one occurrence was manually edited into an exception
+- [x] Admin update that shortens the series and should delete only future non-exception occurrences
+- [x] Admin update that changes timezone or start time across a DST boundary
+- [x] Admin re-save of an API-created series without introducing duplicate occurrences
+- [x] Admin update of a legacy series that has no non-exception occurrence available as a base template
+- [x] Taxonomy term selections violating single-select dimension rules
+- [x] Transaction rollback when one generated occurrence fails validation
+
+**Acceptance Criteria**:
+
+- [x] Admin add-form can create a recurring series and generate all expected occurrence events
+- [x] Admin add-form can create a manual-batch series from inline explicit dates and generate one event per date
+- [x] Admin change-form can synchronize an existing generated series without duplicating occurrences
+- [x] Admin bulk edits preserve future exception occurrences by default
+- [x] Admin validation matches API validation for recurrence rules, event-template rules, location GeoJSON, and taxonomy terms
+- [x] Admin errors are actionable and prevent partial persistence
+- [x] Automated tests cover both create and update behavior from the admin path
+
+**Test Cases**:
+
+- [x] Admin recurring create generates events with `series_id`, `occurrence_index`, and `original_start_datetime`
+- [x] Admin manual-batch create generates one event per inline explicit date in display order
+- [x] Admin create rolls back the saved series if template validation fails after inline dates are submitted
+- [x] Admin update changes future non-exception titles/status/location fields across generated events
+- [x] Admin update leaves an edited exception occurrence untouched
+- [x] Admin update deleting one future occurrence removes only the matching non-exception row
+- [x] Admin update across DST preserves the same local clock time in the configured timezone
+- [x] Admin update of an API-created series does not create duplicate `occurrence_index` values
+- [x] Admin validation rejects invalid location GeoJSON with a clear form error
+- [x] Admin validation rejects missing required template fields such as `title` and `location_mode`
+- [x] Admin validation rejects invalid taxonomy combinations
+- [x] Admin update of a series with no base occurrence/template fails clearly or requires explicit replacement fields, per chosen implementation
+
+---
+
+### Task 2B.16: Replace Term-Centric Event Taxonomy Writes with Dimension Assignments
+
+**Branch**: `feat/event-taxonomy-dimension-assignments`
+
+**Description**: Refactor event and event-series taxonomy authoring away from raw `taxonomy_term_ids` lists and onto a grouped `taxonomy_assignments` contract that matches the product model of taxonomy as optional event attributes.
+
+**Changes**:
+
+- [x] Introduce a shared taxonomy-assignment parser/validator that accepts grouped assignments by dimension
+- [x] Remove `taxonomy_term_ids` from event and event-series write serializers; no backward-compatibility layer is required
+- [x] Add validation that assigned terms:
+  - belong to the stated dimension
+  - are active
+  - are leaf terms only
+  - satisfy `single` vs `multiple` dimension rules
+- [x] Keep taxonomy optional for all event statuses, including `published`
+- [x] Continue persisting assignments through `EventTerm` without changing the storage model
+- [x] Reuse the same taxonomy-assignment contract from both direct event writes and shared series-authoring flows
+- [x] Add clear serializer/service errors for malformed grouped assignments and invalid term/dimension combinations
+
+**Implementation Notes**:
+
+- `TaxonomyDimension` remains the attribute definition, `TaxonomyTerm` remains the selectable vocabulary, and `EventTerm` remains the internal persistence layer.
+- This task intentionally changes the API contract because taxonomy authoring is not yet a published feature.
+- The grouped write shape should be explicit about dimension ownership, for example:
+  - `taxonomy_assignments: [{dimension_id, term_ids[]}]`
+- Validation should reject assignments to inactive dimensions or inactive terms for new writes while still allowing older data to remain stored.
+- The shared validator should be reusable from serializers, admin forms, and any orchestration service extracted by `2B.15`.
+- Event and event-series writes now resolve grouped assignments through one shared service-layer validator instead of duplicating taxonomy checks inside each serializer.
+
+**Edge Cases**:
+
+- [x] Empty or omitted `taxonomy_assignments`
+- [x] Duplicate `dimension_id` entries in the same payload
+- [x] Duplicate term IDs within the same dimension
+- [x] A term assigned under the wrong dimension
+- [x] Multiple terms supplied for a `single` dimension
+- [x] Parent and child terms both supplied for the same dimension
+- [x] Inactive dimension or inactive term supplied in a new write payload
+- [x] Unknown dimension IDs or term IDs
+
+**Acceptance Criteria**:
+
+- [x] Event writes accept only the grouped taxonomy-assignment contract
+- [x] Event-series writes accept the same grouped taxonomy-assignment contract
+- [x] Taxonomy remains optional for draft and published events
+- [x] Leaf-only assignment and selection-mode rules are enforced consistently
+- [x] Existing `EventTerm` persistence remains the only storage layer for event taxonomy
+- [x] Automated tests cover grouped assignment validation on both event and event-series write paths
+
+**Test Cases**:
+
+- [x] Event create with empty taxonomy assignments succeeds
+- [x] Event create with one single-select dimension and one multi-select dimension succeeds
+- [x] Event create rejects duplicate dimension entries
+- [x] Event create rejects non-leaf term assignment
+- [x] Event create rejects inactive term assignment
+- [x] Event-series create accepts grouped taxonomy assignments and persists them onto generated occurrences
+- [x] Event-series update rejects invalid grouped taxonomy combinations with clear errors
+
+---
+
+### Task 2B.17: Add Dimension-Based Taxonomy Hydration for Event and Series Authoring
+
+**Branch**: `feat/event-taxonomy-authoring-hydration`
+
+**Description**: Expose taxonomy as grouped, dimension-based authoring data across event detail, event-series retrieve, and admin authoring flows so taxonomy behaves like optional event attributes instead of direct `EventTerm` maintenance.
+
+**Changes**:
+
+- [x] Add read serializers/helpers that return grouped taxonomy assignments with enough metadata to hydrate edit forms
+- [x] Return taxonomy assignments on event detail responses
+- [x] Return taxonomy assignments on event-series retrieve responses, derived from the base non-exception occurrence/template model established in `2B.15`
+- [x] Extend `EventAdminForm` to render taxonomy by active dimension rather than requiring direct `EventTerm` editing
+- [x] Extend `EventSeriesAdminForm` to render the same taxonomy section for generated occurrences
+- [x] Reuse the shared taxonomy assignment validator/parser from `2B.16` in admin form cleaning and save orchestration
+- [x] Keep `EventTermAdmin` available only as a low-level maintenance/debug surface, not the primary authoring workflow
+- [x] Fail clearly when a legacy series has no usable base occurrence from which taxonomy/template defaults can be derived
+
+**Implementation Notes**:
+
+- This task depends on the shared series-authoring orchestration introduced or extracted in `2B.15`.
+- `EventSeries` itself should remain lightweight; grouped taxonomy on series reads should be derived from the base template occurrence rather than persisted separately on the series row.
+- Read payloads should expose taxonomy in the same grouped shape used for writes, with optional nested dimension/term labels if helpful for admin or frontend hydration.
+- Admin save behavior should continue to preserve exception occurrences by default during series sync.
+- Admin forms now render one dynamic taxonomy field per active dimension, while still including inactive already-assigned terms and dimensions for edit hydration.
+
+**Edge Cases**:
+
+- [x] Event detail for an event with no taxonomy assignments
+- [x] Event detail for an event carrying terms from multiple dimensions
+- [x] Series retrieve where the first occurrence is an exception but a later non-exception base occurrence exists
+- [x] Series retrieve where no non-exception occurrence exists and all occurrences were deleted or converted to exceptions
+- [x] Admin edit of an event that still references inactive assigned terms
+- [x] Admin series edit that changes taxonomy and should update only future non-exception occurrences
+
+**Acceptance Criteria**:
+
+- [x] Event detail responses expose grouped taxonomy assignments for edit hydration
+- [x] Event-series retrieve responses expose grouped taxonomy assignments derived from the series template/base occurrence
+- [x] Admin event create/edit can manage taxonomy by dimension without using direct `EventTerm` admin
+- [x] Admin event-series create/edit can manage taxonomy by dimension for generated occurrences
+- [x] Legacy series states without a usable template occurrence fail with actionable admin/API errors
+- [x] Automated tests cover grouped taxonomy hydration and admin authoring behavior
+
+**Test Cases**:
+
+- [x] Event detail returns grouped taxonomy assignments in dimension order
+- [x] Event detail returns an empty taxonomy assignment list for untagged events
+- [x] Event-series retrieve returns grouped taxonomy assignments derived from the base occurrence
+- [x] Event-series retrieve fails clearly when no base occurrence/template is available
+- [x] Admin event save writes grouped taxonomy assignments through the shared validator
+- [x] Admin event-series create generates tagged occurrences from grouped taxonomy assignments
+- [x] Admin event-series update changes future non-exception occurrence taxonomy while preserving exceptions
+
+---
+
+## Phase 3: GeoFeedback Feature
+
+> **Goal**: Citizen feedback collection with forms and ratings.
+
+---
+
+### Task 3.1: Create `feedback` App with Core Models
+
+**Branch**: `feat/feedback-models`
+
+**Description**: Create feedback app, including `GeoFeedback` model integrated with `django-basic-form-builder`.
+
+**Changes**:
+
+- [x] Add `django-basic-form-builder` to dependencies (`uv add django-basic-form-builder`)
+- [x] Add `formbuilder` to `INSTALLED_APPS` and configure `FORMBUILDER_API_ENABLED = True`
+- [x] Create `tosca_api/apps/feedback/`
+- [x] Add GeoFeedback (FK -> Campaign, FK -> `formbuilder.CustomForm` nullable)
+- [x] Add GeoFeedback fields: `rating_enabled` (bool), `form_enabled` (bool), `allow_drawings` (bool)
+- [x] Add feedback_layers M2M
+- [x] Add `clean()` validation to GeoFeedback: if `form_enabled` is True, `custom_form` must not be null. At least one of `rating_enabled` or `form_enabled` must be True.
+
+**Acceptance Criteria**:
+
+- [x] Admin can create CustomForms via the form builder and link them to GeoFeedback
+- [x] GeoFeedback model validates its configuration correctly
+- [x] Tests pass
+
+**Tests**:
+
+```python
+@pytest.mark.django_db
+def test_feedback_config_validation():
+    # Should fail if form is enabled but no custom_form provided
+    with pytest.raises(ValidationError):
+        GeoFeedback(rating_enabled=False, form_enabled=True, custom_form=None).clean()
+```
+
+**Commit Message**:
+
+```
+feat(feedback): add GeoFeedback and integrate formbuilder
+
+Create feedback app with:
+- Install django-basic-form-builder dependency
+- GeoFeedback: configurable feedback campaign linking to CustomForm
+- rating_enabled and form_enabled configuration toggles
+- FeedbackLayer: M2M junction
+```
+
+---
+
+### Task 3.2: Add FeedbackSubmission Model
+
+**Branch**: `feat/feedback-submission`
+
+**Description**: Add FeedbackSubmission model for ratings, JSON schemas, and geometry.
+
+**Changes**:
+
+- [x] Add FeedbackSubmission model
+- [x] Fields: feedback (FK -> GeoFeedback), rating (Integer 1-5, nullable), form_data (JSONB, nullable), geometry (GeometryField)
+- [x] Add is_anonymized boolean
+
+**Acceptance Criteria**:
+
+- [x] Can store submissions with or without User (nullable FK)
+- [x] Can store geometry (Point/Line/Poly)
+- [x] JSONB field accepts arbitrary dict for dynamic answers to the CustomForm
+
+**Tests**:
+
+```python
+@pytest.mark.django_db
+def test_submission_custom_form_data():
+    sub = FeedbackSubmission.objects.create(rating=5, form_data={"comment": "Hi"})
+    assert sub.rating == 5
+    assert sub.form_data["comment"] == "Hi"
+```
+
+**Commit Message**:
+
+```
+feat(feedback): add FeedbackSubmission model
+
+Add submission model with:
+- feedback FK
+- rating (1-5)
+- form_data JSONB (stores formbuilder answers)
+- geometry (GeometryField for drawings)
+- is_anonymized flag
+```
+
+---
+
+### Task 3.3: GeoFeedback API Endpoints
+
+**Branch**: `feat/feedback-api`
+
+**Description**: Add REST API for GeoFeedback (Admin CRUD, Public Read) and submission.
+
+**Changes**:
+
+- [x] ViewSet for GeoFeedback (Public: ReadOnly; Admin: CRUD)
+- [x] Include the linked `custom_form` slug/URL in the GeoFeedback read schema.
+- [x] Custom action `POST /{id}/submit/` for submissions
+- [x] Validation in submit action: `rating` required if `rating_enabled` is True; `form_data` required if `form_enabled` is True
+
+**Acceptance Criteria**:
+
+- [x] Admin can create/update Feedback forms
+- [x] Anonymous user can submit if allowed
+- [x] Submission validates against Feedback configuration (e.g., rating required if `rating_enabled`; form data validation required if `form_enabled`)
+- [x] CursorPagination for Feedback list
+
+**Tests**:
+
+```python
+def test_submit_feedback_with_rating_and_form(api_client, feedback):
+    # Tests a feedback where both are enabled
+    resp = api_client.post(f"/api/v1/feedback/{feedback.id}/submit/", {
+        "rating": 5,
+        "form_data": {"test_field": "test_answer"}
+    })
+    assert resp.status_code == 201
+```
+
+**Commit Message**:
+
+```
+feat(feedback): add REST API endpoints
+
+Implement GeoFeedback API:
+- GET/POST /api/v1/feedback/ (Admin CRUD, Public Read)
+- POST /api/v1/feedback/{id}/submit/
+
+Supports anonymous submissions, strict feedback config enforcement, and geometry.
+- **Performance**: Use `CursorPagination`.
+```
+
+---
+
+### Task 3.4: Extend FeatureLink for Feedback
+
+**Branch**: `feat/featurelinks-feedback`
+
+**Description**: Verify and test FeatureLink with GeoFeedback.
+
+**Changes**:
+
+- [x] Tests for linking Feedback to other entities
+- [x] Verify Admin UI supports selecting GeoFeedback in generic relation
+
+**Acceptance Criteria**:
+
+- [x] Can link Story -> Feedback (e.g., "Rate this plan")
+- [x] Tests pass
+- [x] Admin UI generic relation picker includes GeoFeedback
+
+**Commit Message**:
+
+```
+test(featurelinks): verify GeoFeedback linking
+
+Add tests for:
+- GeoStory → GeoFeedback links
+- CalendarEvent → GeoFeedback links
+```
+
+---
+
+## Phase 4: Production Readiness
+
+> **Goal**: Optimization and infrastructure hardening.
+
+---
+
+### Task 4.1a: Configure PgBouncer
+
+**Branch**: `chore/pgbouncer-infra`
+
+**Description**: Add PgBouncer connection pooler to production Docker stack.
+
+**Changes**:
+
+- [ ] Add `pgbouncer` service to `docker-compose.prod.yml`
+- [ ] Configure `settings/prod.py` to connect to pgbouncer port
+- [ ] Add pgbouncer.ini / userlist.txt config volume
+
+**Acceptance Criteria**:
+
+- [ ] `docker compose -f docker-compose.prod.yml config` is valid
+- [ ] Application connects via pooler
+
+**Commit Message**:
+
+```
+chore(infra): enable pgbouncer connection pooling
+
+Add pgbouncer service to production stack to manage
+PostGIS connection overhead.
+```
+
+---
+
+### Task 4.1b: Verify Spatial Indexes
+
+**Branch**: `chore/verify-indexes`
+
+**Description**: Audit and verify GiST indexes on all spatial columns.
+
+**Changes**:
+
+- [ ] Create management command `check_spatial_indexes`
+- [ ] Query `pg_indexes` for all geometry columns
+- [ ] Fail if index missing
+
+**Acceptance Criteria**:
+
+- [ ] Command reports OK for current schema
+- [ ] Fails if we drop an index manually
+
+**Commit Message**:
+
+```
+chore(db): add spatial index verification command
+
+Add management command to audit GiST indexes on
+all GeometryField columns.
+```
+
+---
+
+## Phase 5: Security Hardening
+
+> **Goal**: Address security vulnerabilities and harden the application before production deployment.
+
+---
+
+### Task 5.1: Input Sanitization for All Content
+
+**Branch**: `feat/input-sanitization`
+
+**Description**: Implement content sanitization for ALL GeoContext inputs based on `content_type`. This is a security-critical task that must be completed before any API accepts user content.
+
+**Context**: GeoContext stores `content` as raw text. The `content_type` field indicates whether it's simple text or rich HTML. Both types require validation:
+
+- **Simple**: No HTML allowed whatsoever (strip all tags)
+- **Rich**: Only whitelisted HTML tags/attributes allowed
+
+**Attack Vectors Addressed**:
+
+- `<script>` tag injection
+- Event handlers (`onerror`, `onclick`, etc.)
+- CSS injection (`expression()`, malicious `url()`)
+- HTML in "simple" content bypass
+
+**Changes**:
+
+- [x] Add `nh3` dependency to project (`uv add nh3`)
+- [x] Create `tosca_api/apps/core/sanitization.py` with:
+  - `sanitize_simple(content: str) -> str` — strips ALL HTML
+  - `sanitize_rich(content: str) -> str` — allows only whitelisted HTML
+  - `sanitize_content(content: str, content_type: str) -> str` — router function
+- [x] Apply sanitization in GeoContext model `save()` method (enforces security at DB level since Serializers don't exist yet)
+- [x] Add unit tests for both content types
+
+**Sanitization Rules**:
+
+```python
+# For content_type="simple" — NO HTML ALLOWED
+def sanitize_simple(content: str) -> str:
+    """Strip ALL HTML tags, return plain text only."""
+    return nh3.clean(content, tags=set())  # Empty set = strip all
+
+# For content_type="rich" — ALLOWLIST ONLY
+ALLOWED_TAGS = {
+    "p", "br", "strong", "em", "b", "i", "u",
+    "a", "ul", "ol", "li",
+    "h1", "h2", "h3", "h4",
+    "blockquote", "pre", "code",
+    "img", "figure", "figcaption",
+}
+ALLOWED_ATTRS = {
+    "a": {"href", "title", "target"},
+    "img": {"src", "alt", "width", "height"},
+}
+# No inline styles, no event handlers, no javascript: URLs
+
+def sanitize_rich(content: str) -> str:
+    """Allow only whitelisted HTML tags and attributes."""
+    return nh3.clean(
+        content,
+        tags=ALLOWED_TAGS,
+        attributes=ALLOWED_ATTRS,
+        link_rel=None,
+        url_schemes={"http", "https", "mailto"},  # No javascript:
+    )
+```
+
+**Acceptance Criteria**:
+
+- [x] **Simple content**: `<b>Bold</b>` becomes `Bold` (tags stripped)
+- [x] **Rich content**: `<script>alert(1)</script>` is stripped
+- [x] **Rich content**: `<img onerror="alert(1)">` becomes `<img>`
+- [x] **Rich content**: `<a href="javascript:alert(1)">` href is stripped
+- [x] **Rich content**: Valid HTML (e.g., `<p><strong>Hello</strong></p>`) passes through
+- [x] Tests cover both content types and edge cases
+
+**Tests**:
+
+```python
+# tosca_api/apps/core/tests/test_sanitization.py
+import pytest
+from tosca_api.apps.core.sanitization import sanitize_html
+
+def test_removes_script_tags():
+    unsafe = '<p>Hello</p><script>alert(1)</script>'
+    assert '<script>' not in sanitize_html(unsafe)
+    assert '<p>Hello</p>' in sanitize_html(unsafe)
+
+def test_removes_event_handlers():
+    unsafe = '<img src="x" onerror="alert(1)">'
+    result = sanitize_html(unsafe)
+    assert 'onerror' not in result
+
+def test_removes_javascript_urls():
+    unsafe = '<a href="javascript:alert(1)">Click</a>'
+    result = sanitize_html(unsafe)
+    assert 'javascript:' not in result
+
+def test_preserves_safe_html():
+    safe = '<p><strong>Bold</strong> and <em>italic</em></p>'
+    assert sanitize_html(safe) == safe
+```
+
+**Commit Message**:
+
+```
+feat(security): add HTML sanitization for rich content
+
+Implement XSS prevention for GeoContext rich content:
+- Add nh3 dependency for Rust-based HTML sanitization
+- Create allowlist-based sanitizer in core/sanitization.py
+- Strip script tags, event handlers, javascript: URLs
+- Preserve safe semantic HTML tags
+
+Addresses security concern identified in Phase 0.5.
+```
+
+---
+
+### Task 5.2: Rate Limiting for Public Endpoints
+
+**Branch**: `feat/rate-limiting`
+
+**Description**: Implement rate limiting to prevent abuse of public API endpoints.
+
+**Changes**:
+
+- [ ] Add `django-ratelimit` or use DRF's built-in throttling
+- [ ] Configure throttle classes in settings
+- [ ] Apply to public endpoints (campaign list, story detail, etc.)
+
+**Acceptance Criteria**:
+
+- [ ] Anonymous users limited to 100 requests/minute
+- [ ] Authenticated users limited to 1000 requests/minute
+- [ ] Rate limit headers returned in response
+
+**Commit Message**:
+
+```
+feat(security): add rate limiting for API endpoints
+
+Configure DRF throttling to prevent abuse:
+- 100 req/min for anonymous users
+- 1000 req/min for authenticated users
+```
+
+---
+
+### Task 5.3: Security Headers and CORS Hardening
+
+**Branch**: `feat/security-headers`
+
+**Description**: Configure security headers and tighten CORS for production.
+
+**Changes**:
+
+- [ ] Add `django-csp` for Content Security Policy
+- [ ] Configure `SECURE_*` settings in production
+- [ ] Restrict CORS origins for production
+
+**Acceptance Criteria**:
+
+- [ ] CSP header present in responses
+- [ ] X-Frame-Options, X-Content-Type-Options configured
+- [ ] CORS only allows specified origins in production
+
+**Commit Message**:
+
+```
+feat(security): add security headers and CSP
+
+Configure production security:
+- Content Security Policy via django-csp
+- Strict CORS configuration
+- Security headers (X-Frame-Options, etc.)
+```
+
+## Phase 6: Serializer Standardization
+
+> **Goal**: Unify DRF serializers across all business apps, enforcing explicit read-only boundaries and strict validation.
+
+---
+
+### Task 6.1: Standardize `events` and `campaigns` Apps
+
+**Branch**: `chore/standardize-serializers-core`
+
+**Description**: Refactor serializers in the core `events` and `campaigns` applications to use distinct List/Detail/Write serializers, declare `read_only_fields = fields` on read models, and enforce `model.clean()` validation inside `Serializer.validate()`.
+
+**Changes**:
+
+- [x] Rename `CalendarEventCreateSerializer` to `CalendarEventWriteSerializer`
+- [x] Add explicit `CalendarEvent().clean()` call inside `CalendarEventWriteSerializer.validate()`
+- [x] Split `CampaignSerializer` into `CampaignListSerializer`, `CampaignDetailSerializer`, and `CampaignWriteSerializer`
+- [x] Add `read_only_fields = fields` to `CampaignListSerializer` and `CampaignDetailSerializer`
+- [x] Update `events/views.py` and `campaigns/views.py` to route to correct serializers
+
+**Acceptance Criteria**:
+
+- [x] All tests pass
+- [x] `POST /api/v1/events/` validation includes DB-level rules (like start < end) without 500 errors
+
+---
+
+### Task 6.2: Standardize `geostories` and `feedback` Apps
+
+**Branch**: `chore/standardize-serializers-features`
+
+**Description**: Refactor serializers in the `geostories` and `feedback` applications using the unified pattern.
+
+**Changes**:
+
+- [x] Rename `GeoFeedbackCreateUpdateSerializer` to `GeoFeedbackWriteSerializer`
+- [x] Add `read_only_fields = fields` to `GeoFeedbackListSerializer`
+- [x] Add explicit `clean()` enforcement inside `GeoFeedbackWriteSerializer` and `FeedbackSubmissionSerializer`
+- [x] Rename `GeoStorySerializer` to `GeoStoryWriteSerializer`
+- [x] Update `FeatureLinkSerializer`, `GeoContextSerializer`, `LayerRefSerializer` to use `read_only_fields = fields`
+- [x] Refactor `read_only_fields` on `GeoStoryListSerializer` and `GeoStoryDetailSerializer` to conform to `fields` syntax
+- [x] Update respective `views.py` dependencies
+
+**Acceptance Criteria**:
+
+- [x] All tests pass
+- [x] Security boundaries (creation vs retrieve payloads) are rigidly enforced
+
+---
+
+## Phase 7: GeoContext Editor.js Migration
+
+> **Goal**: Replace legacy GeoContext text-plus-`content_type` authoring with canonical Editor.js JSON, deterministic normalization, progressive admin editing, and a staged multi-release migration.
+
+---
+
+### Task 7.1: Canonical GeoContext Editor.js Contract
+
+**Branch**: `feat/geocontext-editorjs-contract`
+
+**Description**: Replace the legacy `GeoContext` string-plus-`content_type` contract with canonical Editor.js JSON. `GeoContext.content` becomes a `JSONField` containing normalized Editor.js block data, and `content_type` is removed from the future model and all read surfaces. This task supersedes the original `content` + `content_type` GeoContext design for future implementation while preserving the old roadmap entries as history.
+
+**Changes**:
+
+- [x] Define `GeoContext.content` as JSON-backed Editor.js content instead of freeform text
+- [x] Remove `content_type` from the future GeoContext model contract
+- [x] Update future nested `GeoContext` read surfaces in `events`, `geostories`, and `feedback` to describe `context.content` as JSON
+- [x] Standardize empty GeoContext content as `{ "blocks": [] }`
+- [x] Remove or mark superseded any future-oriented documentation that still describes the new contract as `content` plus `content_type`
+
+**Acceptance Criteria**:
+
+- [x] `GeoContext.content` is defined as JSON-backed content rather than freeform text
+- [x] `content_type` is removed from the future model, serializers, admin, and schema
+- [x] All nested `GeoContext` read surfaces in events, geostories, and feedback describe `context.content` as JSON
+- [x] Empty content is represented as `{ "blocks": [] }`, not `null`, `""`, or omitted
+- [x] Historical `content_type` references in future-oriented docs for this feature are removed or marked superseded
+
+**Implementation Notes** (completed via PR #105, commit `799f669`):
+
+- `GeoContext.content` redefined as `JSONField(default=empty_editorjs_document, blank=True)` with helper returning `{"blocks": []}`.
+- Destructive migration `0002_editorjs_canonical_contract.py` drops legacy `content_type` and text `content`, adds JSON `content` (pre-production reset; Release 1/2/3 staging in 7.4–7.6 applies only once Phase 7 ships).
+- `GeoContext.save()` normalizes falsy values to the canonical empty document; legacy nh3 sanitization removed from this path (string sanitization still used by Campaign/GeoStory title/summary).
+- Nested `GeoContextSerializer` in `geostories`, `events`, and `feedback` trimmed to `["id", "content"]`.
+- Admin `content_preview` renders truncated JSON of `blocks` or `(empty)`; `content_type` removed from list/filter/fieldsets.
+- `technical-architecture.md` GeoContext section tagged with supersession banner pointing to `decisions.md` §7.1.
+
+**Tests**:
+
+```python
+# Representative test cases
+def test_geocontext_empty_defaults_to_empty_blocks(): ...
+def test_geocontext_persists_editorjs_json_content(): ...
+def test_geostory_detail_serializes_context_content_as_json(): ...
+def test_event_detail_serializes_context_content_as_json(): ...
+def test_feedback_detail_serializes_context_content_as_json(): ...
+def test_schema_contract_omits_content_type_for_future_geocontext_reads(): ...
+```
+
+- [ ] Unit: creating a new empty `GeoContext` yields `{ "blocks": [] }`
+- [ ] Unit: non-empty valid Editor.js content is persisted as JSON
+- [ ] API read: `context.content` serializes as JSON in geostories, events, and feedback detail responses
+- [ ] Schema/doc test: `content_type` no longer appears in the future contract for the affected serializers
+- [ ] Edge case: `content=None` normalizes to `{ "blocks": [] }`
+- [ ] Edge case: missing `content` on write defaults safely to `{ "blocks": [] }`
+
+**Commit Message**:
+
+```text
+feat(geocontext): define canonical Editor.js JSON contract
+
+Replace the future GeoContext content contract with canonical Editor.js JSON:
+- move content to JSON-backed storage
+- remove content_type from the future contract
+- standardize empty documents as {"blocks": []}
+- update nested read surfaces to describe JSON content
+```
+
+---
+
+### Task 7.2: Editor.js Validation and Normalization Layer
+
+**Branch**: `feat/editorjs-validation`
+
+**Description**: Introduce a dedicated `core/editorjs.py` validation and normalization layer for GeoContext Editor.js documents. This module owns block-level schema validation, deterministic normalization, inline HTML sanitization, and rejection of unsupported or ambiguous structures. It is intentionally separate from the legacy HTML sanitizer router.
+
+**Changes**:
+
+- [x] Create a dedicated Editor.js validation module, such as `tosca_api/apps/core/editorjs.py`
+- [x] Validate only the MVP block set: `paragraph`, `header`, `list`, `quote`, `delimiter`, `code`
+- [x] Allow only safe inline formatting in text-bearing fields: `a`, `strong`, `em`, `code`, `br`
+- [x] Normalize `<b>` to `<strong>` and `<i>` to `<em>`
+- [x] Accept full Editor.js save payloads as input but strip `time`, `version`, and block `id` on storage
+- [x] Reject `quote.alignment`
+- [x] Constrain `list.meta` to `{}` for MVP
+- [x] Reject invalid block shapes and unsafe URLs
+
+**Acceptance Criteria**:
+
+- [x] Validation logic lives in a dedicated Editor.js module, not in the legacy HTML sanitizer router
+- [x] Only the MVP block set is accepted: `paragraph`, `header`, `list`, `quote`, `delimiter`, `code`
+- [x] Only allowed inline formatting survives in text-bearing fields: `a`, `strong`, `em`, `code`, `br`
+- [x] `<b>` normalizes to `<strong>` and `<i>` normalizes to `<em>`
+- [x] Full Editor.js save payloads may be accepted as input, but stored documents strip `time`, `version`, and block `id`
+- [x] `quote.alignment` is rejected
+- [x] `list.meta` is allowed only as `{}` for MVP
+- [x] Invalid block shapes or unsafe URLs fail validation
+
+**Implementation Notes**:
+
+- New module `tosca_api/apps/core/editorjs.py` exposes `empty_document()` and `validate_and_normalize(value)`; raises `django.core.exceptions.ValidationError` on invalid shapes, unsupported block types, `quote.alignment`, non-empty `list.meta`, header levels outside 1–4, or `javascript:`-style URLs.
+- Inline sanitization whitelists `a`, `strong`, `em`, `code`, `br` via nh3; `<b>`/`<i>` are rewritten to `<strong>`/`<em>` before sanitization; link schemes restricted to `http`, `https`, `mailto`.
+- `GeoContext.save()` now delegates to `validate_and_normalize`, replacing the prior "normalize empty-only" behavior. Full save envelopes (`time`, `version`, per-block `id`, `tunes`) are stripped to canonical storage form.
+- List items accept either strings (upgraded to `{content, items: []}`) or `{content, items}` dicts (recursively normalized); nested lists preserve shape.
+- 18 unit tests added under `tosca_api/apps/core/tests/test_editorjs.py` covering supported blocks, envelope stripping, semantic tag normalization, script/handler stripping, `javascript:` rejection, unsupported block types, header level bounds, `quote.alignment`, `list.meta` constraint, nested lists, invalid shapes, and byte-equal round-trip.
+
+**Tests**:
+
+```python
+# Representative test cases
+def test_editorjs_accepts_supported_block_types(): ...
+def test_editorjs_normalizes_save_envelope_to_canonical_storage(): ...
+def test_editorjs_normalizes_b_and_i_tags(): ...
+def test_editorjs_rejects_quote_alignment(): ...
+def test_editorjs_rejects_non_empty_list_meta(): ...
+def test_editorjs_rejects_unsupported_block_type(): ...
+```
+
+- [ ] Unit: valid paragraph/header/list/quote/delimiter/code blocks are accepted
+- [ ] Unit: full Editor.js payload with `time`, `version`, and block `id` normalizes to canonical storage shape
+- [ ] Unit: `<b>` and `<i>` normalize to semantic tags
+- [ ] Unit: inline `<script>` and event-handler HTML are stripped or rejected appropriately
+- [ ] Unit: `javascript:` links are rejected or sanitized away
+- [ ] Edge case: unsupported block type fails with explicit validation error
+- [ ] Edge case: header level outside `1-4` fails
+- [ ] Edge case: `quote.alignment` present fails
+- [ ] Edge case: `list.meta` with non-empty keys fails
+- [ ] Edge case: repeated normalize-save-reload-save remains byte-equal
+
+**Commit Message**:
+
+```text
+feat(core): add Editor.js validation and normalization layer
+
+Introduce deterministic Editor.js validation for GeoContext:
+- dedicated core/editorjs.py module
+- strict MVP block schema enforcement
+- inline HTML sanitization and semantic tag normalization
+- canonical storage without time/version/block ids
+```
+
+---
+
+### Task 7.3: Django Admin Editor.js Authoring
+
+**Branch**: `feat/geocontext-editorjs-admin`
+
+**Description**: Add Editor.js authoring to Django admin for GeoContext as progressive enhancement. The underlying form field remains a JSON textarea for no-JS fallback, while JavaScript upgrades it into an Editor.js editing surface and mirrors content back into the textarea before submit. The work also includes vendored static assets, license files, and changelist preview behavior.
+
+**Changes**:
+
+- [x] Add a JSON textarea-backed GeoContext admin form/widget
+- [x] Enhance the textarea with Editor.js when admin JavaScript loads successfully
+- [x] Mirror edited content back into the textarea before submit using standard Django POST submission
+- [x] Vendor Editor.js assets into Django static files instead of loading from a CDN
+- [x] Include required upstream license files with the vendored assets
+- [x] Add changelist plain-text preview extraction with truncation and empty-state handling
+
+**Acceptance Criteria**:
+
+- [x] GeoContext admin uses an Editor.js-powered editing surface when JS loads successfully
+- [x] The non-JS fallback remains a plain textarea containing canonical JSON
+- [x] Form submission relies on standard Django POST behavior; no custom AJAX write path is introduced
+- [x] Editor.js assets are vendored into static files, not loaded from a CDN
+- [x] Required upstream license files are included alongside vendored assets
+- [x] Changelist preview shows extracted plain text, truncated, and displays `(empty)` for empty documents
+
+**Implementation Notes**:
+
+- `tosca_api/apps/geocontext/widgets.py` defines `EditorJsWidget` (subclass of `forms.Textarea`) with a `Media` class loading six vendored scripts plus `init.js` and `editor.css`. `format_value` always emits canonical JSON (defaults to `{"blocks": []}`).
+- `tosca_api/apps/geocontext/forms.py` defines `GeoContextAdminForm` using the widget for `content`; model-level `JSONField` pre-parses strings, and `clean_content` normalizes `""`/`None`/`{}` to `{"blocks": []}` and surfaces JSON-decode errors as form errors.
+- `tosca_api/apps/geocontext/admin.py` wires the form into `GeoContextAdmin` and replaces the raw-JSON preview with `_extract_plain_text`, which flattens paragraph/header/quote/code/list content and returns `(empty)` when no text is present; long previews are truncated to 75 chars plus ellipsis.
+- Vendored assets under `tosca_api/apps/geocontext/static/geocontext/editorjs/vendor/`: `editorjs.umd.js@2.30.7`, `header@2.8.8`, `list@1.10.0` (UMD build), `quote@2.7.3`, `delimiter@1.4.2`, `code@2.9.3`, plus `LICENSE.*` files for each upstream package (all MIT).
+- `init.js` is a progressive-enhancement script: for each `textarea[data-editorjs-target]`, it hides the textarea, mounts Editor.js with the MVP toolset, mirrors content back to the textarea on change and on `submit`, and relies on standard form POST. JS disabled or missing → raw JSON textarea remains fully usable.
+- Widget template at `tosca_api/apps/geocontext/templates/geocontext/widgets/editorjs.html` renders the textarea with help text describing the fallback path.
+- Tests added under `tosca_api/apps/geocontext/tests/test_admin.py` (11 cases) cover widget Media, CDN absence, license file presence, admin change/add render, form parse/persist, malformed JSON rejection, `clean_content` defensive branches, plain-text extraction across block types, and changelist preview empty/truncation behavior.
+- Fixes a pre-existing fixture regression in `featurelinks/tests/test_models.py` that still created GeoContext with a plain string (now JSON), uncovered once Task 7.2 tightened validation.
+
+**Tests**:
+
+```python
+# Representative test cases
+def test_geocontext_admin_includes_editorjs_assets(): ...
+def test_geocontext_admin_renders_json_textarea_fallback(): ...
+def test_geocontext_admin_hydrates_stored_json_on_edit(): ...
+def test_geocontext_admin_preview_truncates_long_content(): ...
+def test_geocontext_admin_preview_handles_empty_document(): ...
+```
+
+- [ ] Admin render: widget assets are included on the GeoContext admin form
+- [ ] Admin render: raw textarea is present before enhancement
+- [ ] Admin behavior: stored JSON hydrates into the editor on edit
+- [ ] Admin submit: edited content is mirrored back into the form field and persists correctly
+- [ ] Admin list: preview is truncated consistently for long documents
+- [ ] Edge case: empty document shows `(empty)` in changelist preview
+- [ ] Edge case: JS not loading still permits valid raw JSON submission
+- [ ] Edge case: malformed JSON pasted into the textarea fails with a clear validation error
+
+**Commit Message**:
+
+```text
+feat(admin): add Editor.js authoring for GeoContext
+
+Add progressive Editor.js authoring in Django admin:
+- JSON textarea fallback
+- JS enhancement without custom AJAX writes
+- vendored assets and license files
+- plain-text preview extraction for changelists
+```
+
+---
+
+### Task 7.4: GeoContext Preflight and HTML-to-Blocks Backfill
+
+**Branch**: `feat/geocontext-editorjs-preflight`
+
+**Description**: Add a read-only preflight command and the Release 1 backfill logic that converts existing GeoContext rows from legacy string or HTML content into canonical Editor.js JSON. Conversion must be deterministic and must abort on legacy media-bearing content rather than silently dropping it.
+
+**Changes**:
+
+- [x] Add a non-mutating preflight command that scans existing GeoContext rows and reports exact sorted IDs that cannot be migrated
+- [x] Make the preflight command read-only and idempotent
+- [x] Convert legacy simple content to paragraph blocks or `{ "blocks": [] }` when blank
+- [x] Sanitize legacy rich HTML first, then parse it into canonical blocks
+- [x] Implement fixed mappings for headers, paragraphs, nested lists, blockquotes, code blocks, inline code, and `<br>`
+- [x] Abort on rows containing `img`, `figure`, or `figcaption`
+- [x] Ensure the data migration uses the same detection logic as the preflight command
+
+**Acceptance Criteria**:
+
+- [x] A preflight command scans existing GeoContext rows and reports the exact sorted IDs that cannot be migrated
+- [x] The preflight command is read-only and idempotent
+- [x] Legacy simple content maps to paragraph blocks or `{ "blocks": [] }` when blank
+- [x] Legacy rich content is sanitized first, then parsed into blocks
+- [x] Supported HTML mappings are fixed and documented: headers, paragraphs, nested lists, blockquotes, code blocks, inline code, `<br>`
+- [x] Rows containing `img`, `figure`, or `figcaption` abort migration with explicit IDs
+- [x] The data migration uses the same detection logic as the preflight command
+
+**Tests**:
+
+```python
+# Representative test cases
+def test_migrate_blank_simple_content_to_empty_blocks(): ...
+def test_migrate_simple_text_to_single_paragraph_block(): ...
+def test_migrate_rich_html_to_deterministic_blocks(): ...
+def test_migrate_nested_lists_preserves_shape(): ...
+def test_preflight_is_read_only_and_repeatable(): ...
+def test_preflight_reports_exact_media_blocking_ids(): ...
+```
+
+- [x] Migration unit: blank simple content becomes `{ "blocks": [] }`
+- [x] Migration unit: simple text becomes one paragraph block
+- [x] Migration unit: supported rich HTML becomes deterministic block JSON
+- [x] Migration unit: nested `<ul>/<ol>` structures preserve nested list shape
+- [x] Migration unit: `<pre><code>` becomes `code` block and inline `<code>` remains inline
+- [x] Migration unit: `<br>` inside paragraphs is preserved
+- [x] Preflight test: command output is sorted and stable across repeated runs
+- [x] Preflight test: command does not mutate database rows
+- [x] Edge case: mixed top-level text nodes outside block tags are folded into paragraph blocks
+- [x] Edge case: sanitized unknown non-media tags do not create undefined block types
+- [x] Edge case: rows with `img`/`figure`/`figcaption` fail and list exact IDs
+
+**Implementation Notes**:
+
+- `tosca_api/apps/core/legacy_html.py` — reusable converter. Exposes
+  `convert_legacy_html(html) -> dict` and `LegacyHtmlMediaError`. Uses
+  `html.parser.HTMLParser` (stdlib; avoids pulling in bs4/lxml).
+  Sanitization runs through `sanitize_rich()` before parsing so the
+  pipeline mirrors the original sanitizer → block contract.
+- Blocking media detection (`img`, `figure`, `figcaption`) happens **before**
+  sanitization so the preflight reports the presence of legacy media
+  verbatim regardless of whether nh3 would have stripped it.
+- Inline tags inside `<pre>` are suppressed so `<pre><code>...</code></pre>`
+  and bare `<pre>...</pre>` both yield a canonical `code` block carrying
+  only the inner text (single leading/trailing newline trimmed).
+- Orphan top-level text nodes between block tags are folded into their
+  own paragraph blocks; unknown non-media wrappers (e.g. `<section>`) are
+  skipped without inventing block types for them.
+- `tosca_api/apps/geocontext/management/commands/geocontext_preflight.py`
+  — read-only Django management command. Scans existing rows with
+  `validate_and_normalize` (stable sort by UUID) and, with
+  `--legacy-input-json path`, dry-runs the HTML converter against a
+  `{id: html}` file to surface media-blocked rows by their input ID.
+  The command never writes to the DB.
+- Release 1 reset means no legacy HTML rows exist in production, so the
+  converter + preflight land as reusable tooling. Later releases can
+  drive any real migration through the same detection logic, satisfying
+  the "migration and preflight agree" acceptance bullet.
+
+**Commit Message**:
+
+```text
+feat(geocontext): add Editor.js preflight and legacy backfill
+
+Prepare Release 1 GeoContext migration:
+- read-only idempotent preflight command
+- deterministic HTML-to-block conversion
+- nested list and code block handling
+- explicit abort on legacy media-bearing rows
+```
+
+---
+
+### Task 7.5: Release 2 Switch to `content_json`
+
+**Branch**: `feat/geocontext-editorjs-switch`
+
+**Description**: Switch application reads and writes to the new JSON-backed GeoContext field while retaining the legacy columns for rollback safety. This release moves the app behavior to the new contract without yet dropping the old fields.
+
+**Changes**:
+
+- [x] Switch all application reads to `content_json` as the GeoContext source of truth *(folded — Task 7.1 destructive reset already made `GeoContext.content` the canonical JSON column; there is no separate `content_json` field to switch to)*
+- [x] Switch all application writes and validation paths to `content_json` *(folded — writes flow through `validate_and_normalize` in `GeoContext.save()` plus the admin form; see Task 7.2/7.3)*
+- [~] Keep legacy columns present for rollback safety during Release 2 *(N/A — Task 7.1 dropped `content_type` and the legacy text column destructively in migration `0002_editorjs_canonical_contract`; phased rollback via legacy columns is no longer available)*
+- [x] Update events, geostories, and feedback nested serializers to emit the JSON-backed content contract
+- [x] Remove active read/write dependencies on `content_type`
+
+**Acceptance Criteria**:
+
+- [x] All application reads use `content_json` as the source of truth *(reads use `GeoContext.content`, canonical JSON)*
+- [x] All application writes populate and validate `content_json` *(writes go through `validate_and_normalize`)*
+- [~] Legacy columns remain present but are no longer the active read/write path *(N/A — see 7.1 destructive reset)*
+- [x] Events, geostories, and feedback nested serializers all emit the JSON-backed content contract
+- [~] Rollback remains possible because legacy columns are still available during this release *(N/A — see 7.1 destructive reset)*
+
+**Tests**:
+
+```python
+# Representative test cases
+def test_geostory_detail_reads_content_json(): ...
+def test_event_detail_reads_content_json(): ...
+def test_feedback_detail_reads_content_json(): ...
+def test_admin_edit_updates_content_json(): ...
+def test_no_active_path_depends_on_content_type(): ...
+```
+
+- [ ] Integration: geostories detail reads from JSON-backed context data
+- [ ] Integration: events detail reads from JSON-backed context data
+- [ ] Integration: feedback detail reads from JSON-backed context data
+- [ ] Integration: admin edits update the JSON-backed field
+- [ ] Regression: no active serializer or admin form still depends on `content_type`
+- [ ] Edge case: rows with empty migrated content still serialize as `{ "blocks": [] }`
+- [ ] Edge case: old columns remaining populated do not affect the read path once switched
+
+**Commit Message**:
+
+```text
+feat(geocontext): switch application reads and writes to content_json
+
+Move GeoContext behavior to the new JSON source of truth:
+- read/write through content_json
+- keep legacy columns for rollback safety
+- update nested serializers and admin paths
+```
+
+**Implementation Notes**:
+
+- The original phased plan (add `content_json`, switch, then drop legacy)
+  was collapsed by Task 7.1, which dropped `content_type` and the legacy
+  text column in one destructive migration. `GeoContext.content` is
+  already the canonical Editor.js JSON field and phased rollback via
+  the legacy columns is no longer a safety net. See decisions.md §[7.5].
+- Nested serializers already expose the JSON contract:
+  `GeoStoryDetailSerializer.context` (via `GeoContextSerializer`),
+  `EventDetailSerializer.context` (via `EventGeoContextSerializer` +
+  `effective_context` series-default resolution), and
+  `GeoFeedbackDetailSerializer.context` (via
+  `FeedbackGeoContextSerializer`). Each exposes `content` as a dict and
+  does not expose a `content_type` discriminator.
+- Removed the dead `tosca_api.apps.core.sanitization.sanitize_content`
+  helper and its standalone test. The helper dispatched on the retired
+  `content_type` string ('simple'/'rich') and was only called by the
+  pre-7.1 `GeoContext.save()`. Remaining sanitization uses
+  `sanitize_simple()` / `sanitize_rich()` directly at each call site.
+- Added `tosca_api/apps/geocontext/tests/test_json_contract.py` (14
+  cases) as the final regression guard covering geostory/event/feedback
+  detail contract, empty-context serialization as `{"blocks": []}`,
+  admin save round-trip, absence of `content_type` on the model, and a
+  guard against re-introducing `sanitize_content`.
+
+---
+
+### Task 7.6: Release 3 Drop Legacy GeoContext Fields
+
+**Branch**: `feat/geocontext-editorjs-cleanup`
+
+**Description**: Complete the migration by removing the legacy GeoContext string fields, renaming `content_json` back to `content`, and finalizing the codebase on the canonical Editor.js contract.
+
+**Changes**:
+
+- [x] Drop the legacy text `content` column and `content_type` *(landed in Task 7.1 via migration `0002_editorjs_canonical_contract`)*
+- [~] Rename `content_json` back to `content` *(N/A — `content_json` was never introduced; destructive 7.1 promoted JSON directly onto `content`)*
+- [x] Remove any remaining model, serializer, admin, migration helper, or doc references to the old fields *(`sanitize_content` helper removed in Task 7.5; post-sweep confirms no remaining in-app references to `content_json` or to a GeoContext `content_type` discriminator)*
+- [x] Align the final schema and codebase with the canonical Editor.js contract
+- [x] Add final regression coverage across model, admin, and nested serializer surfaces
+
+**Acceptance Criteria**:
+
+- [x] Legacy `content` text column and `content_type` are dropped *(Task 7.1)*
+- [~] `content_json` is renamed to `content` *(N/A — never introduced)*
+- [x] No model, serializer, admin, migration helper, or doc for the new path refers to the old fields
+- [x] The final schema and codebase align exactly with the canonical Editor.js contract
+- [x] Regression coverage confirms behavior is unchanged after the rename
+
+**Tests**:
+
+```python
+# Representative test cases
+def test_final_schema_contains_only_json_content_field(): ...
+def test_geocontext_crud_works_after_final_rename(): ...
+def test_nested_serializers_preserve_json_contract_after_cleanup(): ...
+def test_admin_editor_still_loads_after_final_rename(): ...
+```
+
+- [x] Migration test: final schema contains only the canonical JSON `content` field *(`test_geocontext_final_schema_snapshot` pins `{id, title, content, created_by, created_at, updated_at}` and explicitly rejects `content_type` / `content_json`)*
+- [x] Regression: GeoContext create/read/update still works after rename *(`test_geocontext_crud_round_trip`)*
+- [x] Regression: nested serializers still emit the same JSON contract after cleanup *(Task 7.5 `test_json_contract.py` covers geostory / event / feedback detail endpoints)*
+- [x] Regression: admin editor still loads and saves correctly after rename *(Task 7.3 `test_admin.py` covers change-form render + JSON persistence)*
+- [~] Edge case: migration from a Release 2 state with empty and populated rows succeeds without data loss *(N/A — no Release 2 state ever existed; see decision §[7.5b])*
+
+**Implementation Notes**:
+
+- Task 7.6 was almost entirely superseded: Task 7.1 already dropped
+  `content_type` and the legacy text column, and `content_json` was
+  never introduced, so there is no legacy schema to clean up and no
+  column to rename.
+- Remaining work landed as two regression locks in
+  `tosca_api/apps/geocontext/tests/test_models.py`:
+  1. `test_geocontext_final_schema_snapshot` pins the exact set of
+     concrete `GeoContext` fields (`id`, `title`, `content`,
+     `created_by`, `created_at`, `updated_at`) and fails loud if a
+     retired name (`content_type`, `content_json`) reappears.
+  2. `test_geocontext_crud_round_trip` exercises the full
+     create / read / update / delete path through the canonical JSON
+     save pipeline.
+- Full-repo sweep (`grep -R content_json tosca_api/`,
+  `grep -R content_type tosca_api/apps/geocontext/`) confirms no
+  residual references: `content_type` matches in `featurelinks`,
+  `events`, and `geostories` refer to Django's unrelated
+  `contenttypes.ContentType` generic-relations, not to the retired
+  GeoContext discriminator.
+
+**Commit Message**:
+
+```text
+feat(geocontext): finalize Editor.js migration and remove legacy fields
+
+Complete the GeoContext migration:
+- drop legacy content and content_type fields
+- rename content_json back to content
+- remove obsolete references
+- preserve the canonical Editor.js JSON contract
+```
+
+---
+
+## Phase 8: GeoData Provider Integration & LayerRef Refactor
+
+> **Goal**: Replace the standalone `layerrefs` indirection with direct foreign keys to `geodata_providers.Layer` so GeoStory, Event, and GeoFeedback consume canonical layer metadata (geometry, SRID, publishing state, public flag, published URL) from one source of truth, and stop maintaining a parallel layer registry.
+>
+> **Context**:
+>
+> - `geodata_providers` already models `GeodataEngine → Workspace → Store → Layer → Style` and synchronizes layer state with GeoServer/Martin/pg_tileserv via `GeoServerSyncService` and `EngineClientFactory`. It is the canonical layer registry.
+> - `layerrefs.LayerRef` currently holds a free-form `layer_name` (`"workspace:layername"`) and is the M2M target of `GeoStory.layers`, `GeoFeedback.layers`, and `Event.layers` via per-app through models with `display_order`.
+> - There is no FK or resolver between `LayerRef` and `Layer`. Consumers cannot verify a layer exists, is published, is public, or read its geometry/SRID/published URL without parsing the string.
+> - The system is not yet in production. Backward-compatible shims are not required. A destructive schema reset for the affected through-tables is acceptable.
+>
+> **Key Outcomes**:
+>
+> - `GeoStoryLayer`, `EventLayer`, and `FeedbackLayer` reference `geodata_providers.Layer` directly via FK, with `display_order` preserved per parent.
+> - `layerrefs` app, `LayerRefSerializer`, and string-based layer references are removed.
+> - All three consumer apps validate that assigned layers are public + published.
+> - Detail responses for GeoStory / Event / GeoFeedback expose layer summaries (`id`, `name`, `workspace`, `geometry_type`, `srid`, `published_url`, `is_public`, `publishing_state`) instead of just `layer_name`.
+> - Admins deleting a `Layer` see a usage count across consuming apps before confirming.
+> - `Task 1.4a` (LayerRef Sync Client) and `Task 1.4b` (LayerRef Sync Endpoint) are superseded by the existing `GeoServerSyncService` in `geodata_providers`.
+> - `Task 1.3b` (GeoStory Nested Writes) is reframed: the `layers` write contract becomes a list of `Layer.id` UUIDs instead of `layer_name` strings.
+
+---
+
+### Task 8.1: Replace `layerrefs.LayerRef` FK with `geodata_providers.Layer` FK
+
+**Branch**: `feat/layerref-direct-fk`
+
+**Description**: Swap the FK target on `GeoStoryLayer.layer`, `EventLayer.layer`, and `FeedbackLayer.layer` from `layerrefs.LayerRef` to `geodata_providers.Layer`. Re-declare the M2M `layers` field on `GeoStory`, `Event`, and `GeoFeedback` to point at `geodata_providers.Layer` through the existing through models. Preserve `display_order`, the auto-increment `save()` logic, and the `(parent, layer)` uniqueness constraint on each through model.
+
+**Changes**:
+
+- [ ] Change `GeoStoryLayer.layer` FK from `"layerrefs.LayerRef"` to `"geodata_providers.Layer"`, `on_delete=CASCADE`, `related_name="geostory_uses"`
+- [ ] Change `EventLayer.layer` FK from `"layerrefs.LayerRef"` to `"geodata_providers.Layer"`, `on_delete=CASCADE`, `related_name="event_uses"`
+- [ ] Change `FeedbackLayer.layer` FK from `"layerrefs.LayerRef"` to `"geodata_providers.Layer"`, `on_delete=CASCADE`, `related_name="feedback_uses"`
+- [ ] Re-declare `GeoStory.layers`, `Event.layers`, `GeoFeedback.layers` M2M with `to="geodata_providers.Layer"` and `through=` unchanged
+- [ ] Preserve existing `display_order` semantics, `Meta.ordering`, the auto-increment `save()` logic, and the `(parent, layer)` uniqueness constraints
+- [ ] Generate migrations for `geostories`, `events`, `feedback` that swap the FK target (destructive: existing through-rows referencing `LayerRef` are dropped during the migration since the system is not yet in production)
+- [ ] Update model docstrings and admin registrations that mention `LayerRef`
+
+**Acceptance Criteria**:
+
+- [ ] All three through models reference `geodata_providers.Layer` directly
+- [ ] `display_order` ordering still works the same way per parent
+- [ ] The same `Layer` can be assigned to multiple parents at different `display_order` values without conflict
+- [ ] Migrations apply cleanly on a destructive reset
+- [ ] No `LayerRef` import remains in `geostories`, `events`, or `feedback`
+
+**Tests**:
+
+- [ ] Each through model can be created with a `Layer` FK and an explicit `display_order`
+- [ ] The same `Layer` assigned to two different parents persists with independent `display_order` values
+- [ ] Adding a layer without `display_order` auto-increments per parent
+- [ ] `(parent, layer)` uniqueness still rejects duplicate assignments to the same parent
+
+**Commit Message**:
+
+```text
+feat(layers): point GeoStory/Event/Feedback through-models at Layer
+
+Replace the layerrefs.LayerRef FK on GeoStoryLayer, EventLayer, and
+FeedbackLayer with a direct FK to geodata_providers.Layer. Re-declare
+the M2M layers field on each parent. Preserve display_order, ordering,
+auto-increment, and (parent, layer) uniqueness.
+
+Destructive migration: pre-production, no row preservation required.
+```
+
+---
+
+### Task 8.2: Remove `layerrefs` App
+
+**Branch**: `feat/layerrefs-app-removal`
+
+**Description**: Now that no consumer references `layerrefs.LayerRef`, delete the app entirely. Drop the `layerrefs_layerref` table, remove the directory, deregister from `INSTALLED_APPS`, and delete the `LayerRefSerializer` from `geostories`.
+
+**Changes**:
+
+- [ ] Add a destructive migration that drops the `layerrefs_layerref` table
+- [ ] Remove `tosca_api.apps.layerrefs` from `INSTALLED_APPS`
+- [ ] Delete the `tosca_api/apps/layerrefs/` directory in full (models, admin, migrations, tests)
+- [ ] Remove `LayerRefSerializer` from `tosca_api/apps/geostories/serializers.py`
+- [ ] Remove any remaining `from tosca_api.apps.layerrefs...` imports across the codebase
+- [ ] Update `Task 0.6` ("Create `layerrefs` App") to reference this removal in implementation notes
+
+**Acceptance Criteria**:
+
+- [ ] `INSTALLED_APPS` no longer lists `layerrefs`
+- [ ] `tosca_api/apps/layerrefs/` no longer exists
+- [ ] `LayerRefSerializer` no longer exists in `geostories`
+- [ ] `grep -R LayerRef tosca_api/` returns zero matches in production code
+- [ ] Migrations apply cleanly
+
+**Tests**:
+
+- [ ] Repo-level grep test (or equivalent CI assertion) confirms no `LayerRef` references in `tosca_api/apps/`
+- [ ] Existing geostories / events / feedback tests still pass after removal
+
+**Commit Message**:
+
+```text
+chore(layerrefs): remove layerrefs app
+
+The LayerRef indirection has been replaced by direct FKs to
+geodata_providers.Layer. Drop the app, the layerrefs_layerref table,
+INSTALLED_APPS entry, the LayerRefSerializer, and any remaining imports.
+```
+
+---
+
+### Task 8.3: Public + Published Validation on Layer Assignment
+
+**Branch**: `feat/layer-assignment-validation`
+
+**Description**: Add `clean()` validation on `GeoStoryLayer`, `EventLayer`, and `FeedbackLayer` so only layers with `is_public=True` and `publishing_state="PUBLISHED"` can be assigned. Use Django `ValidationError` so admin and DRF surface form-friendly errors.
+
+**Changes**:
+
+- [ ] Add `clean()` to each through model rejecting layers where `is_public=False` or `publishing_state != "PUBLISHED"`
+- [ ] Surface validation errors through DRF write serializers on each consuming app so API clients see 400 with a clear message
+- [ ] Surface validation errors through admin inline saves
+- [ ] Document the rule in each through model's docstring
+
+**Acceptance Criteria**:
+
+- [ ] Assigning a non-public layer is rejected from API and admin
+- [ ] Assigning a non-published layer is rejected from API and admin
+- [ ] Assigning a public + published layer succeeds
+- [ ] Existing valid through-rows continue to round-trip without revalidation errors
+
+**Tests**:
+
+- [ ] Through-model `clean()` rejects `is_public=False`
+- [ ] Through-model `clean()` rejects `publishing_state` other than `PUBLISHED`
+- [ ] Through-model `clean()` accepts public + published layers
+- [ ] DRF writes return 400 with the expected validation message on each consuming app
+- [ ] Admin inline save shows the validation error instead of partially persisting
+
+**Commit Message**:
+
+```text
+feat(layers): enforce public + published layer assignment
+
+Add clean() validation on GeoStoryLayer, EventLayer, and FeedbackLayer
+so only layers with is_public=True and publishing_state=PUBLISHED can
+be attached to a GeoStory, Event, or GeoFeedback.
+```
+
+---
+
+### Task 8.4: `LayerSummarySerializer` and Detail Response Hydration
+
+**Branch**: `feat/layer-summary-serializer`
+
+**Description**: Add a slim, reusable `LayerSummarySerializer` in `geodata_providers` (or a dedicated shared module) that exposes the fields consumers actually need — `id`, `name`, `workspace`, `geometry_type`, `srid`, `published_url`, `is_public`, `publishing_state`. Wire it into GeoStory detail, Event detail, and GeoFeedback detail responses so the frontend gets full layer metadata in one call.
+
+**Changes**:
+
+- [ ] Add `LayerSummarySerializer` exposing `id`, `name`, `workspace` (nested `{id, name}`), `geometry_type`, `srid`, `published_url`, `is_public`, `publishing_state`
+- [ ] Replace nested layer output in GeoStory detail serializer with `LayerSummarySerializer` plus `display_order`
+- [ ] Add nested layer output to Event detail serializer using the same shape
+- [ ] Add nested layer output to GeoFeedback detail serializer using the same shape
+- [ ] Optimize querysets with `select_related("workspace")` and `prefetch_related` on the through tables to avoid N+1 queries
+- [ ] Update OpenAPI schema annotations for the three detail endpoints
+
+**Acceptance Criteria**:
+
+- [ ] GeoStory detail returns each linked layer as a `LayerSummary` object (not just `layer_name`)
+- [ ] Event detail returns linked layers as `LayerSummary` objects
+- [ ] GeoFeedback detail returns linked layers as `LayerSummary` objects
+- [ ] Each linked-layer entry includes `display_order`
+- [ ] No N+1 queries on detail endpoints (verified via test or `assertNumQueries`)
+- [ ] OpenAPI schema reflects the new layer summary contract
+
+**Tests**:
+
+- [ ] GeoStory detail response includes `geometry_type`, `srid`, `published_url`, `is_public`, `publishing_state`, and `display_order` for each linked layer
+- [ ] Event detail response shape matches the GeoStory shape
+- [ ] GeoFeedback detail response shape matches the GeoStory shape
+- [ ] `assertNumQueries` test confirms detail-endpoint queries are bounded regardless of layer count
+
+**Commit Message**:
+
+```text
+feat(layers): add LayerSummarySerializer and wire it into detail APIs
+
+Expose canonical layer metadata (geometry_type, srid, published_url,
+is_public, publishing_state) on GeoStory, Event, and GeoFeedback detail
+endpoints by replacing the legacy LayerRef name-only output with a
+shared LayerSummarySerializer plus display_order from the through model.
+```
+
+---
+
+### Task 8.5: Replace String Layer Writes With UUID-Based Writes
+
+**Branch**: `feat/layer-uuid-writes`
+
+**Description**: Update the write contract for GeoStory, Event, and GeoFeedback so the `layers` payload accepts a list of `Layer.id` UUIDs (with optional `display_order`) instead of `layer_name` strings. This supersedes `Task 1.3b`'s nested-writes contract for layers.
+
+**Changes**:
+
+- [ ] Update GeoStory write serializer to accept `layers` as a list of `{id: <uuid>, display_order: <int>}` objects (or a plain UUID list with auto-incremented order)
+- [ ] Update Event write serializer with the same contract
+- [ ] Update GeoFeedback write serializer with the same contract
+- [ ] Drop any `layer_name` string parsing path
+- [ ] Resolve UUIDs to `Layer` instances and feed them through the through-model `clean()` so validation runs (Task 8.3)
+- [ ] Atomic transactions for nested writes
+- [ ] Update OpenAPI schema and any consumer-facing examples
+- [ ] Update `Task 1.3b` to mark its "layers list of layer_name" sub-bullet superseded; the rest of `1.3b` (context nested writes) is unchanged
+
+**Acceptance Criteria**:
+
+- [ ] POST/PATCH bodies accept layers by UUID and persist them through the existing through models
+- [ ] An invalid / unknown / non-public / non-published UUID returns a clear 400 error
+- [ ] Nested writes are atomic
+- [ ] String-based `layer_name` payloads are no longer accepted
+- [ ] OpenAPI schema reflects the UUID contract
+
+**Tests**:
+
+- [ ] GeoStory create with a list of `Layer` UUIDs persists `GeoStoryLayer` rows in the supplied order
+- [ ] Event create with the UUID contract persists `EventLayer` rows
+- [ ] GeoFeedback create with the UUID contract persists `FeedbackLayer` rows
+- [ ] Unknown UUID returns 400
+- [ ] Non-public layer UUID returns 400
+- [ ] Non-published layer UUID returns 400
+- [ ] String `layer_name` payloads are rejected with a clear error
+
+**Commit Message**:
+
+```text
+feat(layers): switch nested layer writes to Layer UUIDs
+
+Replace the legacy layer_name string contract on GeoStory, Event, and
+GeoFeedback nested writes with a Layer UUID list. Validation runs
+through the through-model clean() introduced in Task 8.3.
+
+Supersedes the layers sub-bullet of Task 1.3b.
+```
+
+---
+
+### Task 8.6: Pre-delete Usage Warning for `Layer`
+
+**Branch**: `feat/layer-delete-usage-warning`
+
+**Description**: Before a `Layer` is deleted (admin or API path), surface a count of GeoStory / Event / GeoFeedback rows that reference it via the new `geostory_uses`, `event_uses`, `feedback_uses` related managers. Admins must confirm the cascade. API deletes return the usage count in the response so callers can warn the user.
+
+**Changes**:
+
+- [ ] Add a helper `Layer.usage_summary() -> dict[str, int]` returning counts via the related managers
+- [ ] Override the `Layer` admin delete confirmation template (or `delete_view` / `delete_selected` action) to show usage counts and a warning banner
+- [ ] In the `LayerViewSet` `destroy` action, return `{usage: {...}, deleted: true/false}`. If `?confirm=true` is not supplied and usage is non-zero, return `409 Conflict` with the usage breakdown instead of deleting
+- [ ] Document the confirmation behavior in OpenAPI
+
+**Acceptance Criteria**:
+
+- [ ] Admin delete confirmation shows usage counts for each consuming app
+- [ ] API delete without `?confirm=true` against a referenced layer returns 409 with usage counts
+- [ ] API delete with `?confirm=true` against a referenced layer cascades and removes through-rows
+- [ ] API delete against an unused layer succeeds without requiring confirmation
+- [ ] Cascade behavior is unchanged at the schema level (`on_delete=CASCADE` on through-models stays)
+
+**Tests**:
+
+- [ ] `Layer.usage_summary()` returns the correct counts across the three consuming apps
+- [ ] Admin delete confirmation page renders the usage warning
+- [ ] API destroy without `confirm=true` on a referenced layer returns 409 + usage payload
+- [ ] API destroy with `confirm=true` on a referenced layer cascades and removes the through-rows
+- [ ] API destroy on an unreferenced layer returns 204
+
+**Commit Message**:
+
+```text
+feat(geodata-providers): warn before deleting a referenced Layer
+
+Add Layer.usage_summary() and surface counts of dependent GeoStory,
+Event, and GeoFeedback rows in admin delete confirmation and the
+LayerViewSet destroy action. API destroy returns 409 unless the caller
+opts in with ?confirm=true.
+```
+
+---
+
+### Task 8.7: Supersede `Task 1.4a` and `Task 1.4b`
+
+**Branch**: `chore/supersede-layerref-sync`
+
+**Description**: Mark the legacy LayerRef sync tasks as superseded by `geodata_providers`. The `geodata_providers` app already exposes `GeoServerSyncService` and `EngineClientFactory` for syncing layers from GeoServer / Martin / pg_tileserv, plus admin actions and an `engines/{id}/sync` API path. There is no remaining work for a separate LayerRef sync client or endpoint.
+
+**Changes**:
+
+- [ ] Update `Task 1.4a` and `Task 1.4b` entries in `tasks.md` and `issues.md` with a "Superseded by Phase 8" note pointing at `GeoServerSyncService`
+- [ ] Update the `Phase 1 - GeoStory Feature` epic in `issues.md` so the `1.4a` / `1.4b` checkboxes are marked superseded rather than open
+- [ ] No code changes
+
+**Acceptance Criteria**:
+
+- [ ] `Task 1.4a` and `Task 1.4b` are clearly marked superseded with a pointer to the canonical sync path
+- [ ] Phase 1 epic reflects the change
+
+**Tests**:
+
+- [ ] None (docs-only)
+
+**Commit Message**:
+
+```text
+docs(layerrefs): mark Task 1.4a/1.4b superseded by geodata_providers
+
+The geodata_providers app's GeoServerSyncService is the canonical layer
+sync path. There is no remaining work for a separate LayerRef sync
+client or endpoint.
+```
+
+---
+
+## Phase 9: GeoStory & GeoContext Image Support
+
+> **Goal**: Add strict, secure image support for GeoStories via a dedicated hero image field and extend GeoContext Editor.js with canonical image blocks backed by authenticated backend uploads.
+
+---
+
+### Task 9.1: GeoStory Hero Image Storage Contract
+
+**Branch**: `feat/geostory-hero-image-model`
+
+**Description**: Add first-class hero image support to `GeoStory` using Django `ImageField` so each story can carry a validated cover image and required alt text. The storage contract must stay backend-agnostic (local now, S3-compatible via Django storage settings).
+
+**Changes**:
+
+- [ ] Add `hero_image = models.ImageField(...)` to `GeoStory`
+- [ ] Add `hero_image_alt = models.CharField(...)` (required when hero image is present)
+- [ ] Add deterministic upload path helper for hero images (e.g. `geostories/hero/%Y/%m/...`)
+- [ ] Add migration for the new model fields
+- [ ] Document that storage is Django-storage-backed and swappable via settings
+
+**Acceptance Criteria**:
+
+- [ ] GeoStory can persist a hero image file via Django storage
+- [ ] GeoStory hero image metadata includes required alt text when image is set
+- [ ] Upload path is deterministic and namespaced for GeoStories
+- [ ] Model migration applies cleanly
+
+**Tests**:
+
+- [ ] Model test: story saves without hero image
+- [ ] Model test: story saves with hero image + alt
+- [ ] Model test: missing alt with hero image fails validation
+- [ ] Migration test: new fields exist with expected null/blank behavior
+
+**Commit Message**:
+
+```text
+feat(geostories): add hero image storage contract
+
+Add GeoStory hero_image and hero_image_alt fields with deterministic
+upload path strategy using Django ImageField-backed storage.
+```
+
+---
+
+### Task 9.2: Strict Image Validation Policy
+
+**Branch**: `feat/image-validation-policy`
+
+**Description**: Implement strict image validation rules for both GeoStory hero images and EditorJS image uploads. Validation must be server-side and enforce a shared policy.
+
+**Changes**:
+
+- [ ] Implement shared validation utility for image files and metadata
+- [ ] Enforce MIME allowlist: `image/jpeg`, `image/png`, `image/webp`
+- [ ] Enforce max file size: `8 MB`
+- [ ] Enforce dimensions: min `800x450`, max `6000x6000`
+- [ ] Enforce required alt text (hero image and EditorJS image block)
+- [ ] Return clear validation errors for each failure type
+
+**Acceptance Criteria**:
+
+- [ ] Unsupported MIME types are rejected
+- [ ] Files above 8 MB are rejected
+- [ ] Images below min or above max dimensions are rejected
+- [ ] Missing/blank alt text is rejected
+- [ ] Validation messages identify the exact violated rule
+
+**Tests**:
+
+- [ ] Unit: valid JPEG/PNG/WebP images pass
+- [ ] Unit: GIF/SVG and other unsupported formats fail
+- [ ] Unit: oversize file fails at >8 MB
+- [ ] Unit: `799x449` fails; `800x450` passes
+- [ ] Unit: `6001x6001` fails; `6000x6000` passes
+- [ ] Unit: empty alt fails for hero and EditorJS image paths
+
+**Commit Message**:
+
+```text
+feat(media): enforce strict server-side image validation policy
+
+Add shared validation for mime, size, dimensions, and alt text across
+GeoStory hero images and EditorJS image ingestion.
+```
+
+---
+
+### Task 9.3: Hero Image API and Admin Surface
+
+**Branch**: `feat/geostory-hero-image-surfaces`
+
+**Description**: Expose hero image fields consistently across API and Django admin so editors can upload/manage hero images and clients can read the image URL + alt text.
+
+**Changes**:
+
+- [ ] Add hero image fields to GeoStory write serializer
+- [ ] Add hero image URL + alt to GeoStory list/detail serializers
+- [ ] Ensure serializer validation invokes model/validation policy for hero image
+- [ ] Update GeoStory admin form/display to include hero image + alt and preview
+- [ ] Update any API examples where GeoStory payloads are shown
+
+**Acceptance Criteria**:
+
+- [ ] GeoStory create/update accepts hero image and alt
+- [ ] GeoStory list/detail includes hero image URL and alt fields
+- [ ] Invalid hero image payload returns clear 400 response
+- [ ] Admin supports upload/edit for hero image and alt
+
+**Tests**:
+
+- [ ] API create test: valid multipart hero image accepted
+- [ ] API patch test: replace/remove hero image behaves correctly
+- [ ] API response test: list/detail includes expected hero image fields
+- [ ] Admin form test: hero image widgets and validation errors render correctly
+
+**Commit Message**:
+
+```text
+feat(geostories): expose hero image in API and admin
+
+Wire hero image upload/read fields through serializers and admin with
+strict validation and response contract coverage.
+```
+
+---
+
+### Task 9.4: Extend EditorJS Canonical Contract With `image` Block
+
+**Branch**: `feat/editorjs-image-block-validation`
+
+**Description**: Extend `tosca_api/apps/core/editorjs.py` to accept, validate, and normalize an EditorJS `image` block while preserving deterministic canonical storage behavior.
+
+**Changes**:
+
+- [ ] Add `image` to allowed block types
+- [ ] Define canonical block shape for storage:
+  - [ ] `type: "image"`
+  - [ ] `data.file.url` (required)
+  - [ ] `data.caption` (sanitized inline HTML)
+  - [ ] `data.alt` (required non-empty)
+  - [ ] `data.mime`, `data.width`, `data.height`
+  - [ ] Optional EditorJS booleans: `withBorder`, `withBackground`, `stretched`
+- [ ] Strip unknown keys during normalization for deterministic output
+- [ ] Enforce URL and metadata constraints aligned with Task 9.2 policy
+
+**Acceptance Criteria**:
+
+- [ ] Valid `image` blocks normalize to canonical shape
+- [ ] Missing URL / alt / mime / dimensions fail validation
+- [ ] Unsupported URL schemes fail validation
+- [ ] Unknown keys are stripped and do not persist
+- [ ] Existing non-image block behavior remains unchanged
+
+**Tests**:
+
+- [ ] Unit: valid image block passes and normalizes deterministically
+- [ ] Unit: invalid scheme (`javascript:` etc.) fails
+- [ ] Unit: missing/blank alt fails
+- [ ] Unit: invalid mime or out-of-range dimensions fail
+- [ ] Unit: unknown keys removed from normalized output
+- [ ] Regression: prior paragraph/list/header/quote/code tests still pass
+
+**Commit Message**:
+
+```text
+feat(core): add canonical EditorJS image block validation
+
+Extend editorjs validator/normalizer to support strict image blocks with
+required URL, alt, mime, and dimension constraints.
+```
+
+---
+
+### Task 9.5: EditorJS Image Upload Endpoint and Storage Contract
+
+**Branch**: `feat/editorjs-image-upload-endpoint`
+
+**Description**: Add authenticated backend upload endpoint(s) for EditorJS image tool. Endpoint returns EditorJS-compatible response payload and stores files via Django media storage.
+
+**Changes**:
+
+- [ ] Add authenticated API endpoint for image upload used by EditorJS admin tool
+- [ ] Validate upload with strict policy from Task 9.2
+- [ ] Store uploads in namespaced path (e.g. `geocontext/editorjs/%Y/%m/...`)
+- [ ] Return EditorJS-compatible payload containing URL and required metadata
+- [ ] Document endpoint contract and errors
+
+**Acceptance Criteria**:
+
+- [ ] Authorized users can upload valid image files
+- [ ] Unauthorized users receive 401/403
+- [ ] Invalid uploads receive structured 400 errors
+- [ ] Response contract is compatible with EditorJS image tool expectations
+- [ ] Stored file URL is resolvable through configured media backend
+
+**Tests**:
+
+- [ ] API auth test: unauthenticated upload rejected
+- [ ] API success test: valid upload returns expected payload shape
+- [ ] API validation test: bad mime/size/dimensions/alt rejected
+- [ ] API contract test: response keys match tool integration expectations
+
+**Commit Message**:
+
+```text
+feat(geocontext): add authenticated EditorJS image upload endpoint
+
+Introduce backend image upload endpoint with strict validation and
+EditorJS-compatible response contract for canonical media storage.
+```
+
+---
+
+### Task 9.6: Admin EditorJS Image Tool Integration
+
+**Branch**: `feat/editorjs-admin-image-tool`
+
+**Description**: Integrate EditorJS image tool into Django admin GeoContext authoring. Use vendored assets and existing progressive-enhancement widget flow.
+
+**Changes**:
+
+- [ ] Vendor EditorJS image tool asset(s) under `geocontext/editorjs/vendor/`
+- [ ] Include upstream license file(s) alongside vendored assets
+- [ ] Update `EditorJsWidget.Media` to include image tool script(s)
+- [ ] Update `init.js` tool configuration to register image tool
+- [ ] Wire image tool uploader config to Task 9.5 endpoint
+- [ ] Keep no-JS textarea fallback unchanged
+
+**Acceptance Criteria**:
+
+- [ ] GeoContext admin loads image tool assets without CDN
+- [ ] EditorJS image uploads work via backend endpoint
+- [ ] Saved EditorJS JSON contains canonical `image` blocks
+- [ ] No-JS fallback remains operational
+
+**Tests**:
+
+- [ ] Admin test: widget media includes vendored image tool scripts
+- [ ] Admin test: no CDN references introduced
+- [ ] Admin integration test: saved JSON contains normalized `image` block
+- [ ] Regression: existing admin editor behavior remains intact
+
+**Commit Message**:
+
+```text
+feat(admin): integrate EditorJS image tool with backend uploads
+
+Vendor and wire EditorJS image tool into GeoContext admin using the
+existing progressive-enhancement flow and canonical JSON persistence.
+```
+
+---
+
+### Task 9.7: Regression and Security Test Coverage
+
+**Branch**: `test/image-support-regressions`
+
+**Description**: Add end-to-end regression coverage for hero image + EditorJS image support across model, serializer, API, validator, upload, and admin surfaces.
+
+**Changes**:
+
+- [ ] Add GeoStory model/serializer/API tests for hero image flows
+- [ ] Add EditorJS validator tests for `image` block strictness
+- [ ] Add upload endpoint auth + validation tests
+- [ ] Add admin integration tests for image tool and canonical persistence
+- [ ] Add negative tests for unsafe URLs and malformed payloads
+
+**Acceptance Criteria**:
+
+- [ ] All new image-related paths are covered by automated tests
+- [ ] Security regressions (unsafe schemes, malformed image data) are explicitly tested
+- [ ] Existing non-image behavior remains green
+
+**Tests**:
+
+- [ ] Model tests for hero image acceptance/rejection by strict rules
+- [ ] Serializer/API tests for hero image fields and validation errors
+- [ ] EditorJS validator tests for valid/invalid `image` blocks
+- [ ] Upload endpoint tests for auth, malformed files, and contract
+- [ ] Admin tests for image tool asset loading and canonical persistence
+
+**Commit Message**:
+
+```text
+test(media): add regression and security coverage for image support
+
+Cover GeoStory hero image and EditorJS image block behavior across
+model/API/validator/upload/admin with strict negative-path tests.
+```
+
+---
+
+### Task 9.8: Schema, Docs, and Supersession Notes
+
+**Branch**: `docs/phase9-image-contract`
+
+**Description**: Document all new payload contracts and operational notes for image support, including OpenAPI updates and non-destructive supersession notes for any stale image placeholders in older docs.
+
+**Changes**:
+
+- [ ] Update OpenAPI schema examples for GeoStory hero image fields
+- [ ] Document EditorJS image block contract in API/docs references
+- [ ] Document upload endpoint request/response examples
+- [ ] Add migration/rollout notes for environments using local media storage
+- [ ] Add non-destructive supersession notes where stale image-related placeholders exist in older tasks/issues docs
+- [ ] Do not auto-close unrelated open tasks (especially Phase 8)
+
+**Acceptance Criteria**:
+
+- [ ] API docs show hero image request/response usage
+- [ ] EditorJS image block schema is documented with strict rules
+- [ ] Upload endpoint contract and error examples are documented
+- [ ] Any stale image placeholders are marked "Superseded by Phase 9" (if touched)
+- [ ] Existing open tasks remain unchanged unless concretely completed
+
+**Tests**:
+
+- [ ] Docs/schema check: OpenAPI includes new hero image fields
+- [ ] Docs/schema check: upload endpoint is present and typed
+- [ ] Docs-only review: supersession notes are non-destructive and scoped
+
+**Commit Message**:
+
+```text
+docs(phase9): document hero image and EditorJS image contracts
+
+Add OpenAPI/documentation updates for hero image and EditorJS image
+upload contracts, plus scoped supersession notes for stale placeholders.
+```

--- a/docs/features-to-add_local/technical-architecture.md
+++ b/docs/features-to-add_local/technical-architecture.md
@@ -1,0 +1,1869 @@
+# **⚙️ Technical Architecture Document: Geostories × Calendar × Participation**
+
+---
+
+## **1. System Overview**
+
+### **Purpose**
+
+The technical system provides a **modular participation framework** combining:
+
+- **Campaigns** – strategic umbrellas that group stories, events, and feedback.
+- **Geostories** – map-based narratives linked to spatial contexts.
+- **Calendar Events** – time-bound participatory activities.
+- **Feedback Cycles** – structured and unstructured feedback collection.
+
+All features share a **common spatial and campaign reference layer**, enabling them to be connected, analyzed, and visualized within one interface.
+
+### **Architecture Layers**
+
+```
+[Frontend: Vue 3 + MapLibre GL + Pinia]
+        ↕
+[API Layer: Django REST Framework]
+        ↕
+[Backend Core: Django + PostGIS + Celery (for async jobs)]
+        ↕
+[Data Services: GeoServer / Vector Tiles / File Storage / Cache]
+        ↕
+[External Integrations: Analytics, AI Summaries, Webhooks, Identity]
+```
+
+---
+
+## **2. Core Modules and Responsibilities**
+
+| **Module**                 | **Purpose**                                                               | **Main Technologies**                                                    | **Key Relations**                                                         |
+| -------------------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------------------ | ------------------------------------------------------------------------- |
+| **Campaign**               | Defines mission, scope, partners, and connects all participation assets.  | Django models + RBAC + analytics snapshots.                              | Parent to stories, events, feedback; exposes KPI endpoints.               |
+| **Geostory**               | Spatial narrative creation and display.                                   | Django models + rich text/media blocks.                                  | Linked to campaigns, layers, direct links, events, and feedback.          |
+| **Calendar**               | Event scheduling, visualization, and map linkage.                         | Django + PostGIS for spatial event storage; frontend calendar component. | Linked to campaigns and optional stories; has feedback after events.      |
+| **Feedback**               | Collects structured (forms) and unstructured (ratings/comments) feedback. | Form schema builder + submission endpoints.                              | Linked to campaigns, stories, or events; aggregated by analytics service. |
+| **Feature Linking**        | Stores explicit relationships across stories, events, and feedback.       | Junction table + admin UI.                                               | Enforces campaign consistency and drives “direct link” UI.                |
+| **Analytics**              | Aggregation and visualization of participation data.                      | Celery tasks + PostGIS spatial joins + visualization endpoints.          | Consumes feedback data and links results to campaigns/stories/events.     |
+| **User & Role Management** | Controls permissions and workflows.                                       | Django Auth + DRF token/JWT + RBAC policy.                               | Defines who can create/edit/publish entities.                             |
+| **Media & Assets**         | Handles images, video, and documents.                                     | Django Storage + S3 or local FS + metadata indexing.                     | Used in Geostories, Events, Feedback forms.                               |
+| **Integration Layer**      | Optional connectors for external APIs (analytics, AI summaries, sensors). | REST clients + Celery tasks.                                             | Extendable microservices.                                                 |
+
+---
+
+## **3. Component Relationships (Conceptual Diagram)**
+
+```
+           +---------------------+
+           |      User Roles     |
+           |  (Citizen, Org, DM) |
+           +----------+----------+
+                      |
+                      v
+           +---------------------+
+           |      Campaign       |
+           | (mission, KPIs,     |
+           |  partners, region)  |
+           +----------+----------+
+                      |
+        +-------------+-----------------------------+
+        |             |                             |
+        v             v                             v
++---------------+ +----------------+          +--------------+
+|    GeoStory   | |  CalendarEvent |          |  GeoFeedback |
+| (media,       | | (title, date,  |          | (forms, rate)|
+|  narrative)   | |  geometry)     |          |              |
+| + GeoContext  | | + GeoContext   |          | + GeoContext |
++-------+-------+ +--------+-------+          +-------+------+
+        |                  |                          ^
+        |                  |                          |
+        v                  v                          |
+    +----------------------------------------------------+
+    |                   Feature Links                    |
+    |        (direct refs between any entities)          |
+    +--------------------------+-------------------------+
+                               |
+                               v
+                     +---------------------+
+                     | Feedback Submission |
+                     | (User answers)      |
+                     +----------+----------+
+                                |
+                                v
+                         +-------------+
+                         |  Analytics  |
+                         | Aggregation |
+                         +------+------+
+                                |
+                                v
+                      +------------------+
+                      | Updated Campaign |
+                      | & Stories        |
+                      +------------------+
+```
+
+---
+
+## **4. Data Model Overview (Simplified ERD)**
+
+```
+[Campaign]
+ ├─ id (UUID)
+ ├─ title (varchar)
+ ├─ summary (text, nullable)
+ ├─ status (enum: draft/active/archived)
+ ├─ visibility (enum: public/private)
+ ├─ created_by → User (FK)
+ └─ created_at, updated_at
+
+[GeoContext]  ← NEW: content submodule
+ ├─ id (UUID)
+ ├─ content (TEXT)
+ ├─ content_type (enum: simple/rich)
+ ├─ created_by → User (FK)
+ └─ created_at, updated_at
+
+[LayerRef]  ← GeoServer layer reference (synced)
+ ├─ id (UUID)
+ ├─ layer_name (varchar, unique)
+ └─ created_at
+
+    %% Feature Entities
+    GEOSTORY {
+        UUID id PK
+        UUID campaign_id FK
+        VARCHAR title
+        TEXT summary
+        ENUM status "draft, published, archived"
+        UUID author_id FK
+        UUID cover_media_id FK
+        UUID context_id FK "1:1 UNIQUE"
+        TIMESTAMPTZ created_at
+        TIMESTAMPTZ updated_at
+    }
+
+    CALENDAREVENT {
+        UUID id PK
+        UUID campaign_id FK
+        VARCHAR title
+        TEXT description
+        UUID context_id FK "1:1 UNIQUE"
+        TIMESTAMPTZ start_datetime
+        TIMESTAMPTZ end_datetime
+        GEOMETRY location "Point 4326"
+        UUID organizer_id FK
+        ENUM status "draft, published, cancelled"
+        ENUM visibility "public, private"
+        TIMESTAMPTZ created_at
+        TIMESTAMPTZ updated_at
+    }
+
+    GEOFEEDBACK {
+        UUID id PK
+        UUID campaign_id FK
+        VARCHAR title
+        BOOL rating_enabled
+        BOOL form_enabled
+        BOOL allow_drawings
+        UUID custom_form_id FK "nullable (from formbuilder)"
+        UUID context_id FK "1:1 UNIQUE"
+        TIMESTAMPTZ active_from
+        TIMESTAMPTZ active_to
+        ENUM visibility "public, private"
+        UUID created_by_id FK
+        TIMESTAMPTZ created_at
+        TIMESTAMPTZ updated_at
+    }
+
+    %% Feedback Categorization (Provided by formbuilder)
+    CUSTOM_FORM {
+        UUID id PK
+        VARCHAR name
+        VARCHAR slug UK
+        JSONB json_schema
+        ENUM status
+    }
+
+    FEEDBACKSUBMISSION {
+        UUID id PK
+        UUID feedback_id FK
+        UUID user_id FK "nullable"
+        INT rating "1-5, nullable"
+        JSONB form_data
+        GEOMETRY geometry "Any geometry type"
+        BOOL is_anonymized
+        TIMESTAMPTZ created_at
+    }
+
+[GeoFeedback]
+ ├─ id (UUID)
+ ├─ campaign → Campaign (FK)
+ ├─ title
+ ├─ rating_enabled (bool)        ← allow star ratings
+ ├─ form_enabled (bool)          ← allow form submissions
+ ├─ allow_drawings (bool)        ← allow geometry input
+ ├─ custom_form → CustomForm (FK, nullable) ← formbuilder dependency
+ ├─ context → GeoContext (FK, nullable)  ← 1:1 content
+ ├─ active_from, active_to (nullable)
+ └─ visibility, created_at, updated_at
+
+[feedback_layers]  ← M2M join table
+ ├─ feedback → GeoFeedback (FK)
+ ├─ layer → LayerRef (FK)
+ ├─ display_order (int)
+ └─ UNIQUE(feedback, layer)
+
+[FeatureLink]
+ ├─ id (UUID)
+ ├─ campaign → Campaign (FK)
+ ├─ source_content_type (FK → ContentType)
+ ├─ source_object_id (UUID)
+ ├─ target_content_type (FK → ContentType)
+ ├─ target_object_id (UUID)
+ ├─ link_type (enum: direct/read_more/action)
+ └─ created_at, created_by → User
+
+[FeedbackSubmission]
+ ├─ id (UUID)
+ ├─ feedback → GeoFeedback (FK)
+ ├─ user → User (nullable)  ← authenticated or anonymous
+ ├─ rating (int, nullable)  ← 1-5 stars if rating_enabled
+ ├─ form_data (JSONB, nullable)  ← form responses based on CustomForm schema
+ ├─ geometry (Geometry, nullable)  ← if allow_drawings
+ └─ created_at, is_anonymized (bool)
+```
+
+> [!NOTE]
+> **Analytics models** (e.g., `AnalyticsSnapshot`, `mission_kpis`) are **optional** and will be added in a future phase. The core system operates without them.
+
+---
+
+### **4.1 Campaign Schema & Behavior**
+
+- Campaigns are **logical containers** that group related stories, events, and feedback forms.
+- Every participatory artifact references exactly one campaign via `campaign_id` FK.
+- Status workflow: `draft` → `active` → `archived`.
+- Permissions can be scoped per campaign (future: `campaign_members` table for RBAC).
+
+---
+
+### **4.2 Feature Linking Strategies (Loose vs Direct)**
+
+We support two layers of relationships:
+
+1.  **Loose association** via `campaign_id` — all entities within a campaign are implicitly related.
+2.  **Direct links** via `FeatureLink` — explicit connections between specific entities.
+
+| Option                           | Pros                                                       | Cons                                          |
+| -------------------------------- | ---------------------------------------------------------- | --------------------------------------------- |
+| Junction table (`feature_links`) | Referential integrity, metadata support, efficient lookups | Polymorphic FK validation in app layer        |
+| JSONB arrays on entities         | Simple schema                                              | No FK guarantees, hard to query reverse links |
+
+**Decision:** Use `feature_links` table with `campaign_id` denormalized for query simplicity and "same campaign" constraint enforcement.
+
+---
+
+### **4.3 Detailed Schema Definitions**
+
+#### **Campaign**
+
+The campaign is the **top-level organizational unit**. It serves as a logical umbrella for participation activities.
+
+##### Schema Definition
+
+| Column          | PostgreSQL Type | Nullable | Default             | Description                                   |
+| --------------- | --------------- | -------- | ------------------- | --------------------------------------------- |
+| `id`            | `UUID`          | NOT NULL | `gen_random_uuid()` | Primary key                                   |
+| `title`         | `VARCHAR(255)`  | NOT NULL | —                   | Human-readable campaign name                  |
+| `summary`       | `TEXT`          | NULL     | `NULL`              | Brief description for context                 |
+| `status`        | `VARCHAR(20)`   | NOT NULL | `'draft'`           | Workflow state: `draft`, `active`, `archived` |
+| `visibility`    | `VARCHAR(20)`   | NOT NULL | `'private'`         | Access control: `public`, `private`           |
+| `created_by_id` | `UUID`          | NOT NULL | —                   | FK → `auth_user.id`                           |
+| `created_at`    | `TIMESTAMPTZ`   | NOT NULL | `NOW()`             | Creation timestamp                            |
+| `updated_at`    | `TIMESTAMPTZ`   | NOT NULL | `NOW()`             | Last modification (auto-updated)              |
+
+##### Constraints
+
+| Constraint                | Type        | Definition                                                  |
+| ------------------------- | ----------- | ----------------------------------------------------------- |
+| `pk_campaign`             | PRIMARY KEY | `(id)`                                                      |
+| `fk_campaign_created_by`  | FOREIGN KEY | `created_by_id REFERENCES auth_user(id) ON DELETE RESTRICT` |
+| `chk_campaign_status`     | CHECK       | `status IN ('draft', 'active', 'archived')`                 |
+| `chk_campaign_visibility` | CHECK       | `visibility IN ('public', 'private')`                       |
+
+##### Indexes
+
+| Index Name                | Columns           | Type   | Purpose                |
+| ------------------------- | ----------------- | ------ | ---------------------- |
+| `idx_campaign_status`     | `status`          | B-tree | Filter by status       |
+| `idx_campaign_visibility` | `visibility`      | B-tree | Filter by visibility   |
+| `idx_campaign_created_by` | `created_by_id`   | B-tree | List campaigns by user |
+| `idx_campaign_created_at` | `created_at DESC` | B-tree | Sort by creation date  |
+
+##### PostgreSQL DDL
+
+```sql
+-- Enum types (optional, or use VARCHAR with CHECK)
+-- CREATE TYPE campaign_status AS ENUM ('draft', 'active', 'archived');
+-- CREATE TYPE campaign_visibility AS ENUM ('public', 'private');
+
+CREATE TABLE campaign (
+    id              UUID            PRIMARY KEY DEFAULT gen_random_uuid(),
+    title           VARCHAR(255)    NOT NULL,
+    summary         TEXT,
+    status          VARCHAR(20)     NOT NULL DEFAULT 'draft',
+    visibility      VARCHAR(20)     NOT NULL DEFAULT 'private',
+    created_by_id   UUID            NOT NULL,
+    created_at      TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+
+    -- Constraints
+    CONSTRAINT fk_campaign_created_by
+        FOREIGN KEY (created_by_id) REFERENCES auth_user(id) ON DELETE RESTRICT,
+    CONSTRAINT chk_campaign_status
+        CHECK (status IN ('draft', 'active', 'archived')),
+    CONSTRAINT chk_campaign_visibility
+        CHECK (visibility IN ('public', 'private'))
+);
+
+-- Indexes
+CREATE INDEX idx_campaign_status ON campaign(status);
+CREATE INDEX idx_campaign_visibility ON campaign(visibility);
+CREATE INDEX idx_campaign_created_by ON campaign(created_by_id);
+CREATE INDEX idx_campaign_created_at ON campaign(created_at DESC);
+
+-- Auto-update updated_at trigger
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_campaign_updated_at
+    BEFORE UPDATE ON campaign
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+```
+
+##### Django Model Reference
+
+```python
+from django.db import models
+from django.contrib.auth import get_user_model
+import uuid
+
+User = get_user_model()
+
+class Campaign(models.Model):
+    class Status(models.TextChoices):
+        DRAFT = 'draft', 'Draft'
+        ACTIVE = 'active', 'Active'
+        ARCHIVED = 'archived', 'Archived'
+
+    class Visibility(models.TextChoices):
+        PUBLIC = 'public', 'Public'
+        PRIVATE = 'private', 'Private'
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    title = models.CharField(max_length=255)
+    summary = models.TextField(blank=True, null=True)
+    status = models.CharField(
+        max_length=20,
+        choices=Status.choices,
+        default=Status.DRAFT
+    )
+    visibility = models.CharField(
+        max_length=20,
+        choices=Visibility.choices,
+        default=Visibility.PRIVATE
+    )
+    created_by = models.ForeignKey(
+        User,
+        on_delete=models.RESTRICT,
+        related_name='campaigns'
+    )
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        db_table = 'campaign'
+        ordering = ['-created_at']
+        indexes = [
+            models.Index(fields=['status']),
+            models.Index(fields=['visibility']),
+            models.Index(fields=['created_by']),
+            models.Index(fields=['-created_at']),
+        ]
+
+    def __str__(self):
+        return self.title
+```
+
+##### Design Notes
+
+- **No `slug`** — campaigns are not URL-routed entities; use UUID in API paths.
+- **No `region_geometry`** — spatial extent derived from child GeoStories if needed.
+- **No `timeline_start/end`** — can be computed from child events' date ranges.
+- **No `owner_org`** — initially use `created_by`; organization ownership can be added later via a `campaign_members` join table.
+- **`ON DELETE RESTRICT`** — prevents deleting users who own campaigns; handle via application logic.
+
+---
+
+#### **GeoContext**
+
+Reusable content submodule for stories, events, and feedback. Starts as plain text; will support WYSIWYG rich text in future.
+
+> **Superseded for future implementation (Phase 7, Task 7.1)**: The `content` (TEXT) + `content_type` (`simple`/`rich`) contract described in this section is retained as historical context. The canonical future contract stores `GeoContext.content` as Editor.js JSON and drops `content_type` entirely. Empty documents are represented as `{ "blocks": [] }`. See `docs/features-to-add/decisions.md` §7.1.
+
+##### Schema Definition
+
+| Column          | PostgreSQL Type | Nullable | Default             | Description                                |
+| --------------- | --------------- | -------- | ------------------- | ------------------------------------------ |
+| `id`            | `UUID`          | NOT NULL | `gen_random_uuid()` | Primary key                                |
+| `content`       | `TEXT`          | NOT NULL | `''`                | Text content (plain text or rich text)     |
+| `content_type`  | `VARCHAR(20)`   | NOT NULL | `'simple'`          | `simple` (text) or `rich` (WYSIWYG blocks) |
+| `created_by_id` | `UUID`          | NOT NULL | —                   | FK → `auth_user.id`                        |
+| `created_at`    | `TIMESTAMPTZ`   | NOT NULL | `NOW()`             | Creation timestamp                         |
+| `updated_at`    | `TIMESTAMPTZ`   | NOT NULL | `NOW()`             | Last modification                          |
+
+##### Constraints
+
+| Constraint                    | Type        | Definition                                                  |
+| ----------------------------- | ----------- | ----------------------------------------------------------- |
+| `pk_geocontext`               | PRIMARY KEY | `(id)`                                                      |
+| `fk_geocontext_created_by`    | FOREIGN KEY | `created_by_id REFERENCES auth_user(id) ON DELETE RESTRICT` |
+| `chk_geocontext_content_type` | CHECK       | `content_type IN ('simple', 'rich')`                        |
+
+##### PostgreSQL DDL
+
+```sql
+CREATE TABLE geocontext (
+    id              UUID            PRIMARY KEY DEFAULT gen_random_uuid(),
+    content         TEXT            NOT NULL DEFAULT '',
+    content_type    VARCHAR(20)     NOT NULL DEFAULT 'simple',
+    created_by_id   UUID            NOT NULL,
+    created_at      TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT fk_geocontext_created_by
+        FOREIGN KEY (created_by_id) REFERENCES auth_user(id) ON DELETE RESTRICT,
+    CONSTRAINT chk_geocontext_content_type
+        CHECK (content_type IN ('simple', 'rich'))
+);
+
+CREATE TRIGGER trg_geocontext_updated_at
+    BEFORE UPDATE ON geocontext
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+```
+
+##### Django Model
+
+```python
+class GeoContext(models.Model):
+    class ContentType(models.TextChoices):
+        SIMPLE = 'simple', 'Simple Text'
+        RICH = 'rich', 'Rich Text'
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    content = models.TextField(default='')
+    content_type = models.CharField(
+        max_length=20,
+        choices=ContentType.choices,
+        default=ContentType.SIMPLE
+    )
+    created_by = models.ForeignKey(
+        User, on_delete=models.RESTRICT, related_name='geocontexts'
+    )
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        db_table = 'geocontext'
+```
+
+---
+
+#### **LayerRef**
+
+Reference to a GeoServer layer. Synced from GeoServer; can be linked to stories, events, or feedback via M2M.
+
+##### Schema Definition
+
+| Column       | PostgreSQL Type | Nullable | Default             | Description                                            |
+| ------------ | --------------- | -------- | ------------------- | ------------------------------------------------------ |
+| `id`         | `UUID`          | NOT NULL | `gen_random_uuid()` | Primary key                                            |
+| `layer_name` | `VARCHAR(255)`  | NOT NULL | —                   | GeoServer layer identifier (format: `workspace:layer`) |
+| `created_at` | `TIMESTAMPTZ`   | NOT NULL | `NOW()`             | When synced from GeoServer                             |
+
+##### Constraints
+
+| Constraint               | Type        | Definition     |
+| ------------------------ | ----------- | -------------- |
+| `pk_layerref`            | PRIMARY KEY | `(id)`         |
+| `uq_layerref_layer_name` | UNIQUE      | `(layer_name)` |
+
+##### PostgreSQL DDL
+
+```sql
+CREATE TABLE layerref (
+    id          UUID            PRIMARY KEY DEFAULT gen_random_uuid(),
+    layer_name  VARCHAR(255)    NOT NULL UNIQUE,
+    created_at  TIMESTAMPTZ     NOT NULL DEFAULT NOW()
+);
+```
+
+##### Django Model
+
+```python
+class LayerRef(models.Model):
+    """
+    Stores GeoServer layer references. Synced via update_layers() class method.
+    Can be linked M2M to GeoStory, CalendarEvent, or GeoFeedback.
+    """
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    layer_name = models.CharField(max_length=255, unique=True)  # e.g., 'workspace:layer_name'
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        db_table = 'layerref'
+
+    def __str__(self):
+        return self.layer_name
+
+    @classmethod
+    def update_layers(cls):
+        """Sync layers from GeoServer. Add new, remove stale."""
+        from geonode.geoserver.helpers import gs_catalog
+        try:
+            current_layers = {layer.name for layer in gs_catalog.get_layers()}
+            existing = set(cls.objects.values_list('layer_name', flat=True))
+
+            # Add new
+            for name in current_layers - existing:
+                cls.objects.create(layer_name=name)
+            # Remove stale
+            cls.objects.filter(layer_name__in=existing - current_layers).delete()
+        except Exception as e:
+            print(f"Error syncing LayerRef: {e}")
+```
+
+##### Design Notes
+
+- **Simple structure** — only `layer_name`, no extra metadata
+- **Synced from GeoServer** — `update_layers()` method keeps table in sync
+- **M2M relationships** — linked to features via join tables (e.g., `geostory_layers`, `event_layers`, `feedback_layers`)
+
+##### REST API (Manual Sync)
+
+**Endpoint**: `POST /api/layers/sync/`
+**Action**: Triggers manual sync with GeoServer catalog.
+**Status**: `AUTHENTICATED` (Editor+)
+
+```python
+# ViewSet Action
+@action(detail=False, methods=['post'])
+def sync(self, request):
+    # logic to fetch from gs_catalog and update LayerRef
+    return Response({"status": "synced", "count": ...})
+```
+
+---
+
+#### **GeoStory**
+
+Spatial narratives that combine maps, media, and data to communicate local issues.
+
+##### Schema Definition
+
+| Column           | PostgreSQL Type | Nullable | Default             | Description                        |
+| ---------------- | --------------- | -------- | ------------------- | ---------------------------------- |
+| `id`             | `UUID`          | NOT NULL | `gen_random_uuid()` | Primary key                        |
+| `campaign_id`    | `UUID`          | NOT NULL | —                   | FK → `campaign.id`                 |
+| `title`          | `VARCHAR(255)`  | NOT NULL | —                   | Story title                        |
+| `summary`        | `TEXT`          | NULL     | `NULL`              | Brief description                  |
+| `status`         | `VARCHAR(20)`   | NOT NULL | `'draft'`           | `draft`, `published`, `archived`   |
+| `author_id`      | `UUID`          | NOT NULL | —                   | FK → `auth_user.id`                |
+| `cover_media_id` | `UUID`          | NULL     | `NULL`              | FK → `media_asset.id` (optional)   |
+| `context_id`     | `UUID`          | NULL     | `NULL`              | FK → `geocontext.id` (1:1 content) |
+| `created_at`     | `TIMESTAMPTZ`   | NOT NULL | `NOW()`             | Creation timestamp                 |
+| `updated_at`     | `TIMESTAMPTZ`   | NOT NULL | `NOW()`             | Last modification                  |
+
+##### Constraints
+
+| Constraint             | Type        | Definition                                                |
+| ---------------------- | ----------- | --------------------------------------------------------- |
+| `pk_geostory`          | PRIMARY KEY | `(id)`                                                    |
+| `fk_geostory_campaign` | FOREIGN KEY | `campaign_id REFERENCES campaign(id) ON DELETE CASCADE`   |
+| `fk_geostory_author`   | FOREIGN KEY | `author_id REFERENCES auth_user(id) ON DELETE RESTRICT`   |
+| `fk_geostory_context`  | FOREIGN KEY | `context_id REFERENCES geocontext(id) ON DELETE SET NULL` |
+| `chk_geostory_status`  | CHECK       | `status IN ('draft', 'published', 'archived')`            |
+
+##### Indexes
+
+| Index Name                | Columns           | Type   | Purpose                    |
+| ------------------------- | ----------------- | ------ | -------------------------- |
+| `idx_geostory_campaign`   | `campaign_id`     | B-tree | Filter stories by campaign |
+| `idx_geostory_status`     | `status`          | B-tree | Filter published stories   |
+| `idx_geostory_author`     | `author_id`       | B-tree | Filter by author           |
+| `idx_geostory_created_at` | `created_at DESC` | B-tree | For pagination             |
+
+##### PostgreSQL DDL
+
+```sql
+CREATE TABLE geostory (
+    id              UUID            PRIMARY KEY DEFAULT gen_random_uuid(),
+    campaign_id     UUID            NOT NULL,
+    title           VARCHAR(255)    NOT NULL,
+    summary         TEXT,
+    status          VARCHAR(20)     NOT NULL DEFAULT 'draft',
+    author_id       UUID            NOT NULL,
+    cover_media_id  UUID,
+    context_id      UUID            UNIQUE,  -- 1:1 relationship enforced
+    created_at      TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT fk_geostory_campaign
+        FOREIGN KEY (campaign_id) REFERENCES campaign(id) ON DELETE CASCADE,
+    CONSTRAINT fk_geostory_author
+        FOREIGN KEY (author_id) REFERENCES auth_user(id) ON DELETE RESTRICT,
+    CONSTRAINT fk_geostory_context
+        FOREIGN KEY (context_id) REFERENCES geocontext(id) ON DELETE SET NULL,
+    CONSTRAINT chk_geostory_status
+        CHECK (status IN ('draft', 'published', 'archived'))
+);
+
+-- Indexes
+CREATE INDEX idx_geostory_campaign ON geostory(campaign_id);
+CREATE INDEX idx_geostory_status ON geostory(status);
+CREATE INDEX idx_geostory_author ON geostory(author_id);
+CREATE INDEX idx_geostory_created_at ON geostory(created_at DESC);  -- For pagination
+
+CREATE TRIGGER trg_geostory_updated_at
+    BEFORE UPDATE ON geostory
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+```
+
+##### M2M: geostory_layers
+
+```sql
+CREATE TABLE geostory_layers (
+    id              UUID            PRIMARY KEY DEFAULT gen_random_uuid(),
+    geostory_id     UUID            NOT NULL,
+    layer_id        UUID            NOT NULL,
+    display_order   INTEGER         NOT NULL DEFAULT 0,
+
+    CONSTRAINT fk_geostory_layers_story
+        FOREIGN KEY (geostory_id) REFERENCES geostory(id) ON DELETE CASCADE,
+    CONSTRAINT fk_geostory_layers_layer
+        FOREIGN KEY (layer_id) REFERENCES layerref(id) ON DELETE CASCADE,
+    CONSTRAINT uq_geostory_layers
+        UNIQUE (geostory_id, layer_id)
+);
+
+CREATE INDEX idx_geostory_layers_story ON geostory_layers(geostory_id);
+```
+
+##### Django Model
+
+```python
+class GeoStory(models.Model):
+    class Status(models.TextChoices):
+        DRAFT = 'draft', 'Draft'
+        PUBLISHED = 'published', 'Published'
+        ARCHIVED = 'archived', 'Archived'
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    campaign = models.ForeignKey(
+        Campaign, on_delete=models.CASCADE, related_name='stories'
+    )
+    title = models.CharField(max_length=255)
+    summary = models.TextField(blank=True, null=True)
+    status = models.CharField(
+        max_length=20, choices=Status.choices, default=Status.DRAFT
+    )
+    author = models.ForeignKey(
+        User, on_delete=models.RESTRICT, related_name='stories'
+    )
+    cover_media_id = models.UUIDField(null=True, blank=True)
+    # context field defined in OneToOne from GeoContext if preferred, or here
+    context = models.OneToOneField(
+        'GeoContext', on_delete=models.SET_NULL, null=True, blank=True, related_name='geostory'
+    )
+    layers = models.ManyToManyField(
+        LayerRef, through='GeoStoryLayer', related_name='stories'
+    )
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        db_table = 'geostory'
+        ordering = ['-created_at']
+        indexes = [
+            models.Index(fields=['campaign']),
+            models.Index(fields=['status']),
+            models.Index(fields=['author']),
+        ]
+
+
+class GeoStoryLayer(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    geostory = models.ForeignKey(GeoStory, on_delete=models.CASCADE)
+    layer = models.ForeignKey(LayerRef, on_delete=models.CASCADE)
+    display_order = models.IntegerField(default=0)
+
+    class Meta:
+        db_table = 'geostory_layers'
+        unique_together = ['geostory', 'layer']
+        ordering = ['display_order']
+```
+
+##### Design Notes
+
+- **Removed `locale`** — single language for MVP
+- **`cover_media_id` nullable** — optional cover image
+- **`context_id` 1:1** — links to GeoContext for story content
+- **`ON DELETE CASCADE`** for campaign — deleting a campaign removes its stories
+- **`ON DELETE SET NULL`** for context — allows orphan cleanup later
+
+#### **CalendarEvent**
+
+Time-bound participatory activities (e.g., "Workshop", "Site Visit") linked to campaigns.
+
+##### Schema Definition
+
+| Column           | PostgreSQL Type         | Nullable | Default             | Description                        |
+| ---------------- | ----------------------- | -------- | ------------------- | ---------------------------------- |
+| `id`             | `UUID`                  | NOT NULL | `gen_random_uuid()` | Primary key                        |
+| `campaign_id`    | `UUID`                  | NOT NULL | —                   | FK → `campaign.id`                 |
+| `title`          | `VARCHAR(255)`          | NOT NULL | —                   | Event title                        |
+| `description`    | `TEXT`                  | NULL     | `NULL`              | Short description                  |
+| `context_id`     | `UUID`                  | NULL     | `NULL`              | FK → `geocontext.id` (1:1 content) |
+| `start_datetime` | `TIMESTAMPTZ`           | NOT NULL | —                   | Event start                        |
+| `end_datetime`   | `TIMESTAMPTZ`           | NOT NULL | —                   | Event end                          |
+| `location`       | `GEOMETRY(Point, 4326)` | NULL     | `NULL`              | Event location (Point)             |
+| `organizer_id`   | `UUID`                  | NOT NULL | —                   | FK → `auth_user.id`                |
+| `status`         | `VARCHAR(20)`           | NOT NULL | `'published'`       | `draft`, `published`, `cancelled`  |
+| `visibility`     | `VARCHAR(20)`           | NOT NULL | `'public'`          | `public`, `private`                |
+| `created_at`     | `TIMESTAMPTZ`           | NOT NULL | `NOW()`             | Creation timestamp                 |
+| `updated_at`     | `TIMESTAMPTZ`           | NOT NULL | `NOW()`             | Last modification                  |
+
+##### Constraints
+
+| Constraint                   | Type        | Definition                                                 |
+| ---------------------------- | ----------- | ---------------------------------------------------------- |
+| `pk_calendarevent`           | PRIMARY KEY | `(id)`                                                     |
+| `fk_calendarevent_campaign`  | FOREIGN KEY | `campaign_id REFERENCES campaign(id) ON DELETE CASCADE`    |
+| `fk_calendarevent_context`   | FOREIGN KEY | `context_id REFERENCES geocontext(id) ON DELETE SET NULL`  |
+| `fk_calendarevent_organizer` | FOREIGN KEY | `organizer_id REFERENCES auth_user(id) ON DELETE RESTRICT` |
+| `chk_event_dates`            | CHECK       | `end_datetime >= start_datetime`                           |
+
+##### Indexes
+
+| Index Name                   | Columns                        | Type   | Purpose              |
+| ---------------------------- | ------------------------------ | ------ | -------------------- |
+| `idx_calendarevent_campaign` | `campaign_id`                  | B-tree | Filter by campaign   |
+| `idx_calendarevent_dates`    | `start_datetime, end_datetime` | B-tree | Filter by date range |
+| `idx_calendarevent_geom`     | `location`                     | GiST   | Spatial queries      |
+
+##### PostgreSQL DDL
+
+```sql
+CREATE TABLE calendarevent (
+    id              UUID            PRIMARY KEY DEFAULT gen_random_uuid(),
+    campaign_id     UUID            NOT NULL,
+    title           VARCHAR(255)    NOT NULL,
+    description     TEXT,
+    context_id      UUID            UNIQUE,  -- 1:1 relationship enforced
+    start_datetime  TIMESTAMPTZ     NOT NULL,
+    end_datetime    TIMESTAMPTZ     NOT NULL,
+    location        GEOMETRY(Point, 4326),
+    organizer_id    UUID            NOT NULL,
+    status          VARCHAR(20)     NOT NULL DEFAULT 'published',
+    visibility      VARCHAR(20)     NOT NULL DEFAULT 'public',
+    created_at      TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT fk_calendarevent_campaign
+        FOREIGN KEY (campaign_id) REFERENCES campaign(id) ON DELETE CASCADE,
+    CONSTRAINT fk_calendarevent_context
+        FOREIGN KEY (context_id) REFERENCES geocontext(id) ON DELETE SET NULL,
+    CONSTRAINT fk_calendarevent_organizer
+        FOREIGN KEY (organizer_id) REFERENCES auth_user(id) ON DELETE RESTRICT,
+    CONSTRAINT chk_event_dates
+        CHECK (end_datetime >= start_datetime)
+);
+
+CREATE INDEX idx_calendarevent_campaign ON calendarevent(campaign_id);
+CREATE INDEX idx_calendarevent_dates ON calendarevent(start_datetime, end_datetime);
+CREATE INDEX idx_calendarevent_campaign_dates ON calendarevent(campaign_id, start_datetime, end_datetime);  -- Compound for campaign-scoped queries
+CREATE INDEX idx_calendarevent_geom ON calendarevent USING GIST(location);
+
+CREATE TRIGGER trg_calendarevent_updated_at
+    BEFORE UPDATE ON calendarevent
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+```
+
+##### M2M: event_layers
+
+```sql
+CREATE TABLE event_layers (
+    id              UUID            PRIMARY KEY DEFAULT gen_random_uuid(),
+    event_id        UUID            NOT NULL,
+    layer_id        UUID            NOT NULL,
+    display_order   INTEGER         NOT NULL DEFAULT 0,
+
+    CONSTRAINT fk_event_layers_event
+        FOREIGN KEY (event_id) REFERENCES calendarevent(id) ON DELETE CASCADE,
+    CONSTRAINT fk_event_layers_layer
+        FOREIGN KEY (layer_id) REFERENCES layerref(id) ON DELETE CASCADE,
+    CONSTRAINT uq_event_layers
+        UNIQUE (event_id, layer_id)
+);
+
+CREATE INDEX idx_event_layers_event ON event_layers(event_id);
+```
+
+##### Django Model
+
+```python
+class CalendarEvent(models.Model):
+    class Status(models.TextChoices):
+        DRAFT = 'draft', 'Draft'
+        PUBLISHED = 'published', 'Published'
+        CANCELLED = 'cancelled', 'Cancelled'
+
+    class Visibility(models.TextChoices):
+        PUBLIC = 'public', 'Public'
+        PRIVATE = 'private', 'Private'
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    campaign = models.ForeignKey(
+        Campaign, on_delete=models.CASCADE, related_name='events'
+    )
+    title = models.CharField(max_length=255)
+    description = models.TextField(blank=True, null=True)
+    context = models.OneToOneField(
+        GeoContext, on_delete=models.SET_NULL, null=True, blank=True
+    )
+    start_datetime = models.DateTimeField()
+    end_datetime = models.DateTimeField()
+    location = models.PointField(srid=4326, blank=True, null=True)
+    organizer = models.ForeignKey(
+        User, on_delete=models.RESTRICT, related_name='organized_events'
+    )
+    layers = models.ManyToManyField(
+        LayerRef, through='EventLayer', related_name='events'
+    )
+    status = models.CharField(
+        max_length=20, choices=Status.choices, default=Status.PUBLISHED
+    )
+    visibility = models.CharField(
+        max_length=20, choices=Visibility.choices, default=Visibility.PUBLIC
+    )
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        db_table = 'calendarevent'
+        ordering = ['start_datetime']
+        indexes = [
+            models.Index(fields=['campaign']),
+            models.Index(fields=['start_datetime', 'end_datetime']),
+        ]
+
+class EventLayer(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    event = models.ForeignKey(CalendarEvent, on_delete=models.CASCADE)
+    layer = models.ForeignKey(LayerRef, on_delete=models.CASCADE)
+    display_order = models.IntegerField(default=0)
+
+    class Meta:
+        db_table = 'event_layers'
+        unique_together = ['event', 'layer']
+        ordering = ['display_order']
+```
+
+---
+
+| Column           | PostgreSQL Type | Nullable | Default             | Description                                            |
+| ---------------- | --------------- | -------- | ------------------- | ------------------------------------------------------ |
+| `id`             | `UUID`          | NOT NULL | `gen_random_uuid()` | Primary key                                            |
+| `campaign_id`    | `UUID`          | NOT NULL | —                   | FK → `campaign.id`                                     |
+| `title`          | `VARCHAR(255)`  | NOT NULL | —                   | Feedback title                                         |
+| `rating_enabled` | `BOOLEAN`       | NOT NULL | `TRUE`              | Allow star ratings                                     |
+| `form_enabled`   | `BOOLEAN`       | NOT NULL | `FALSE`             | Allow form submissions                                 |
+| `allow_drawings` | `BOOLEAN`       | NOT NULL | `FALSE`             | Allow geometry input (requires form_enabled)           |
+| `custom_form_id` | `UUID`          | NULL     | `NULL`              | FK → `custom_form.id` (from django-basic-form-builder) |
+| `context_id`     | `UUID`          | NULL     | `NULL`              | FK → `geocontext.id` (1:1 content)                     |
+| `active_from`    | `TIMESTAMPTZ`   | NULL     | `NULL`              | When feedback opens                                    |
+| `active_to`      | `TIMESTAMPTZ`   | NULL     | `NULL`              | When feedback closes                                   |
+| `visibility`     | `VARCHAR(20)`   | NOT NULL | `'public'`          | `public`, `private`                                    |
+| `created_by_id`  | `UUID`          | NOT NULL | —                   | FK → `auth_user.id`                                    |
+| `created_at`     | `TIMESTAMPTZ`   | NOT NULL | `NOW()`             | Creation timestamp                                     |
+| `updated_at`     | `TIMESTAMPTZ`   | NOT NULL | `NOW()`             | Last modification                                      |
+
+##### Constraints
+
+| Constraint                  | Type        | Definition                                                        |
+| --------------------------- | ----------- | ----------------------------------------------------------------- |
+| `pk_geofeedback`            | PRIMARY KEY | `(id)`                                                            |
+| `fk_geofeedback_campaign`   | FOREIGN KEY | `campaign_id REFERENCES campaign(id) ON DELETE CASCADE`           |
+| `fk_geofeedback_type`       | FOREIGN KEY | `feedback_type_id REFERENCES feedbacktype(id) ON DELETE SET NULL` |
+| `fk_geofeedback_context`    | FOREIGN KEY | `context_id REFERENCES geocontext(id) ON DELETE SET NULL`         |
+| `fk_geofeedback_created_by` | FOREIGN KEY | `created_by_id REFERENCES auth_user(id) ON DELETE RESTRICT`       |
+| `chk_geofeedback_mode`      | CHECK       | `rating_enabled OR form_enabled` (at least one mode)              |
+| `chk_geofeedback_drawings`  | CHECK       | `NOT allow_drawings OR form_enabled`                              |
+
+##### Indexes
+
+| Index Name                 | Columns                  | Type   | Purpose                |
+| -------------------------- | ------------------------ | ------ | ---------------------- |
+| `idx_geofeedback_campaign` | `campaign_id`            | B-tree | Filter by campaign     |
+| `idx_geofeedback_active`   | `active_from, active_to` | B-tree | Filter active feedback |
+
+##### PostgreSQL DDL
+
+```sql
+CREATE TABLE geofeedback (
+    id                  UUID            PRIMARY KEY DEFAULT gen_random_uuid(),
+    campaign_id         UUID            NOT NULL,
+    title               VARCHAR(255)    NOT NULL,
+    rating_enabled      BOOLEAN         NOT NULL DEFAULT TRUE,
+    form_enabled        BOOLEAN         NOT NULL DEFAULT FALSE,
+    allow_drawings      BOOLEAN         NOT NULL DEFAULT FALSE,
+    form_schema         JSONB           NOT NULL DEFAULT '{}',
+    feedback_type_id    UUID,
+    context_id          UUID            UNIQUE,  -- 1:1 relationship enforced
+    active_from         TIMESTAMPTZ,
+    active_to           TIMESTAMPTZ,
+    visibility          VARCHAR(20)     NOT NULL DEFAULT 'public',
+    created_by_id       UUID            NOT NULL,
+    created_at          TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+    updated_at          TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT fk_geofeedback_campaign
+        FOREIGN KEY (campaign_id) REFERENCES campaign(id) ON DELETE CASCADE,
+    CONSTRAINT fk_geofeedback_custom_form
+        FOREIGN KEY (custom_form_id) REFERENCES custom_form(id) ON DELETE SET NULL,
+    CONSTRAINT fk_geofeedback_context
+        FOREIGN KEY (context_id) REFERENCES geocontext(id) ON DELETE SET NULL,
+    CONSTRAINT fk_geofeedback_created_by
+        FOREIGN KEY (created_by_id) REFERENCES auth_user(id) ON DELETE RESTRICT,
+    CONSTRAINT chk_geofeedback_mode
+        CHECK (rating_enabled OR form_enabled),
+    CONSTRAINT chk_geofeedback_drawings
+        CHECK (NOT allow_drawings OR form_enabled)
+);
+
+CREATE INDEX idx_geofeedback_campaign ON geofeedback(campaign_id);
+CREATE INDEX idx_geofeedback_active ON geofeedback(active_from, active_to);
+CREATE INDEX idx_geofeedback_visibility ON geofeedback(visibility);  -- Filter by public/private
+
+CREATE TRIGGER trg_geofeedback_updated_at
+    BEFORE UPDATE ON geofeedback
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+```
+
+##### M2M: feedback_layers
+
+```sql
+CREATE TABLE feedback_layers (
+    id              UUID            PRIMARY KEY DEFAULT gen_random_uuid(),
+    feedback_id     UUID            NOT NULL,
+    layer_id        UUID            NOT NULL,
+    display_order   INTEGER         NOT NULL DEFAULT 0,
+
+    CONSTRAINT fk_feedback_layers_feedback
+        FOREIGN KEY (feedback_id) REFERENCES geofeedback(id) ON DELETE CASCADE,
+    CONSTRAINT fk_feedback_layers_layer
+        FOREIGN KEY (layer_id) REFERENCES layerref(id) ON DELETE CASCADE,
+    CONSTRAINT uq_feedback_layers
+        UNIQUE (feedback_id, layer_id)
+);
+
+CREATE INDEX idx_feedback_layers_feedback ON feedback_layers(feedback_id);
+```
+
+##### Django Model
+
+```python
+class GeoFeedback(models.Model):
+    class Visibility(models.TextChoices):
+        PUBLIC = 'public', 'Public'
+        PRIVATE = 'private', 'Private'
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    campaign = models.ForeignKey(
+        Campaign, on_delete=models.CASCADE, related_name='feedbacks'
+    )
+    title = models.CharField(max_length=255)
+    rating_enabled = models.BooleanField(default=True)
+    form_enabled = models.BooleanField(default=False)
+    allow_drawings = models.BooleanField(default=False)
+    custom_form = models.ForeignKey(
+        'formbuilder.CustomForm', on_delete=models.SET_NULL, null=True, blank=True
+    )
+    context = models.OneToOneField(
+        GeoContext, on_delete=models.SET_NULL, null=True, blank=True
+    )
+    layers = models.ManyToManyField(
+        LayerRef, through='FeedbackLayer', related_name='feedbacks'
+    )
+    active_from = models.DateTimeField(null=True, blank=True)
+    active_to = models.DateTimeField(null=True, blank=True)
+    visibility = models.CharField(
+        max_length=20, choices=Visibility.choices, default=Visibility.PUBLIC
+    )
+    created_by = models.ForeignKey(
+        User, on_delete=models.RESTRICT, related_name='created_feedbacks'
+    )
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        db_table = 'geofeedback'
+        indexes = [
+            models.Index(fields=['campaign']),
+            models.Index(fields=['active_from', 'active_to']),
+        ]
+
+    def clean(self):
+        if not self.rating_enabled and not self.form_enabled:
+            raise ValidationError("At least one of rating_enabled or form_enabled must be True.")
+        if self.allow_drawings and not self.form_enabled:
+            raise ValidationError("allow_drawings requires form_enabled to be True.")
+        if self.form_enabled and not self.custom_form:
+            raise ValidationError("custom_form is required when form_enabled is True.")
+
+
+class FeedbackLayer(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    feedback = models.ForeignKey(GeoFeedback, on_delete=models.CASCADE)
+    layer = models.ForeignKey(LayerRef, on_delete=models.CASCADE)
+    display_order = models.IntegerField(default=0)
+
+    class Meta:
+        db_table = 'feedback_layers'
+        unique_together = ['feedback', 'layer']
+        ordering = ['display_order']
+```
+
+##### Design Notes
+
+- **Three modes**: `rating_enabled` only, `form_enabled` only, or both (composite)
+- **`allow_drawings`** requires `form_enabled` — users can draw geometries on the map
+- **`custom_form` generated via package** — the structure of a form is controlled via `django-basic-form-builder`'s `CustomForm` model.
+- **`custom_form` required for forms** — validated in `clean()` method
+- **`custom_form` nullable** when only rating is enabled
+- **Layers M2M** — same pattern as GeoStory
+
+---
+
+#### **FeatureLink**
+
+Explicit relationships between entities within a campaign (Story ↔ Event, Story ↔ Feedback).
+
+##### Schema Definition
+
+| Column                   | PostgreSQL Type | Nullable | Default             | Description                           |
+| ------------------------ | --------------- | -------- | ------------------- | ------------------------------------- |
+| `id`                     | `UUID`          | NOT NULL | `gen_random_uuid()` | Primary key                           |
+| `campaign_id`            | `UUID`          | NOT NULL | —                   | FK → `campaign.id` (enforce boundary) |
+| `source_content_type_id` | `INTEGER`       | NOT NULL | —                   | FK → `django_content_type.id`         |
+| `source_object_id`       | `UUID`          | NOT NULL | —                   | ID of source (Story/Event/Feedback)   |
+| `target_content_type_id` | `INTEGER`       | NOT NULL | —                   | FK → `django_content_type.id`         |
+| `target_object_id`       | `UUID`          | NOT NULL | —                   | ID of target (Story/Event/Feedback)   |
+| `link_type`              | `VARCHAR(20)`   | NOT NULL | `'related'`         | `direct`, `read_more`, `action`       |
+| `created_by_id`          | `UUID`          | NOT NULL | —                   | FK → `auth_user.id`                   |
+| `created_at`             | `TIMESTAMPTZ`   | NOT NULL | `NOW()`             | Creation timestamp                    |
+
+##### Constraints
+
+| Constraint                | Type        | Definition                                                                                      |
+| ------------------------- | ----------- | ----------------------------------------------------------------------------------------------- |
+| `pk_featurelink`          | PRIMARY KEY | `(id)`                                                                                          |
+| `fk_featurelink_campaign` | FOREIGN KEY | `campaign_id REFERENCES campaign(id) ON DELETE CASCADE`                                         |
+| `fk_featurelink_creator`  | FOREIGN KEY | `created_by_id REFERENCES auth_user(id) ON DELETE RESTRICT`                                     |
+| `chk_no_self_link`        | CHECK       | `NOT (source_content_type_id = target_content_type_id AND source_object_id = target_object_id)` |
+
+##### Indexes
+
+| Index Name                 | Columns                                    | Type   | Purpose            |
+| -------------------------- | ------------------------------------------ | ------ | ------------------ |
+| `idx_featurelink_campaign` | `campaign_id`                              | B-tree | Filter by campaign |
+| `idx_featurelink_source`   | `source_content_type_id, source_object_id` | B-tree | Forward lookup     |
+| `idx_featurelink_target`   | `target_content_type_id, target_object_id` | B-tree | Reverse lookup     |
+
+##### PostgreSQL DDL
+
+```sql
+CREATE TABLE featurelink (
+    id                      UUID            PRIMARY KEY DEFAULT gen_random_uuid(),
+    campaign_id             UUID            NOT NULL,
+
+    -- Generic Foreign Key (Source)
+    source_content_type_id  INTEGER         NOT NULL,
+    source_object_id        UUID            NOT NULL,
+
+    -- Generic Foreign Key (Target)
+    target_content_type_id  INTEGER         NOT NULL,
+    target_object_id        UUID            NOT NULL,
+
+    link_type               VARCHAR(20)     NOT NULL DEFAULT 'related',
+    created_by_id           UUID            NOT NULL,
+    created_at              TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT fk_featurelink_campaign
+        FOREIGN KEY (campaign_id) REFERENCES campaign(id) ON DELETE CASCADE,
+    CONSTRAINT fk_featurelink_creator
+        FOREIGN KEY (created_by_id) REFERENCES auth_user(id) ON DELETE RESTRICT,
+    CONSTRAINT chk_no_self_link
+        CHECK (NOT (source_content_type_id = target_content_type_id AND source_object_id = target_object_id)),
+    CONSTRAINT uq_featurelink_no_duplicates
+        UNIQUE (source_content_type_id, source_object_id, target_content_type_id, target_object_id)
+);
+
+CREATE INDEX idx_featurelink_campaign ON featurelink(campaign_id);
+CREATE INDEX idx_featurelink_source ON featurelink(source_content_type_id, source_object_id);
+CREATE INDEX idx_featurelink_target ON featurelink(target_content_type_id, target_object_id);
+
+-- ============================================================================
+-- TRIGGER VALIDATION: Validate linked entities exist and belong to same campaign
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION validate_featurelink()
+RETURNS TRIGGER AS $$
+DECLARE
+    source_campaign_id UUID;
+    target_campaign_id UUID;
+    source_table_name TEXT;
+    target_table_name TEXT;
+    entity_exists BOOLEAN;
+BEGIN
+    -- Get content type model names from django_content_type
+    SELECT model INTO source_table_name
+    FROM django_content_type WHERE id = NEW.source_content_type_id;
+
+    SELECT model INTO target_table_name
+    FROM django_content_type WHERE id = NEW.target_content_type_id;
+
+    -- Validate source entity exists and get its campaign_id
+    CASE source_table_name
+        WHEN 'geostory' THEN
+            SELECT campaign_id INTO source_campaign_id FROM geostory WHERE id = NEW.source_object_id;
+        WHEN 'calendarevent' THEN
+            SELECT campaign_id INTO source_campaign_id FROM calendarevent WHERE id = NEW.source_object_id;
+        WHEN 'geofeedback' THEN
+            SELECT campaign_id INTO source_campaign_id FROM geofeedback WHERE id = NEW.source_object_id;
+        ELSE
+            RAISE EXCEPTION 'Invalid source content type: %', source_table_name;
+    END CASE;
+
+    IF source_campaign_id IS NULL THEN
+        RAISE EXCEPTION 'Source entity not found: % with id %', source_table_name, NEW.source_object_id;
+    END IF;
+
+    -- Validate target entity exists and get its campaign_id
+    CASE target_table_name
+        WHEN 'geostory' THEN
+            SELECT campaign_id INTO target_campaign_id FROM geostory WHERE id = NEW.target_object_id;
+        WHEN 'calendarevent' THEN
+            SELECT campaign_id INTO target_campaign_id FROM calendarevent WHERE id = NEW.target_object_id;
+        WHEN 'geofeedback' THEN
+            SELECT campaign_id INTO target_campaign_id FROM geofeedback WHERE id = NEW.target_object_id;
+        ELSE
+            RAISE EXCEPTION 'Invalid target content type: %', target_table_name;
+    END CASE;
+
+    IF target_campaign_id IS NULL THEN
+        RAISE EXCEPTION 'Target entity not found: % with id %', target_table_name, NEW.target_object_id;
+    END IF;
+
+    -- Validate both entities belong to the same campaign as the link
+    IF source_campaign_id != NEW.campaign_id THEN
+        RAISE EXCEPTION 'Source entity belongs to different campaign (expected %, got %)',
+            NEW.campaign_id, source_campaign_id;
+    END IF;
+
+    IF target_campaign_id != NEW.campaign_id THEN
+        RAISE EXCEPTION 'Target entity belongs to different campaign (expected %, got %)',
+            NEW.campaign_id, target_campaign_id;
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_featurelink_validate
+    BEFORE INSERT OR UPDATE ON featurelink
+    FOR EACH ROW
+    EXECUTE FUNCTION validate_featurelink();
+
+-- Note: This trigger validates:
+--   1. Source object exists in geostory, calendarevent, or geofeedback
+--   2. Target object exists in geostory, calendarevent, or geofeedback
+--   3. Both source and target belong to the same campaign as the link
+--   4. Content types must be one of the allowed models
+```
+
+##### Django Model
+
+```python
+from django.contrib.contenttypes.fields import GenericForeignKey
+from django.contrib.contenttypes.models import ContentType
+
+class FeatureLink(models.Model):
+    class LinkType(models.TextChoices):
+        DIRECT = 'direct', 'Direct Link'
+        READ_MORE = 'read_more', 'Read More'
+        ACTION = 'action', 'Take Action'
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    campaign = models.ForeignKey(
+        Campaign, on_delete=models.CASCADE, related_name='feature_links'
+    )
+
+    # Source Entity
+    source_content_type = models.ForeignKey(
+        ContentType, on_delete=models.CASCADE, related_name='link_sources'
+    )
+    source_object_id = models.UUIDField()
+    source_object = GenericForeignKey('source_content_type', 'source_object_id')
+
+    # Target Entity
+    target_content_type = models.ForeignKey(
+        ContentType, on_delete=models.CASCADE, related_name='link_targets'
+    )
+    target_object_id = models.UUIDField()
+    target_object = GenericForeignKey('target_content_type', 'target_object_id')
+
+    link_type = models.CharField(
+        max_length=20, choices=LinkType.choices, default=LinkType.RELATED
+    )
+    created_by = models.ForeignKey(
+        User, on_delete=models.RESTRICT, related_name='created_links'
+    )
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        db_table = 'featurelink'
+        indexes = [
+            models.Index(fields=['campaign']),
+            models.Index(fields=['source_content_type', 'source_object_id']),
+            models.Index(fields=['target_content_type', 'target_object_id']),
+        ]
+
+    def clean(self):
+        if self.source_content_type == self.target_content_type and \
+           self.source_object_id == self.target_object_id:
+            raise ValidationError("Cannot link a feature to itself.")
+```
+
+**Constraints:**
+
+- `UNIQUE (source_type, source_id, target_type, target_id)` — no duplicate links
+- Application-level validation ensures source/target entities exist
+
+---
+
+#### **FeedbackSubmission**
+
+User responses to feedback forms.
+
+| Column        | Type                    | Nullable | Description                          |
+| ------------- | ----------------------- | -------- | ------------------------------------ |
+| `id`          | UUID                    | No       | Primary key                          |
+| `feedback_id` | UUID (FK → GeoFeedback) | No       | Parent feedback form                 |
+| `user_id`     | UUID (FK → User)        | Yes      | Null for anonymous submissions       |
+| `rating`      | INTEGER                 | Yes      | 1-5 star rating (if enabled)         |
+| `form_data`   | JSONB                   | Yes      | Form responses matching `CustomForm` |
+| `geometry`    | GEOMETRY(Any, 4326)     | Yes      | Optional location of submission      |
+| `anonymized`  | BOOLEAN                 | No       | Whether user data has been scrubbed  |
+| `created_at`  | TIMESTAMPTZ             | No       | Submission timestamp                 |
+
+**Constraints:**
+
+- `CHECK (rating IS NULL OR (rating >= 1 AND rating <= 5))`
+
+---
+
+## **5. API Design**
+
+### **Core Endpoints (REST/JSON)**
+
+| **Endpoint**                                        | **Method**       | **Purpose**                                                    |
+| --------------------------------------------------- | ---------------- | -------------------------------------------------------------- |
+| /api/campaigns/                                     | GET, POST        | Create/list campaigns with mission metadata.                   |
+| /api/campaigns/{id}/                                | GET, PATCH       | Retrieve or update campaign detail.                            |
+| /api/campaigns/{id}/summary/                        | GET              | Aggregated KPIs (stories count, participation, sentiment).     |
+| /api/stories/                                       | GET, POST, PATCH | CRUD Geostories scoped by campaign.                            |
+| /api/stories/{id}/events/                           | GET              | List events directly linked to a story.                        |
+| /api/events/                                        | GET, POST        | Create/list calendar events (filterable by campaign or story). |
+| /api/feedback/                                      | GET, POST        | Create/manage feedback configurations (campaign-scoped).       |
+| /api/feedback/{id}/submit/                          | POST             | Submit user feedback.                                          |
+| /api/feature-links/                                 | POST, DELETE     | Manage curated direct links (enforces same campaign).          |
+| /api/feature-links?source_type=story&source_id=UUID | GET              | Fetch direct links for rendering UI sections.                  |
+| /api/analytics/{story_id}/                          | GET              | Return aggregated impact summaries (story-level).              |
+| /api/analytics/campaigns/{id}/                      | GET              | Campaign-level impact summaries.                               |
+
+All creation endpoints (`stories`, `events`, `feedback`) require a `campaign` UUID in the payload. The API responds with the `campaign_id` plus pre-hydrated arrays for `direct_links` (queried from `feature_links`) so the frontend can render “Direct” and “More from this campaign” sections without extra joins.
+
+### **Integration APIs**
+
+- /api/hooks/geostory-updated/ — triggers analytics recalculation.
+- /api/hooks/event-finished/ — triggers post-event feedback.
+- /api/ai/summary/{story_id}/ — optional AI service for summarizing feedback text.
+
+---
+
+## **6. Frontend Architecture**
+
+| **Layer**                    | **Description**                            | **Example Components**                               |
+| ---------------------------- | ------------------------------------------ | ---------------------------------------------------- |
+| **UI Framework**             | Vue 3 + Composition API + Tailwind CSS.    | GeoStoryView.vue, CalendarView.vue, FeedbackForm.vue |
+| **Map Layer**                | MapLibre GL integrated with Pinia store.   | useMapStore, LayerManager, StoryHighlight            |
+| **State Management (Pinia)** | Stores for modular entities.               | useStoryStore, useEventStore, useFeedbackStore       |
+| **Routing (Vue Router)**     | Structured routes per feature.             | /stories/:id, /events, /feedback/:id                 |
+| **Interaction Controls**     | Map click events, feature linking, popups. | onFeatureClick() → open StorySidebar()               |
+| **Analytics UI**             | Charts and maps for outcome summaries.     | StoryImpactPanel.vue, EventStats.vue                 |
+
+---
+
+## **7. Backend Architecture (Django)**
+
+### **App Modules**
+
+```
+/apps
+ ├── stories/         (Geostories models, serializers, views)
+ ├── events/          (Calendar events)
+ ├── feedback/        (Forms, submissions)
+ ├── analytics/       (aggregations, caching)
+ ├── media/           (asset mgmt)
+ ├── users/           (auth, roles)
+ └── common/          (utils, signals, mixins)
+```
+
+### **Core Services**
+
+- **Celery Worker:** asynchronous analytics aggregation, email notifications.
+- **Redis:** task queue and cache for frequent story/event queries.
+- **PostGIS:** geometry storage and spatial queries for linking stories, events, and feedback.
+- **GeoServer or Vector Tile Service:** serves map data for story regions.
+- **S3/MinIO:** handles uploaded media (images, documents, videos).
+
+---
+
+## **8. Analytics Flow**
+
+#### **FeedbackSubmission**
+
+Individual user submissions for a GeoFeedback form.
+
+##### Schema Definition
+
+| Column               | PostgreSQL Type            | Nullable | Default             | Description                                |
+| -------------------- | -------------------------- | -------- | ------------------- | ------------------------------------------ |
+| `id`                 | `UUID`                     | NOT NULL | `gen_random_uuid()` | Primary key                                |
+| `feedback_id`        | `UUID`                     | NOT NULL | —                   | FK → `geofeedback.id`                      |
+| `user_id`            | `UUID`                     | NULL     | `NULL`              | FK → `auth_user.id` (if authenticated)     |
+| `rating`             | `INTEGER`                  | NULL     | `NULL`              | 1-5 stars (if rating enabled)              |
+| `selected_option_id` | `UUID`                     | NULL     | `NULL`              | FK → `feedbackoption.id` (if form enabled) |
+| `form_data`          | `JSONB`                    | NULL     | `NULL`              | Form field responses                       |
+| `geometry`           | `GEOMETRY(Geometry, 4326)` | NULL     | `NULL`              | User-drawn geometry (Point, Line, Polygon) |
+| `is_anonymized`      | `BOOLEAN`                  | NOT NULL | `FALSE`             | If user requested anonymity                |
+| `created_at`         | `TIMESTAMPTZ`              | NOT NULL | `NOW()`             | Submission timestamp                       |
+
+##### Constraints
+
+| Constraint                       | Type        | Definition                                                            |
+| -------------------------------- | ----------- | --------------------------------------------------------------------- |
+| `pk_feedbacksubmission`          | PRIMARY KEY | `(id)`                                                                |
+| `fk_feedbacksubmission_feedback` | FOREIGN KEY | `feedback_id REFERENCES geofeedback(id) ON DELETE CASCADE`            |
+| `fk_feedbacksubmission_user`     | FOREIGN KEY | `user_id REFERENCES auth_user(id) ON DELETE SET NULL`                 |
+| `fk_feedbacksubmission_option`   | FOREIGN KEY | `selected_option_id REFERENCES feedbackoption(id) ON DELETE SET NULL` |
+| `chk_feedbacksubmission_rating`  | CHECK       | `rating IS NULL OR (rating >= 1 AND rating <= 5)`                     |
+
+##### Indexes
+
+| Index Name                        | Columns              | Type   | Purpose                      |
+| --------------------------------- | -------------------- | ------ | ---------------------------- |
+| `idx_feedbacksubmission_feedback` | `feedback_id`        | B-tree | Filter by feedback           |
+| `idx_feedbacksubmission_user`     | `user_id`            | B-tree | Filter by user               |
+| `idx_feedbacksubmission_option`   | `selected_option_id` | B-tree | Filter by sentiment/category |
+| `idx_feedbacksubmission_geom`     | `geometry`           | GiST   | Spatial analysis             |
+
+##### PostgreSQL DDL
+
+```sql
+CREATE TABLE feedbacksubmission (
+    id                  UUID            PRIMARY KEY DEFAULT gen_random_uuid(),
+    feedback_id         UUID            NOT NULL,
+    user_id             UUID,
+    rating              INTEGER,
+    selected_option_id  UUID,
+    form_data           JSONB           DEFAULT '{}',
+    location            GEOMETRY(Geometry, 4326),
+    is_anonymized       BOOLEAN         NOT NULL DEFAULT FALSE,
+    created_at          TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT fk_feedbacksubmission_feedback
+        FOREIGN KEY (feedback_id) REFERENCES geofeedback(id) ON DELETE CASCADE,
+    CONSTRAINT fk_feedbacksubmission_user
+        FOREIGN KEY (user_id) REFERENCES auth_user(id) ON DELETE SET NULL,
+    CONSTRAINT fk_feedbacksubmission_option
+        FOREIGN KEY (selected_option_id) REFERENCES feedbackoption(id) ON DELETE SET NULL,
+    CONSTRAINT chk_feedbacksubmission_rating
+        CHECK (rating IS NULL OR (rating >= 1 AND rating <= 5)),
+    CONSTRAINT chk_feedbacksubmission_location_form
+        CHECK (location IS NOT NULL OR form_data IS NULL OR form_data = '{}'::jsonb)
+);
+
+CREATE INDEX idx_feedbacksubmission_feedback ON feedbacksubmission(feedback_id);
+CREATE INDEX idx_feedbacksubmission_user ON feedbacksubmission(user_id);
+CREATE INDEX idx_feedbacksubmission_option ON feedbacksubmission(selected_option_id);
+CREATE INDEX idx_feedbacksubmission_loc ON feedbacksubmission USING GIST(location);
+```
+
+##### Django Model
+
+```python
+class FeedbackSubmission(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    feedback = models.ForeignKey(
+        GeoFeedback, on_delete=models.CASCADE, related_name='submissions'
+    )
+    user = models.ForeignKey(
+        User, on_delete=models.SET_NULL, null=True, blank=True
+    )
+    rating = models.IntegerField(null=True, blank=True)
+    selected_option = models.ForeignKey(
+        FeedbackOption, on_delete=models.SET_NULL, null=True, blank=True
+    )
+    form_data = models.JSONField(default=dict, blank=True, null=True)
+    geometry = models.GeometryField(srid=4326, blank=True, null=True)
+    is_anonymized = models.BooleanField(default=False)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        db_table = 'feedbacksubmission'
+        indexes = [
+            models.Index(fields=['feedback']),
+            models.Index(fields=['selected_option']),
+        ]
+
+    def clean(self):
+        # Validate based on parent feedback configuration
+        if self.feedback.rating_enabled and self.rating is None:
+             pass # Logic depends on if rating is mandatory
+
+        if self.feedback.form_enabled:
+             if not self.location:
+                  # Location is mandatory if form is enabled
+                  raise ValidationError("Location is mandatory for form feedback.")
+
+             if self.selected_option and \
+                self.selected_option.feedback_type != self.feedback.feedback_type:
+                  raise ValidationError("Selected option does not match feedback type.")
+
+##### Design Notes
+
+- **`location`**: The pin on the map. Mandatory **only if** `form_enabled=True`. Optional for rating-only feedback.
+- **`allow_drawings`**: If true, users can draw additional geometries (lines/polygons) inside the form. These are stored within `form_data` (FeatureCollection), NOT in the `location` column.
+```
+
+---
+
+```
+1. Event or feedback submission received.
+2. Signal triggers Celery task.
+3. Task aggregates results grouped by:
+     - Campaign ID
+     - Geostory ID
+     - Event ID
+     - Time period
+4. Results stored in AnalyticsSnapshot table.
+5. Frontend fetches metrics for dashboards:
+     - Ratings distribution
+     - Participation counts
+     - Sentiment summaries
+6. Updated GeoStory and Campaign views display impact metrics.
+```
+
+---
+
+## **9. Integration & Extensibility**
+
+### **9.1 Layer Management Strategy: Transition from Legacy**
+
+We have modernized the integration with GeoServer to support per-feature layer ordering and user-controlled syncing.
+
+#### **Before: Legacy Model (`tosca-geonode-main/cpt`)**
+
+- **Architecture**: A simple `GeoserverLayers` model storing just `layer_name`.
+- **Relationship**: Layers were linked directly to the `Campaign`. All stories in a campaign had to share the exact same map context.
+- **Sync**: Relied on a rigid `update_layers` cron job that auto-synced the entire catalog, often leading to clutter or stale data.
+
+#### **After: Fine-Grained `LayerRef` Architecture**
+
+- **Architecture**: Enriched `LayerRef` model with `display_name` and explicit ordering support.
+- **Relationship**: Layers are now linked to **specific features** (GeoStory, CalendarEvent, GeoFeedback) via junction tables (`geostory_layers`, etc.).
+- **Benefit**: This allows a Story to show "Roads + Floods", while an Event in the same campaign shows "Shelters + Traffic", with each author controlling the exact Z-index (stacking order) of layers.
+
+#### **Why Manual Sync?**
+
+We adopted a **Manual User-Triggered Sync** strategy (`POST /api/layers/sync/`) via a UI button because:
+
+1.  **Control**: Authors see new layers immediately when _they_ need them, without waiting for a cron job.
+2.  **Performance**: Avoids expensive periodic API calls to GeoServer catalog.
+3.  **Simplicity**: Reduces background worker complexity and synchronization race conditions.
+
+---
+
+## **10. Security & Compliance**
+
+| **Aspect**          | **Implementation**                                            |
+| ------------------- | ------------------------------------------------------------- |
+| **Authentication**  | JWT or OAuth2 tokens via Django REST Framework.               |
+| **Authorization**   | Role-based access control (admin, editor, organizer, public). |
+| **GDPR compliance** | Pseudonymized feedback storage; explicit consent checkboxes.  |
+| **Data separation** | Feedback stored separately from user profiles.                |
+| **HTTPS + CSP**     | Enforced for all routes.                                      |
+
+---
+
+## **11. Deployment & Infrastructure**
+
+| **Component** | **Service**                      | **Notes**                                       |
+| ------------- | -------------------------------- | ----------------------------------------------- |
+| Backend       | Django + Gunicorn + Nginx        | API, admin, async worker.                       |
+| Database      | PostgreSQL + PostGIS + PgBouncer | Spatial queries, analytics, connection pooling. |
+| Task Queue    | Celery + Redis                   | Background processing.                          |
+| File Storage  | S3 / MinIO                       | Media & file uploads.                           |
+| Map Services  | GeoServer or TileServer GL       | Vector tile delivery.                           |
+| Frontend      | Static Vue build served via CDN  | SPA client.                                     |
+
+Deployment pipelines via **GitHub Actions or GitLab CI**, containerized using **Docker Compose or Kubernetes**.
+
+---
+
+## **12. Extensible Data Relationships**
+
+### **12.1 Parent-Child Relationships (via Foreign Key)**
+
+These are structural relationships enforced by FK constraints:
+
+| **Parent**    | **Child**          | **Cardinality** | **Description**                         |
+| ------------- | ------------------ | --------------- | --------------------------------------- |
+| Campaign      | GeoStory           | 1–N             | Campaign hosts multiple stories         |
+| Campaign      | CalendarEvent      | 1–N             | Campaign hosts multiple events          |
+| Campaign      | GeoFeedback        | 1–N             | Campaign hosts multiple feedback forms  |
+| Campaign      | FeatureLink        | 1–N             | Links scoped to campaign for validation |
+| GeoFeedback   | FeedbackSubmission | 1–N             | Feedback form receives submissions      |
+| FeedbackType  | FeedbackOption     | 1–N             | Type has multiple options               |
+| GeoStory      | GeoContext         | 1–1             | Story has optional rich content         |
+| CalendarEvent | GeoContext         | 1–1             | Event has optional rich content         |
+| GeoFeedback   | GeoContext         | 1–1             | Feedback has optional rich content      |
+
+### **12.2 Direct Linking (via FeatureLink)**
+
+These are explicit M:N relationships between features, enabling cross-referencing within a campaign:
+
+| **Source**    | **Target**    | **Cardinality** | **Description**                                   |
+| ------------- | ------------- | --------------- | ------------------------------------------------- |
+| GeoStory      | GeoStory      | M–N             | Stories can reference other stories (except self) |
+| GeoStory      | CalendarEvent | M–N             | Stories can link to related events                |
+| GeoStory      | GeoFeedback   | M–N             | Stories can link to feedback forms                |
+| CalendarEvent | GeoStory      | M–N             | Events can reference related stories              |
+| CalendarEvent | CalendarEvent | M–N             | Events can link to other events (except self)     |
+| CalendarEvent | GeoFeedback   | M–N             | Events can link to feedback forms                 |
+| GeoFeedback   | GeoStory      | M–N             | Feedback can reference related stories            |
+| GeoFeedback   | CalendarEvent | M–N             | Feedback can link to related events               |
+| GeoFeedback   | GeoFeedback   | M–N             | Feedback can link to other forms (except self)    |
+
+> [!NOTE]
+> **FeatureLink Rules:**
+>
+> - Source and target must belong to the **same campaign**
+> - An entity **cannot link to itself** (enforced by CHECK constraint)
+> - No duplicate links (enforced by UNIQUE constraint)
+> - Links are **directional** (source → target), but can be created bidirectionally
+> - Validated by `validate_featurelink()` trigger for referential integrity
+
+### **12.3 Layer Associations (via M:M Junction Tables)**
+
+| **Entity**    | **LayerRef** | **Junction Table** | **Description**                   |
+| ------------- | ------------ | ------------------ | --------------------------------- |
+| GeoStory      | LayerRef     | `geostory_layers`  | Story displays selected layers    |
+| CalendarEvent | LayerRef     | `event_layers`     | Event displays selected layers    |
+| GeoFeedback   | LayerRef     | `feedback_layers`  | Feedback displays selected layers |
+
+## **13. Technical Benefits**
+
+- **Shared foundation:** all participation features built from reusable primitives.
+- **Loose coupling:** Geostories, Events, and Feedback work independently but link through shared spatial IDs.
+- **Low-code authoring:** new stories and events created via UI, no deployment required.
+- **Analytics ready:** built-in data model supports KPI dashboards, exports, and machine learning later.
+
+---
+
+## **14. Summary**
+
+The **Geostories × Calendar × Participation** architecture is modular, scalable, and designed for long-term sustainability.
+
+It integrates narrative, spatial, and participatory data within one ecosystem, while maintaining clear boundaries between frontend, backend, and data services.
+
+**Key principle:**
+
+> “Every story can become an event. Every event can generate feedback. Every feedback makes the story smarter — and every campaign keeps the loop aligned with its mission.”
+
+This approach transforms a static information system into a **self-learning participation platform** — technically robust, socially transparent, and ready for cross-sector collaboration.
+
+---
+
+## **15. Developer Checklist: Security, Query Efficiency & Common Pitfalls**
+
+> [!IMPORTANT]
+> Use this checklist during development to ensure database operations are secure, efficient, and maintainable.
+
+---
+
+### **15.1 Security Checklist**
+
+#### ✅ SQL Injection Prevention
+
+| Check                                 | Status | Notes                                        |
+| ------------------------------------- | ------ | -------------------------------------------- |
+| Use Django ORM for all queries        | ⬜     | ORM uses parameterized queries automatically |
+| Never use f-strings in raw SQL        | ⬜     | Always use `cursor.execute(sql, params)`     |
+| Validate user input before queries    | ⬜     | Especially UUIDs, enums, and filters         |
+| Escape layer_name for GeoServer calls | ⬜     | Could be injection vector in external APIs   |
+
+```python
+# ❌ DANGEROUS - SQL Injection vulnerable
+cursor.execute(f"SELECT * FROM geostory WHERE id = '{user_input}'")
+
+# ✅ SAFE - Parameterized query
+cursor.execute("SELECT * FROM geostory WHERE id = %s", [user_input])
+
+# ✅ SAFE - Django ORM
+GeoStory.objects.filter(id=user_input)
+```
+
+#### ✅ JSONB Validation
+
+| Check                               | Status | Notes                                         |
+| ----------------------------------- | ------ | --------------------------------------------- |
+| Validate `form_schema` structure    | ⬜     | Use JSON Schema validation in `clean()`       |
+| Validate `form_data` against schema | ⬜     | Ensure submitted data matches expected fields |
+| Limit JSONB depth and size          | ⬜     | Prevent DoS via deeply nested objects         |
+
+```python
+import jsonschema
+
+FORM_SCHEMA_VALIDATOR = {
+    "type": "object",
+    "properties": {
+        "fields": {"type": "array"},
+        "title": {"type": "string", "maxLength": 255}
+    },
+    "additionalProperties": False
+}
+
+def clean(self):
+    try:
+        jsonschema.validate(self.form_schema, FORM_SCHEMA_VALIDATOR)
+    except jsonschema.ValidationError as e:
+        raise ValidationError(f"Invalid form_schema: {e.message}")
+```
+
+#### ✅ XSS Prevention
+
+| Check                                  | Status | Notes                                           |
+| -------------------------------------- | ------ | ----------------------------------------------- |
+| Escape `geocontext.content` on render  | ⬜     | Use Django's `escape` or `bleach` for rich text |
+| Sanitize HTML if `content_type='rich'` | ⬜     | Whitelist allowed HTML tags                     |
+| Never trust `form_data` text values    | ⬜     | Escape before display in frontend               |
+
+```python
+import bleach
+
+ALLOWED_TAGS = ['p', 'br', 'strong', 'em', 'ul', 'ol', 'li', 'a', 'h1', 'h2', 'h3']
+ALLOWED_ATTRS = {'a': ['href', 'title']}
+
+def safe_content(self):
+    if self.content_type == 'rich':
+        return bleach.clean(self.content, tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRS)
+    return escape(self.content)
+```
+
+#### ✅ Input Validation
+
+| Check                                  | Status | Notes                         |
+| -------------------------------------- | ------ | ----------------------------- |
+| Validate UUIDs before database queries | ⬜     | Reject malformed UUIDs early  |
+| Validate enum values                   | ⬜     | Status, visibility, link_type |
+| Validate geometry WKT/GeoJSON          | ⬜     | Use PostGIS `ST_IsValid()`    |
+| Rate limit anonymous feedback          | ⬜     | Prevent spam/abuse            |
+
+```python
+from django.core.exceptions import ValidationError
+import uuid
+
+def validate_uuid(value):
+    try:
+        uuid.UUID(str(value))
+    except ValueError:
+        raise ValidationError(f"'{value}' is not a valid UUID")
+```
+
+---
+
+### **15.2 Query Efficiency Checklist**
+
+#### ✅ Use Proper Indexes
+
+| Query Pattern         | Required Index                        | Status    |
+| --------------------- | ------------------------------------- | --------- |
+| Filter by campaign    | `idx_*_campaign`                      | ✅ Exists |
+| Filter by status      | `idx_*_status`                        | ✅ Exists |
+| Filter by date range  | `idx_calendarevent_dates`             | ✅ Exists |
+| Campaign + date range | `idx_calendarevent_campaign_dates`    | ✅ Exists |
+| Spatial queries       | GiST on geometry columns              | ✅ Exists |
+| Pagination by date    | `idx_geostory_created_at`             | ✅ Exists |
+| FeatureLink lookups   | Composite on content_type + object_id | ✅ Exists |
+
+#### ✅ Prevent N+1 Queries
+
+```python
+# ❌ N+1 Problem - Each iteration triggers a query
+stories = GeoStory.objects.filter(campaign=campaign)
+for story in stories:
+    print(story.context.content)     # Query per story
+    print(story.campaign.title)      # Another query per story
+
+# ✅ Fixed - Use select_related for FK/OneToOne
+stories = GeoStory.objects.filter(campaign=campaign).select_related(
+    'context', 'campaign', 'author', 'cover_media'
+)
+
+# ✅ For M2M relationships, use prefetch_related
+stories = GeoStory.objects.filter(campaign=campaign).prefetch_related('layers')
+```
+
+#### ✅ Optimize Common Queries
+
+| Endpoint                  | Optimization                              | Status |
+| ------------------------- | ----------------------------------------- | ------ |
+| List stories by campaign  | Use `select_related('context', 'author')` | ⬜     |
+| List events in date range | Use compound index                        | ⬜     |
+| Fetch feature links       | Use composite index lookups               | ⬜     |
+| Count submissions         | Use `COUNT(*)` not `len(queryset)`        | ⬜     |
+
+```python
+# ❌ Inefficient - Loads all objects into memory
+count = len(FeedbackSubmission.objects.filter(feedback=feedback))
+
+# ✅ Efficient - Database does the counting
+count = FeedbackSubmission.objects.filter(feedback=feedback).count()
+```
+
+#### ✅ Pagination Best Practices
+
+```python
+# ❌ Offset pagination is slow for large datasets
+# Page 10000 requires scanning 100000 rows
+GeoStory.objects.all()[100000:100010]
+
+# ✅ Cursor-based pagination with indexed column (REQUIRED)
+last_seen = request.GET.get('cursor')
+# Use DRF's CursorPagination
+```
+
+---
+
+### **15.3 Common Pitfalls**
+
+#### ⚠️ GenericForeignKey Limitations
+
+```python
+# ❌ Can't filter directly on GenericForeignKey target
+links = FeatureLink.objects.filter(source_object__title='Test')  # Won't work!
+
+# ✅ Must filter by content_type and object_id
+from django.contrib.contenttypes.models import ContentType
+geostory_ct = ContentType.objects.get_for_model(GeoStory)
+story_ids = GeoStory.objects.filter(title='Test').values_list('id', flat=True)
+links = FeatureLink.objects.filter(
+    source_content_type=geostory_ct,
+    source_object_id__in=story_ids
+)
+```
+
+#### ⚠️ Geometry Validation
+
+```python
+# ❌ Invalid geometry can crash queries
+region = GEOSGeometry('POLYGON((0 0, 0 1, 1 0, 0 0))')  # Not closed properly
+
+# ✅ Validate geometry before saving
+from django.contrib.gis.geos import GEOSGeometry
+
+def clean_location(self):
+    if self.location and not self.location.valid:
+        self.location = self.location.buffer(0)  # Fix geometry
+```
+
+#### ⚠️ 1:1 Relationship Gotchas
+
+```python
+# The UNIQUE constraint on context_id enforces 1:1
+# BUT you must create GeoContext first
+
+# ❌ Fails - GeoContext doesn't exist
+story = GeoStory.objects.create(
+    campaign=campaign,
+    title='Test',
+    context_id=some_uuid  # Invalid FK!
+)
+
+# ✅ Create context first, then link
+context = GeoContext.objects.create(content='...', created_by=user)
+story = GeoStory.objects.create(
+    campaign=campaign,
+    title='Test',
+    context=context  # Valid
+)
+```
+
+#### ⚠️ Migrating 1:1 to N:N (Future)
+
+If you later need multiple features to share the same GeoContext:
+
+```sql
+-- Step 1: Drop UNIQUE constraint
+ALTER TABLE geostory DROP CONSTRAINT geostory_context_id_key;
+ALTER TABLE calendarevent DROP CONSTRAINT calendarevent_context_id_key;
+ALTER TABLE geofeedback DROP CONSTRAINT geofeedback_context_id_key;
+
+-- Step 2: (Optional) Create M2M junction tables if needed
+-- CREATE TABLE geostory_contexts (geostory_id, context_id, PRIMARY KEY...)
+```
+
+---
+
+### **15.4 Pre-Deployment Checklist**
+
+| Item                                              | Status | Notes                                   |
+| ------------------------------------------------- | ------ | --------------------------------------- |
+| Run `EXPLAIN ANALYZE` on critical queries         | ⬜     | Ensure indexes are used                 |
+| Enable `log_min_duration_statement` in PostgreSQL | ⬜     | Log slow queries                        |
+| Test FeatureLink trigger with edge cases          | ⬜     | Invalid content types, missing entities |
+| Verify JSONB size limits                          | ⬜     | Set max size in application layer       |
+| Enable HTTPS in production                        | ⬜     | Mandatory for all routes                |
+| Configure rate limiting for `/feedback/*/submit/` | ⬜     | Prevent anonymous abuse                 |
+| Set up database connection pooling                | ⬜     | Use PgBouncer for production            |
+
+---

--- a/docs/formbuilder/package-readme.md
+++ b/docs/formbuilder/package-readme.md
@@ -1,0 +1,262 @@
+# django-basic-form-builder
+
+Reusable Django app that lets admins define JSON-rendered forms directly in the Django admin, then expose them via a read-only API endpoint. Works with Django 5.1+, DRF 3.15+, and the dependency stack listed in `pyproject.toml`.
+
+## Installation
+
+1. Install with [uv](https://github.com/astral-sh/uv) (preferred) or pip:
+
+   ```bash
+   uv pip install django-basic-form-builder
+   ```
+
+   Optional extras:
+   - PostgreSQL support: `uv pip install "django-basic-form-builder[postgres]"`
+   - HTML sanitization utilities (if you integrate them yourself): `uv pip install "django-basic-form-builder[html]"`
+
+2. Add `formbuilder` (and `rest_framework` if not already present) to `INSTALLED_APPS`.
+3. Explicitly enable the read-only API endpoint (it is off by default to avoid exposing form data unintentionally):
+
+   ```python
+   FORMBUILDER_API_ENABLED = True
+   ```
+
+4. Include the API URLs in your project routes:
+
+   ```python
+   from django.urls import include, path
+
+   urlpatterns = [
+       path('api/forms/', include('formbuilder.api.urls')),
+   ]
+   ```
+
+5. Run migrations (`python manage.py migrate`).
+
+## Admin Usage
+
+- Create a **Custom Form** entry in admin (name, slug, description, status).
+- Add **Form Fields** using the stacked inline editor; supported types are `text`, `number`, `textarea`, `dropdown`, `radio`, `checkbox`, `rating`, `boolean`, `email`, `date`.
+- For each field:
+  - **Label**: Short technical identifier (e.g., "Email", "Full Name") - used internally and in compact UIs
+  - **Question**: Detailed question or explanation for users (e.g., "What is your email address? We'll use this to send you updates.")
+    - For feedback forms, this is the primary text users see
+    - Can be left blank if the label is self-explanatory
+  - **Slug**: Technical field identifier (auto-generated from label)
+  - Configure shared attributes (required, placeholder, default value, help text)
+- For dropdown, radio, and checkbox fields:
+  - After saving the form, click "Save and continue editing"
+  - Click on a field to edit it individually
+  - Use the "Field options" inline editor at the bottom to add options
+- For text/number/rating fields:
+  - Expand the relevant configuration section (Text/Number/Rating Configuration)
+  - Use the dedicated config fields (min/max length, min/max value, rating scale)
+  - These fields are type-specific and only apply to their respective field types
+  - Or use the advanced JSON config section for power users
+- **Position auto-update**: When you add or remove fields, positions are automatically renumbered (1, 2, 3, etc.)
+- **Visual separation**: Each form field is shown in a separate bordered box for clarity
+- On every save, the app regenerates a JSON snapshot stored on `CustomForm.json_schema`.
+- Use the "Preview JSON" link to inspect the generated schema in a new tab.
+- Running on Python 3.14? A compatibility shim automatically patches Django's template context copy routine.
+
+### Label vs Question - When to Use Which?
+
+**Label** (required):
+
+- Short, concise identifier: "Email", "Phone", "Rating"
+- Used in compact form layouts, tables, and admin interfaces
+- Technical reference for developers
+- Appears in form labels and summaries
+
+**Question** (optional but recommended for feedback forms):
+
+- Full question or detailed explanation: "How satisfied are you with our service?"
+- Primary text shown to users in feedback/survey forms
+- Can include context, examples, or instructions
+- Better user experience for participation forms
+
+**Example:**
+
+```text
+Label: "Service Quality"
+Question: "On a scale of 1-5 stars, how would you rate the quality of service you received today?"
+
+Label: "Email"
+Question: "What email address should we use to send you updates about your inquiry?"
+```
+
+### Quick Start Guide
+
+1. **Create a form in Django admin:**
+   - Navigate to `/admin/formbuilder/customform/add/`
+   - Fill in: Name = "Contact Us", Slug = "contact-us", Status = "published"
+   - Click "Add another Form field" in the inline section:
+     - Label = "Full Name"
+     - Slug = "full_name"
+     - Question = "What is your full name?"
+     - Type = "text"
+     - Required = ✓
+   - Add another field:
+     - Label = "Department"
+     - Slug = "department"
+     - Question = "Which department would you like to contact?"
+     - Type = "dropdown"
+   - Click "Save and continue editing"
+   - Click on the Department field link to edit it
+   - In the "Field options" section at the bottom, add:
+     - Option 1: Value = "sales", Label = "Sales Team", Position = 1
+     - Option 2: Value = "support", Label = "Customer Support", Position = 2
+   - Add a rating field back in the main form:
+     - Label = "Satisfaction"
+     - Question = "How satisfied are you with our service?"
+     - Type = "rating"
+     - Expand "Rating Configuration" section
+     - Set Scale = 5, Style = "stars"
+   - Positions will auto-update as you add/remove fields
+   - Save the form
+
+2. **Fetch the JSON schema via API:**
+
+   ```bash
+   curl http://localhost:8000/api/forms/contact-us/
+   ```
+
+   You'll receive:
+
+   ```json
+   {
+     "form": {
+       "name": "Contact Us",
+       "slug": "contact-us",
+       "status": "published"
+     },
+     "fields": [
+       {
+         "id": "full_name",
+         "type": "text",
+         "label": "Full Name",
+         "question": "What is your full name?",
+         "required": true,
+         "position": 1,
+         ...
+       },
+       {
+         "id": "department",
+         "type": "dropdown",
+         "label": "Department",
+         "question": "Which department would you like to contact?",
+         "config": {
+           "options": [
+             {"value": "sales", "label": "Sales Team", "isDefault": false},
+             {"value": "support", "label": "Customer Support", "isDefault": false}
+           ]
+         },
+         "position": 2,
+         ...
+       },
+       {
+         "id": "satisfaction",
+         "type": "rating",
+         "label": "Satisfaction",
+         "question": "How satisfied are you with our service?",
+         "config": {
+           "scale": 5,
+           "style": "stars"
+         },
+         "position": 3,
+         ...
+       }
+     ]
+   }
+   ```
+
+3. **Preview before publishing:**
+   - While editing a form in admin, click the "Preview JSON" link to see the generated schema
+   - Forms with `status="draft"` return 404 from the API but are visible in admin preview
+
+## JSON Schema Contract
+
+Returned from `/api/forms/<slug>/` when the form status is `published`.
+
+```json
+{
+  "form": {
+    "name": "Contact Us",
+    "slug": "contact-us",
+    "description": "Lead capture form",
+    "status": "published"
+  },
+  "fields": [
+    {
+      "id": "full_name",
+      "type": "text",
+      "label": "Full Name",
+      "required": true,
+      "helpText": "As shown on ID",
+      "placeholder": "Jane Doe",
+      "defaultValue": null,
+      "position": 1,
+      "config": {
+        "minLength": 2,
+        "maxLength": 120,
+        "inputMode": "text",
+        "prefix": "",
+        "suffix": ""
+      }
+    }
+  ]
+}
+```
+
+### Field Attribute Matrix
+
+| Field Type | Config Keys                                                                | Notes                                                 |
+| ---------- | -------------------------------------------------------------------------- | ----------------------------------------------------- |
+| `text`     | `minLength`, `maxLength`, `pattern`, `inputMode`, `prefix`, `suffix`       | Single-line text input                                |
+| `number`   | `min`, `max`, `step`, `prefix`, `suffix`, `unit`                           | Numeric input with validation                         |
+| `textarea` | `rows`, `minLength`, `maxLength`, `autoResize`                             | Multi-line text input                                 |
+| `dropdown` | `allowMultiple`, `allowOther`, `options`, `defaultOption`                  | Options managed via FieldOption model (inline editor) |
+| `radio`    | `allowOther`, `options`, `defaultOption`                                   | Single selection, options via FieldOption model       |
+| `checkbox` | `minSelections`, `maxSelections`, `allowOther`, `options`, `defaultOption` | Multiple selections, options via FieldOption model    |
+| `rating`   | `scale` (5 or 10), `style` (stars/numeric/emoji), `minLabel`, `maxLabel`   | Rating scale input                                    |
+| `boolean`  | `trueLabel`, `falseLabel`, `style`                                         | Yes/No or True/False                                  |
+| `email`    | `confirmEmail`                                                             | Email with validation                                 |
+| `date`     | `minDate`, `maxDate`, `format`                                             | Date picker                                           |
+
+## Sample Fixture
+
+Load an example form (Contact Us) into any project:
+
+```bash
+python manage.py loaddata formbuilder/fixtures/demo_form.json
+```
+
+The fixture seeds one published `CustomForm` with two fields (text + dropdown) so you can immediately hit `/api/forms/contact-demo/` and inspect the JSON. Use this as a template when sharing schemas with frontend teams.
+
+## Testing Locally
+
+This repo includes a tiny Django settings module (`formbuilder_test_site`) used only for running the test suite:
+
+```bash
+uv sync --group dev
+pytest
+```
+
+The configured `pytest` run uses `-vv --cov=formbuilder --cov-report=term-missing`, so the CLI output lists each test, statuses, and line coverage to help you verify exactly what executed.
+
+## Development Setup
+
+To enable pre-commit hooks for linting and formatting:
+
+```bash
+uv tool install pre-commit
+pre-commit install
+```
+
+## Feature Flag
+
+Toggle the read-only API via the `FORMBUILDER_API_ENABLED` setting. The API is disabled unless you explicitly set `FORMBUILDER_API_ENABLED = True`; when left `False`, `/api/forms/<slug>/` returns 404 regardless of form status.
+
+## Compatibility Notes
+
+- Django 5.1 on Python 3.14 has a known bug in `django.template.context.BaseContext.__copy__`. This package patches the method at import time so admin pages continue to work. No action is required from host projects besides including `formbuilder` in `INSTALLED_APPS`.

--- a/docs/implementation/editorjs-geocontext-plan.md
+++ b/docs/implementation/editorjs-geocontext-plan.md
@@ -1,0 +1,78 @@
+# GeoContext Editor.js Integration, Revised
+
+## Summary
+
+- Replace `GeoContext.content` with canonical Editor.js JSON and remove `content_type`. This is an intentional contract change and is acceptable because the app is not yet published.
+- Use Editor.js only in Django admin for authoring, but make the backend contract JSON-first everywhere `GeoContext` is exposed through geostories, events, and feedback.
+- Limit MVP authoring to `paragraph`, `header`, `list`, `quote`, `delimiter`, and `code`, plus inline `link`, `bold`, `italic`, and `inlineCode`. No image, embed, raw HTML, or upload tools.
+
+## Implementation Changes
+
+- Change `GeoContext.content` from `TextField` to `JSONField` with canonical default `{"blocks": []}`. Persist only the normalized document shape `{ "blocks": [...] }`; accept full Editor.js save payloads on input, but strip `time`, `version`, and block `id` fields during normalization so repeated save/load/save cycles are deterministic.
+- Move JSON validation into a new module such as `tosca_api/apps/core/editorjs.py`. Keep `nh3`-based HTML sanitization there only for inline text fragments inside block data, not as the primary document validator.
+- Enforce model-level validation by normalizing `GeoContext.content` inside model validation and save flow. `None`, missing values, and empty strings coerce to `{"blocks": []}`. Any non-empty value must normalize to a dict with a `blocks` list.
+- Fix the inline HTML whitelist used inside text-bearing fields to: `a`, `strong`, `em`, `code`, and `br`. Normalize `<b>` to `<strong>` and `<i>` to `<em>`. `inlineCode` maps to `<code>`. Reject unsafe URLs and strip scripts/event handlers with `nh3`.
+- Validate allowed block schemas exactly:
+  - `paragraph`: `data.text`
+  - `header`: `data.text`, `data.level` with allowed levels `1-4`
+  - `list`: `data.style` in `ordered|unordered`, recursive `items`, and each item limited to `content`, `meta`, `items`; `meta` must be `{}` for MVP
+  - `quote`: `data.text` and optional empty `caption`; reject any `alignment` key for deterministic storage
+  - `delimiter`: empty `data`
+  - `code`: `data.code`
+- Build the Django admin editor as progressive enhancement in `geocontext` admin:
+  - the form field is a textarea containing canonical JSON by default
+  - JS upgrades that textarea into an Editor.js mount and mirrors changes back into the textarea before submit
+  - no custom AJAX is used, so standard Django form CSRF handling remains unchanged
+  - if JS fails to load, admins can still submit raw JSON through the textarea
+  - changelist preview renders extracted plain text from blocks, truncated to 120 characters, with `(empty)` for no visible text
+- Vendor Editor.js assets into Django static files and include upstream license files with the vendored sources. Use official packages only. The current upstream split to assume is: core Editor.js is [Apache-2.0](https://github.com/codex-team/editorjs), while official block tools such as [list](https://github.com/editor-js/list) and [paragraph](https://github.com/editor-js/paragraph) are MIT.
+- Fix the legacy HTML-to-block migration algorithm:
+  1. Release 1 adds `content_json` alongside existing columns.
+  2. Backfill converts existing rows into canonical block JSON.
+  3. Release 2 switches application reads and writes to `content_json`, but keeps legacy columns in place for rollback safety.
+  4. Release 3 drops legacy `content` and `content_type`, then renames `content_json` to `content`.
+- Legacy HTML backfill rules are fixed:
+  - old `simple` content becomes either `{"blocks": []}` if blank or one `paragraph` block with sanitized inline text
+  - old rich content is first passed through `sanitize_rich`, then parsed into blocks
+  - `h1`-`h4` become `header` blocks with matching levels
+  - `p` becomes `paragraph`, preserving inline markup and `<br>`
+  - top-level inline/text nodes outside block tags are folded into `paragraph` blocks
+  - `ul` and `ol` become `list` blocks with recursive nested items preserved using the official nested list JSON shape from [Editor.js List](https://github.com/editor-js/list)
+  - `blockquote` becomes `quote` with `caption=""`
+  - `pre><code` and `pre` become `code`
+  - inline `<code>` outside `pre` stays inline inside paragraph/header/quote/list item content
+  - unknown non-media tags are handled by the initial `nh3` sanitize pass and then parsed from the sanitized fragment
+  - sanitized fragments containing `img`, `figure`, or `figcaption` abort conversion for that row, and the migration aborts with a sorted explicit ID list
+- Add a non-mutating preflight command that scans all `GeoContext` rows and prints the exact IDs that would abort migration. The command must be read-only and idempotent. The data migration must use the same detection logic and fail with the same sorted ID list.
+
+## Public Interfaces
+
+- `GeoContext.content` becomes canonical Editor.js JSON with shape `{ "blocks": [...] }` everywhere it is exposed.
+- `content_type` is removed from models, admin, serializers, tests, and schema output.
+- Read responses never return `null` for `context.content`; empty documents return `{ "blocks": [] }`.
+- The backend accepts Editor.js-compatible write payloads but normalizes them to the canonical stored shape described above.
+- This plan is based on Editor.js’s official JSON save contract documented at [editorjs.io](https://editorjs.io/saving-data/), but the persisted backend shape is intentionally narrower for deterministic storage.
+
+## Test Plan
+
+- Model/unit tests for valid documents, malformed top-level payloads, unsupported block types, invalid block schemas, unsafe links, and inline XSS attempts such as `<script>` inside paragraph text.
+- Normalization tests for `None`, `""`, full Editor.js payloads with `time/version/id`, and canonical output equality after normalize-save-reload-save.
+- Migration tests for:
+  - simple text to paragraph blocks
+  - rich HTML to deterministic block JSON for paragraphs, headers, nested lists, quotes, code blocks, mixed inline formatting, and `<br>` handling
+  - exact sorted abort ID list for rows containing legacy media HTML
+  - dry-run preflight producing the same abort set as the real migration
+  - preflight command remaining read-only and returning the same output across repeated runs
+- Admin tests for:
+  - widget assets included on the GeoContext admin form
+  - textarea fallback visible before JS enhancement
+  - editor hydration from stored JSON
+  - round-trip save without semantic or canonical JSON drift
+  - changelist preview output for long and empty documents
+- API tests for geostories, events, and feedback detail serializers confirming `context.content` is JSON and `content_type` is absent.
+
+## Assumptions
+
+- Backward compatibility for published API consumers is out of scope because the app is not yet published.
+- No standalone GeoContext CRUD API is added in this work; only admin authoring, model validation, migration, and existing nested read surfaces change.
+- Media/image support remains explicitly out of scope for MVP; any row containing legacy media markup blocks the migration until handled manually or in a later media phase.

--- a/tosca_api/apps/events/serializers.py
+++ b/tosca_api/apps/events/serializers.py
@@ -9,7 +9,10 @@ from rest_framework import serializers
 from rest_framework_gis.serializers import GeoFeatureModelSerializer
 
 from tosca_api.apps.geocontext.models import GeoContext
-from tosca_api.apps.geodata_providers.api.serializers import LayerSummarySerializer
+from tosca_api.apps.geodata_providers.api.serializers import (
+    LayerSummarySerializer,
+    LayerUUIDListField,
+)
 
 from .models import (
     Event,
@@ -293,6 +296,7 @@ class EventWriteSerializer(TaxonomyAssignmentResolutionMixin, serializers.ModelS
         required=False,
         write_only=True,
     )
+    layers = LayerUUIDListField(required=False, write_only=True)
 
     class Meta:
         model = Event
@@ -321,6 +325,7 @@ class EventWriteSerializer(TaxonomyAssignmentResolutionMixin, serializers.ModelS
             "organizer",
             "context",
             "taxonomy_assignments",
+            "layers",
         ]
         read_only_fields = ["id", "organizer"]
 
@@ -335,13 +340,13 @@ class EventWriteSerializer(TaxonomyAssignmentResolutionMixin, serializers.ModelS
         instance = Event()
         if self.instance is not None:
             for field in self.Meta.fields:
-                if field in {"id", "taxonomy_assignments"}:
+                if field in {"id", "taxonomy_assignments", "layers"}:
                     continue
                 setattr(instance, field, getattr(self.instance, field))
             instance.pk = self.instance.pk
 
         for attr, value in attrs.items():
-            if attr.startswith("_"):
+            if attr.startswith("_") or attr == "layers":
                 continue
             setattr(instance, attr, value)
 
@@ -349,15 +354,21 @@ class EventWriteSerializer(TaxonomyAssignmentResolutionMixin, serializers.ModelS
         instance.clean()
         return attrs
 
+    @transaction.atomic
     def create(self, validated_data):
         taxonomy_terms = validated_data.pop("_taxonomy_terms", serializers.empty)
+        layers = validated_data.pop("layers", None)
         event = super().create(validated_data)
         if taxonomy_terms is not serializers.empty:
             self._replace_event_terms(event, taxonomy_terms)
+        if layers is not None:
+            self._sync_layers(event, layers)
         return event
 
+    @transaction.atomic
     def update(self, instance, validated_data):
         taxonomy_terms = validated_data.pop("_taxonomy_terms", serializers.empty)
+        layers = validated_data.pop("layers", None)
         should_mark_exception = self._should_mark_exception(
             instance=instance,
             validated_data=validated_data,
@@ -374,7 +385,18 @@ class EventWriteSerializer(TaxonomyAssignmentResolutionMixin, serializers.ModelS
         event = super().update(instance, validated_data)
         if taxonomy_terms is not serializers.empty:
             self._replace_event_terms(event, taxonomy_terms)
+        if layers is not None:
+            self._sync_layers(event, layers)
         return event
+
+    @staticmethod
+    def _sync_layers(event: Event, layers: list) -> None:
+        """Replace the event's EventLayer rows with the supplied list."""
+        EventLayer.objects.filter(event=event).delete()
+        for index, layer in enumerate(layers):
+            EventLayer.objects.create(
+                event=event, layer=layer, display_order=index
+            )
 
     def _should_mark_exception(self, instance, validated_data, taxonomy_terms) -> bool:
         if not instance.series_id:

--- a/tosca_api/apps/events/tests/test_api.py
+++ b/tosca_api/apps/events/tests/test_api.py
@@ -1851,3 +1851,54 @@ def test_event_detail_returns_layer_summary(api_client, user, future_event):
     assert layer_payload["is_public"] is True
     assert layer_payload["publishing_state"] == "PUBLISHED"
     assert layers[0]["display_order"] == 1
+
+
+@pytest.mark.django_db
+def test_event_create_with_layer_uuids(api_client, user, campaign):
+    """POST with layers=[uuid] must persist EventLayer rows in order."""
+    from tosca_api.apps.events.models import EventLayer
+    from tosca_api.apps.geodata_providers.test_helpers import make_layer
+
+    l1 = make_layer("workspace:evt_w_1", user=user)
+    l2 = make_layer("workspace:evt_w_2", user=user)
+
+    now = timezone.now()
+    api_client.force_authenticate(user=user)
+    payload = {
+        "title": "Event w/ layers",
+        "campaign": str(campaign.id),
+        "start_datetime": now.isoformat(),
+        "end_datetime": (now + timedelta(hours=1)).isoformat(),
+        "location": {"type": "Point", "coordinates": [10.0, 53.5]},
+        "location_mode": "physical",
+        "layers": [str(l1.id), str(l2.id)],
+    }
+    response = api_client.post("/api/v1/events/", payload, format="json")
+    assert response.status_code == 201, response.data
+
+    event = Event.objects.get(id=response.data["id"])
+    rows = list(EventLayer.objects.filter(event=event).order_by("display_order"))
+    assert [r.layer_id for r in rows] == [l1.id, l2.id]
+
+
+@pytest.mark.django_db
+def test_event_create_rejects_unpublished_layer(api_client, user, campaign):
+    from tosca_api.apps.geodata_providers.test_helpers import make_layer
+
+    draft_layer = make_layer(
+        "workspace:evt_w_draft", user=user, publishing_state="DRAFT"
+    )
+    now = timezone.now()
+    api_client.force_authenticate(user=user)
+    payload = {
+        "title": "Bad layers",
+        "campaign": str(campaign.id),
+        "start_datetime": now.isoformat(),
+        "end_datetime": (now + timedelta(hours=1)).isoformat(),
+        "location": {"type": "Point", "coordinates": [10.0, 53.5]},
+        "location_mode": "physical",
+        "layers": [str(draft_layer.id)],
+    }
+    response = api_client.post("/api/v1/events/", payload, format="json")
+    assert response.status_code == 400
+    assert "layers" in response.data

--- a/tosca_api/apps/feedback/serializers.py
+++ b/tosca_api/apps/feedback/serializers.py
@@ -1,7 +1,11 @@
+from django.db import transaction
 from rest_framework import serializers
 from rest_framework_gis.fields import GeometryField
 from tosca_api.apps.geocontext.models import GeoContext
-from tosca_api.apps.geodata_providers.api.serializers import LayerSummarySerializer
+from tosca_api.apps.geodata_providers.api.serializers import (
+    LayerSummarySerializer,
+    LayerUUIDListField,
+)
 
 from .models import FeedbackLayer, FeedbackSubmission, GeoFeedback
 
@@ -93,7 +97,15 @@ class GeoFeedbackDetailSerializer(serializers.ModelSerializer):
 
 
 class GeoFeedbackWriteSerializer(serializers.ModelSerializer):
-    """Write serializer for creating or updating GeoFeedback."""
+    """
+    Write serializer for creating or updating GeoFeedback.
+
+    Accepts an optional ``layers`` list of ``geodata_providers.Layer`` UUIDs.
+    Order of UUIDs in the list becomes the per-feedback display_order.
+    Layers must be public + published — see ``LayerUUIDListField``.
+    """
+
+    layers = LayerUUIDListField(required=False, write_only=True)
 
     class Meta:
         model = GeoFeedback
@@ -109,18 +121,45 @@ class GeoFeedbackWriteSerializer(serializers.ModelSerializer):
             "allow_drawings",
             "status",
             "visibility",
+            "layers",
         ]
         read_only_fields = ["id", "created_by"]
 
     def validate(self, attrs):
         """Invoke model clean() for DB-level validation."""
-        instance = GeoFeedback(**attrs)
+        layer_attrs = {k: v for k, v in attrs.items() if k != "layers"}
+        instance = GeoFeedback(**layer_attrs)
         if self.instance:
-            for attr, value in attrs.items():
+            for attr, value in layer_attrs.items():
                 setattr(instance, attr, value)
-        
+
         instance.clean()
         return attrs
+
+    @transaction.atomic
+    def create(self, validated_data):
+        layers = validated_data.pop("layers", None)
+        feedback = super().create(validated_data)
+        if layers is not None:
+            self._sync_layers(feedback, layers)
+        return feedback
+
+    @transaction.atomic
+    def update(self, instance, validated_data):
+        layers = validated_data.pop("layers", None)
+        feedback = super().update(instance, validated_data)
+        if layers is not None:
+            self._sync_layers(feedback, layers)
+        return feedback
+
+    @staticmethod
+    def _sync_layers(feedback: GeoFeedback, layers: list) -> None:
+        """Replace the feedback's FeedbackLayer rows with the supplied list."""
+        FeedbackLayer.objects.filter(feedback=feedback).delete()
+        for index, layer in enumerate(layers):
+            FeedbackLayer.objects.create(
+                feedback=feedback, layer=layer, display_order=index
+            )
 
 
 

--- a/tosca_api/apps/feedback/tests/test_api.py
+++ b/tosca_api/apps/feedback/tests/test_api.py
@@ -266,3 +266,49 @@ class TestFeedbackDetailLayers:
         assert layer_payload["is_public"] is True
         assert layer_payload["publishing_state"] == "PUBLISHED"
         assert layers[0]["display_order"] == 1
+
+
+@pytest.mark.django_db
+class TestFeedbackLayerWrites:
+    """Nested layer writes via UUID list."""
+
+    def test_create_with_layer_uuids(self, admin_client, admin_user, campaign):
+        from tosca_api.apps.feedback.models import FeedbackLayer, GeoFeedback
+        from tosca_api.apps.geodata_providers.test_helpers import make_layer
+
+        l1 = make_layer("workspace:fb_w_1", user=admin_user)
+        l2 = make_layer("workspace:fb_w_2", user=admin_user)
+
+        payload = {
+            "title": "FB w/ layers",
+            "campaign": str(campaign.id),
+            "rating_enabled": True,
+            "form_enabled": False,
+            "layers": [str(l1.id), str(l2.id)],
+        }
+        resp = admin_client.post("/api/v1/feedback/", payload, format="json")
+        assert resp.status_code == 201, resp.data
+
+        fb = GeoFeedback.objects.get(id=resp.data["id"])
+        rows = list(
+            FeedbackLayer.objects.filter(feedback=fb).order_by("display_order")
+        )
+        assert [r.layer_id for r in rows] == [l1.id, l2.id]
+        assert [r.display_order for r in rows] == [0, 1]
+
+    def test_create_rejects_non_public_layer(self, admin_client, admin_user, campaign):
+        from tosca_api.apps.geodata_providers.test_helpers import make_layer
+
+        private = make_layer(
+            "workspace:fb_w_private", user=admin_user, is_public=False
+        )
+        payload = {
+            "title": "FB",
+            "campaign": str(campaign.id),
+            "rating_enabled": True,
+            "form_enabled": False,
+            "layers": [str(private.id)],
+        }
+        resp = admin_client.post("/api/v1/feedback/", payload, format="json")
+        assert resp.status_code == 400
+        assert "layers" in resp.data

--- a/tosca_api/apps/geodata_providers/api/serializers.py
+++ b/tosca_api/apps/geodata_providers/api/serializers.py
@@ -38,6 +38,50 @@ class LayerSummarySerializer(serializers.ModelSerializer):
         read_only_fields = fields
 
 
+class LayerUUIDListField(serializers.ListField):
+    """
+    Write-side field that accepts a list of Layer UUIDs and resolves them
+    to ``geodata_providers.Layer`` instances.
+
+    Used by consumer apps (geostories, events, feedback) for nested layer
+    writes. Reports clear 400 errors for unknown UUIDs and pushes
+    public + published validation through the same shared helper used by
+    the through-model ``clean()`` methods.
+    """
+
+    child = serializers.UUIDField()
+
+    def to_internal_value(self, data):
+        from tosca_api.apps.geodata_providers.validators import (
+            validate_layer_is_public_and_published,
+        )
+
+        ids = super().to_internal_value(data)
+        if not ids:
+            return []
+
+        layers_by_id = Layer.objects.in_bulk(ids)
+        missing = [str(i) for i in ids if i not in layers_by_id]
+        if missing:
+            raise serializers.ValidationError(
+                f"Unknown layer id(s): {', '.join(missing)}"
+            )
+
+        from django.core.exceptions import ValidationError as DjangoValidationError
+
+        resolved: list[Layer] = []
+        for layer_id in ids:
+            layer = layers_by_id[layer_id]
+            try:
+                validate_layer_is_public_and_published(layer)
+            except DjangoValidationError as exc:
+                raise serializers.ValidationError(
+                    exc.message_dict.get("layer", str(exc))
+                )
+            resolved.append(layer)
+        return resolved
+
+
 class GeodataEngineSerializer(serializers.ModelSerializer):
     """Serializer for GeodataEngine model."""
 

--- a/tosca_api/apps/geostories/serializers.py
+++ b/tosca_api/apps/geostories/serializers.py
@@ -1,9 +1,14 @@
 from django.contrib.contenttypes.models import ContentType
 from rest_framework import serializers
 
+from django.db import transaction
+
 from tosca_api.apps.featurelinks.models import FeatureLink
 from tosca_api.apps.geocontext.models import GeoContext
-from tosca_api.apps.geodata_providers.api.serializers import LayerSummarySerializer
+from tosca_api.apps.geodata_providers.api.serializers import (
+    LayerSummarySerializer,
+    LayerUUIDListField,
+)
 
 from .models import GeoStory, GeoStoryLayer
 
@@ -132,7 +137,13 @@ class GeoStoryWriteSerializer(serializers.ModelSerializer):
     """
     Write serializer for GeoStory model.
     Used for create/update operations (Admin/Editor use).
+
+    Accepts an optional ``layers`` list of ``geodata_providers.Layer`` UUIDs.
+    Order of UUIDs in the list becomes the per-story display_order. Layers
+    must be public + published — see ``LayerUUIDListField``.
     """
+
+    layers = LayerUUIDListField(required=False, write_only=True)
 
     class Meta:
         model = GeoStory
@@ -144,6 +155,7 @@ class GeoStoryWriteSerializer(serializers.ModelSerializer):
             "campaign",
             "author",
             "context",
+            "layers",
             "created_at",
             "updated_at",
         ]
@@ -151,10 +163,36 @@ class GeoStoryWriteSerializer(serializers.ModelSerializer):
 
     def validate(self, attrs):
         """Invoke model clean() for DB-level validation."""
-        instance = GeoStory(**attrs)
+        layer_attrs = {k: v for k, v in attrs.items() if k != "layers"}
+        instance = GeoStory(**layer_attrs)
         if self.instance:
-            for attr, value in attrs.items():
+            for attr, value in layer_attrs.items():
                 setattr(instance, attr, value)
-        
+
         instance.clean()
         return attrs
+
+    @transaction.atomic
+    def create(self, validated_data):
+        layers = validated_data.pop("layers", None)
+        story = super().create(validated_data)
+        if layers is not None:
+            self._sync_layers(story, layers)
+        return story
+
+    @transaction.atomic
+    def update(self, instance, validated_data):
+        layers = validated_data.pop("layers", None)
+        story = super().update(instance, validated_data)
+        if layers is not None:
+            self._sync_layers(story, layers)
+        return story
+
+    @staticmethod
+    def _sync_layers(story: GeoStory, layers: list) -> None:
+        """Replace the story's GeoStoryLayer rows with the supplied list."""
+        GeoStoryLayer.objects.filter(geostory=story).delete()
+        for index, layer in enumerate(layers):
+            GeoStoryLayer.objects.create(
+                geostory=story, layer=layer, display_order=index
+            )

--- a/tosca_api/apps/geostories/tests/test_api.py
+++ b/tosca_api/apps/geostories/tests/test_api.py
@@ -253,6 +253,82 @@ def test_geostory_detail_layers_no_n_plus_one(api_client, user, geostory):
 
 
 @pytest.mark.django_db
+def test_geostory_create_with_layer_uuids(api_client, user, campaign):
+    """POST with layers=[uuid1, uuid2] must persist GeoStoryLayer rows."""
+    from tosca_api.apps.geodata_providers.test_helpers import make_layer
+
+    layer1 = make_layer("workspace:write_a", user=user)
+    layer2 = make_layer("workspace:write_b", user=user)
+
+    api_client.force_authenticate(user=user)
+    payload = {
+        "title": "Story With Layers",
+        "campaign": str(campaign.id),
+        "layers": [str(layer1.id), str(layer2.id)],
+    }
+    response = api_client.post("/api/v1/stories/", payload, format="json")
+    assert response.status_code == 201
+
+    story = GeoStory.objects.get(id=response.data["id"])
+    rows = list(GeoStoryLayer.objects.filter(geostory=story).order_by("display_order"))
+    assert [r.layer_id for r in rows] == [layer1.id, layer2.id]
+    assert [r.display_order for r in rows] == [0, 1]
+
+
+@pytest.mark.django_db
+def test_geostory_create_rejects_unknown_layer_uuid(api_client, user, campaign):
+    import uuid as uuid_module
+
+    api_client.force_authenticate(user=user)
+    payload = {
+        "title": "Story",
+        "campaign": str(campaign.id),
+        "layers": [str(uuid_module.uuid4())],
+    }
+    response = api_client.post("/api/v1/stories/", payload, format="json")
+    assert response.status_code == 400
+    assert "layers" in response.data
+
+
+@pytest.mark.django_db
+def test_geostory_create_rejects_non_public_layer(api_client, user, campaign):
+    from tosca_api.apps.geodata_providers.test_helpers import make_layer
+
+    private = make_layer("workspace:write_private", user=user, is_public=False)
+
+    api_client.force_authenticate(user=user)
+    payload = {
+        "title": "Story",
+        "campaign": str(campaign.id),
+        "layers": [str(private.id)],
+    }
+    response = api_client.post("/api/v1/stories/", payload, format="json")
+    assert response.status_code == 400
+    assert "layers" in response.data
+
+
+@pytest.mark.django_db
+def test_geostory_update_replaces_layers(api_client, user, geostory):
+    from tosca_api.apps.geodata_providers.test_helpers import make_layer
+
+    initial = make_layer("workspace:upd_initial", user=user)
+    GeoStoryLayer.objects.create(geostory=geostory, layer=initial, display_order=0)
+
+    replacement = make_layer("workspace:upd_replacement", user=user)
+    api_client.force_authenticate(user=user)
+    response = api_client.patch(
+        f"/api/v1/stories/{geostory.id}/",
+        {"layers": [str(replacement.id)]},
+        format="json",
+    )
+    assert response.status_code == 200
+
+    rows = list(GeoStoryLayer.objects.filter(geostory=geostory))
+    assert len(rows) == 1
+    assert rows[0].layer_id == replacement.id
+
+
+@pytest.mark.django_db
 def test_geostory_detail_has_feature_links(api_client, user, geostory, campaign):
     """Test that detail view returns outgoing feature links."""
     # Create another story to link to


### PR DESCRIPTION
Add a shared LayerUUIDListField in geodata_providers that resolves a list of Layer UUIDs, rejects unknown ids with a clear 400, and runs the public + published validator already enforced by through-model clean(). Wire it into GeoStory, Event, and GeoFeedback write serializers as an optional `layers` field — order in the list becomes per-parent display_order.

Sync helpers wipe and rewrite each parent's through-rows inside an atomic transaction so partial writes can't leak. Cover create, update, and rejection paths (unknown UUID, non-public, non-published) with API tests across all three apps.

## Summary

- [ ] Description of changes
- [ ] Related issue link

## Testing

- [ ] `uv run pytest`
- [ ] Other (describe)
