### PR TITLE
feat(layers): warn before deleting a referenced Layer

### DIFF
--- a/tosca_api/apps/geodata_providers/admin.py
+++ b/tosca_api/apps/geodata_providers/admin.py
@@ -1313,6 +1313,31 @@ class LayerAdmin(RemoteDeleteAdminMixin, admin.ModelAdmin):
     # ------------------------------------------------------------------
     # 4.5 — Delete safety: GeoServer-first for PUBLISHED layers
     # ------------------------------------------------------------------
+    def delete_view(self, request, object_id, extra_context=None):
+        """Inject GeoStory/Event/GeoFeedback usage counts into the page."""
+        try:
+            layer = self.get_object(request, object_id)
+        except Exception:
+            layer = None
+
+        if layer is not None:
+            usage = layer.usage_summary()
+            if any(usage.values()):
+                self.message_user(
+                    request,
+                    (
+                        f"Layer '{layer.name}' is referenced by "
+                        f"{usage['geostories']} geostories, "
+                        f"{usage['events']} events, and "
+                        f"{usage['feedbacks']} feedbacks. "
+                        "Confirming will cascade-remove those references."
+                    ),
+                    messages.WARNING,
+                )
+            extra_context = {**(extra_context or {}), "layer_usage_summary": usage}
+
+        return super().delete_view(request, object_id, extra_context=extra_context)
+
     def delete_model(self, request, obj):
         result = LayerService.delete_layer_safe(obj)
         if not result.get('success'):

--- a/tosca_api/apps/geodata_providers/api/views.py
+++ b/tosca_api/apps/geodata_providers/api/views.py
@@ -491,6 +491,24 @@ class LayerViewSet(viewsets.ModelViewSet):
     def destroy(self, request, *args, **kwargs):
         layer = self.get_object()
 
+        # Pre-delete usage warning: if any GeoStory / Event / GeoFeedback
+        # references this layer, require an explicit ?confirm=true so the
+        # caller can show the user what will be cascade-removed.
+        usage = layer.usage_summary()
+        if any(usage.values()) and request.query_params.get("confirm") != "true":
+            return Response(
+                {
+                    "success": False,
+                    "error": "layer_in_use",
+                    "detail": (
+                        "Layer is referenced by other features. Re-send with "
+                        "?confirm=true to cascade-delete those references."
+                    ),
+                    "usage": usage,
+                },
+                status=status.HTTP_409_CONFLICT,
+            )
+
         result = LayerService.delete_layer_safe(layer)
         if not result.get('success', False):
             return Response(
@@ -501,7 +519,14 @@ class LayerViewSet(viewsets.ModelViewSet):
                 },
                 status=status.HTTP_400_BAD_REQUEST,
             )
-        return Response({'success': True, 'message': 'Layer unpublished and deleted.'}, status=status.HTTP_200_OK)
+        return Response(
+            {
+                'success': True,
+                'message': 'Layer unpublished and deleted.',
+                'usage': usage,
+            },
+            status=status.HTTP_200_OK,
+        )
 
     @action(detail=True, methods=['post'])
     def publish(self, request, pk=None):

--- a/tosca_api/apps/geodata_providers/models.py
+++ b/tosca_api/apps/geodata_providers/models.py
@@ -385,6 +385,21 @@ class Layer(TimeStampedModel):
         """Return True if the layer is currently published."""
         return self.publishing_state == self.PublishingState.PUBLISHED
 
+    def usage_summary(self) -> dict[str, int]:
+        """
+        Return how many GeoStory / Event / GeoFeedback rows reference this
+        layer through their respective through-tables.
+
+        Used by the admin delete-confirmation page and the API destroy
+        action to warn an operator before a CASCADE removes the layer
+        from every parent that depends on it.
+        """
+        return {
+            "geostories": self.geostory_uses.count(),
+            "events": self.event_uses.count(),
+            "feedbacks": self.feedback_uses.count(),
+        }
+
 
 class Style(TimeStampedModel):
     """

--- a/tosca_api/apps/geodata_providers/tests/test_layer_usage.py
+++ b/tosca_api/apps/geodata_providers/tests/test_layer_usage.py
@@ -1,0 +1,164 @@
+"""Tests for Layer.usage_summary() and the Layer destroy pre-delete guard."""
+
+from datetime import timedelta
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.contrib.gis.geos import Point
+from django.utils import timezone
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from tosca_api.apps.campaigns.models import Campaign
+from tosca_api.apps.geodata_providers.api.views import LayerViewSet
+
+
+def _call_destroy(user, layer, *, confirm: bool = False):
+    """Invoke LayerViewSet.destroy directly without needing a URL mount."""
+    factory = APIRequestFactory()
+    url = f"/?confirm=true" if confirm else "/"
+    request = factory.delete(url)
+    force_authenticate(request, user=user)
+    view = LayerViewSet.as_view({"delete": "destroy"})
+    return view(request, pk=str(layer.id))
+from tosca_api.apps.events.models import Event, EventLayer
+from tosca_api.apps.feedback.models import FeedbackLayer, GeoFeedback
+from tosca_api.apps.geodata_providers.models import Layer
+from tosca_api.apps.geodata_providers.test_helpers import make_layer
+from tosca_api.apps.geostories.models import GeoStory, GeoStoryLayer
+
+User = get_user_model()
+
+
+@pytest.fixture
+def admin_user():
+    return User.objects.create_user(
+        username="usage_admin", password="x", is_staff=True, is_superuser=True
+    )
+
+
+@pytest.fixture
+def campaign(admin_user):
+    return Campaign.objects.create(title="Usage Campaign", created_by=admin_user)
+
+
+@pytest.fixture
+def layer(admin_user):
+    return make_layer("workspace:usage_layer", user=admin_user)
+
+
+@pytest.mark.django_db
+def test_usage_summary_zero_for_unreferenced_layer(layer):
+    assert layer.usage_summary() == {
+        "geostories": 0,
+        "events": 0,
+        "feedbacks": 0,
+    }
+
+
+@pytest.mark.django_db
+def test_usage_summary_counts_each_consumer(layer, admin_user, campaign):
+    story = GeoStory.objects.create(
+        title="S", campaign=campaign, author=admin_user
+    )
+    GeoStoryLayer.objects.create(geostory=story, layer=layer)
+
+    now = timezone.now()
+    event = Event.objects.create(
+        campaign=campaign,
+        title="E",
+        start_datetime=now,
+        end_datetime=now + timedelta(hours=1),
+        location=Point(10.0, 53.5, srid=4326),
+        organizer=admin_user,
+    )
+    EventLayer.objects.create(event=event, layer=layer)
+
+    fb = GeoFeedback.objects.create(
+        campaign=campaign,
+        title="F",
+        rating_enabled=True,
+        form_enabled=False,
+        created_by=admin_user,
+    )
+    FeedbackLayer.objects.create(feedback=fb, layer=layer)
+
+    assert layer.usage_summary() == {
+        "geostories": 1,
+        "events": 1,
+        "feedbacks": 1,
+    }
+
+
+@pytest.mark.django_db
+def test_destroy_returns_409_when_layer_in_use(
+    admin_user, layer, campaign, monkeypatch
+):
+    """API destroy without ?confirm=true must return 409 with usage."""
+    story = GeoStory.objects.create(
+        title="S", campaign=campaign, author=admin_user
+    )
+    GeoStoryLayer.objects.create(geostory=story, layer=layer)
+
+    # Block any real engine call — we should not reach the service.
+    from tosca_api.apps.geodata_providers.services.commands import layer_service
+
+    monkeypatch.setattr(
+        layer_service.LayerService,
+        "delete_layer_safe",
+        lambda *a, **kw: pytest.fail("delete_layer_safe should not run on 409"),
+    )
+
+    resp = _call_destroy(admin_user, layer)
+    assert resp.status_code == 409
+    assert resp.data["error"] == "layer_in_use"
+    assert resp.data["usage"]["geostories"] == 1
+    assert Layer.objects.filter(id=layer.id).exists()
+
+
+@pytest.mark.django_db
+def test_destroy_with_confirm_true_runs_delete(
+    admin_user, layer, campaign, monkeypatch
+):
+    """With ?confirm=true the destroy proceeds to LayerService.delete_layer_safe."""
+    story = GeoStory.objects.create(
+        title="S", campaign=campaign, author=admin_user
+    )
+    GeoStoryLayer.objects.create(geostory=story, layer=layer)
+
+    from tosca_api.apps.geodata_providers.services.commands import layer_service
+
+    called = {}
+
+    def fake_delete(layer_obj):
+        called["called"] = True
+        layer_obj.delete()
+        return {"success": True}
+
+    monkeypatch.setattr(
+        layer_service.LayerService, "delete_layer_safe", fake_delete
+    )
+
+    resp = _call_destroy(admin_user, layer, confirm=True)
+    assert resp.status_code == 200
+    assert called.get("called") is True
+    assert resp.data["usage"]["geostories"] == 1
+    assert not Layer.objects.filter(id=layer.id).exists()
+
+
+@pytest.mark.django_db
+def test_destroy_unreferenced_layer_does_not_require_confirm(
+    admin_user, layer, monkeypatch
+):
+    from tosca_api.apps.geodata_providers.services.commands import layer_service
+
+    def fake_delete(layer_obj):
+        layer_obj.delete()
+        return {"success": True}
+
+    monkeypatch.setattr(
+        layer_service.LayerService, "delete_layer_safe", fake_delete
+    )
+
+    resp = _call_destroy(admin_user, layer)
+    assert resp.status_code == 200
+    assert not Layer.objects.filter(id=layer.id).exists()


### PR DESCRIPTION
Add Layer.usage_summary() returning the count of GeoStory, Event, and GeoFeedback rows that reference a layer through their through-tables.

In the admin, override LayerAdmin.delete_view to flash a warning banner with the per-app counts and surface them in the confirmation template's extra context. In the API, the LayerViewSet destroy action returns 409 Conflict with the usage breakdown when the layer is referenced and the caller did not opt in with ?confirm=true; with the flag, deletion proceeds through LayerService.delete_layer_safe and the usage summary is echoed in the success payload.

## Summary

- [ ] Description of changes
- [ ] Related issue link

## Testing

- [ ] `uv run pytest`
- [ ] Other (describe)
