### PR TITLE
feat(media): add tiered image validation policy

### DIFF
--- a/tosca_api/apps/core/image_policy.py
+++ b/tosca_api/apps/core/image_policy.py
@@ -1,0 +1,188 @@
+"""
+Tiered server-side image validation policy.
+
+Two callables are exposed:
+
+- ``validate_hero_image(file)`` — strict tier for GeoStory hero images.
+- ``validate_inline_image(file)`` — relaxed tier for EditorJS inline image
+  blocks.
+
+Both share MIME, size, and decode rules and differ only in dimension bounds.
+
+Design notes:
+
+- MIME is determined by reading the file *header bytes* via Pillow
+  (``Image.open(...).format``). Request ``Content-Type`` is advisory only and
+  is never trusted.
+- Validation is **read-only**. The validator never rewrites or replaces the
+  upload bytes — the file written to storage is byte-for-byte identical to
+  what the client sent. EXIF/metadata stripping is handled later, at
+  derivative re-encode time (Task 9.4), not on ingest.
+- Alt text is enforced at the use-site (hero in Tasks 9.1/9.3, inline image
+  block in Task 9.5), not at this validation layer.
+"""
+
+from __future__ import annotations
+
+from typing import IO, Any, Tuple
+
+from django.core.exceptions import ValidationError
+from PIL import Image, UnidentifiedImageError
+
+
+MAX_FILE_SIZE_BYTES: int = 8 * 1024 * 1024  # 8 MB
+
+# Pillow format string -> canonical MIME
+_PILLOW_FORMAT_TO_MIME: dict[str, str] = {
+    "JPEG": "image/jpeg",
+    "PNG": "image/png",
+    "WEBP": "image/webp",
+}
+ALLOWED_MIME_TYPES: frozenset[str] = frozenset(_PILLOW_FORMAT_TO_MIME.values())
+
+HERO_MIN_DIMENSIONS: Tuple[int, int] = (800, 450)
+HERO_MAX_DIMENSIONS: Tuple[int, int] = (6000, 6000)
+
+INLINE_MIN_DIMENSIONS: Tuple[int, int] = (200, 200)
+INLINE_MAX_DIMENSIONS: Tuple[int, int] = (6000, 6000)
+
+
+def _file_size(file: Any) -> int:
+    size = getattr(file, "size", None)
+    if isinstance(size, int):
+        return size
+    pos = file.tell() if hasattr(file, "tell") else None
+    file.seek(0, 2)
+    size = file.tell()
+    if pos is not None:
+        file.seek(pos)
+    else:
+        file.seek(0)
+    return size
+
+
+def _rewind(file: Any) -> None:
+    if hasattr(file, "seek"):
+        file.seek(0)
+
+
+def _open_image(file: Any) -> Tuple[str, Tuple[int, int]]:
+    """Return (mime, (width, height)) by inspecting the file header.
+
+    Raises ValidationError on decode failure or unsupported format.
+    """
+    _rewind(file)
+    try:
+        # Use a fresh open for ``verify`` (which renders the image unusable
+        # afterwards) and a second open to read dimensions.
+        with Image.open(file) as probe:
+            probe.verify()
+    except UnidentifiedImageError as exc:
+        raise ValidationError(
+            {"image": f"Unable to decode image file: {exc}"}
+        ) from exc
+    except Exception as exc:  # Pillow may raise SyntaxError/OSError on bad data
+        raise ValidationError(
+            {"image": f"Unable to decode image file: {exc}"}
+        ) from exc
+
+    _rewind(file)
+    try:
+        with Image.open(file) as img:
+            fmt = (img.format or "").upper()
+            width, height = img.size
+    except UnidentifiedImageError as exc:
+        raise ValidationError(
+            {"image": f"Unable to read image dimensions: {exc}"}
+        ) from exc
+    except Exception as exc:
+        raise ValidationError(
+            {"image": f"Unable to read image dimensions: {exc}"}
+        ) from exc
+    finally:
+        _rewind(file)
+
+    mime = _PILLOW_FORMAT_TO_MIME.get(fmt)
+    if mime is None:
+        raise ValidationError(
+            {
+                "image": (
+                    f"Unsupported image format '{fmt or 'unknown'}'. "
+                    f"Allowed: {sorted(ALLOWED_MIME_TYPES)}."
+                )
+            }
+        )
+    return mime, (width, height)
+
+
+def _validate_common(file: Any) -> Tuple[str, Tuple[int, int]]:
+    """Run shared MIME / size / decode rules and return (mime, dimensions)."""
+    if file is None:
+        raise ValidationError({"image": "No image file provided."})
+
+    size = _file_size(file)
+    if size > MAX_FILE_SIZE_BYTES:
+        raise ValidationError(
+            {
+                "image": (
+                    f"Image file is {size} bytes; maximum allowed is "
+                    f"{MAX_FILE_SIZE_BYTES} bytes (8 MB)."
+                )
+            }
+        )
+
+    return _open_image(file)
+
+
+def _validate_dimensions(
+    dimensions: Tuple[int, int],
+    *,
+    minimum: Tuple[int, int],
+    maximum: Tuple[int, int],
+    tier: str,
+) -> None:
+    width, height = dimensions
+    min_w, min_h = minimum
+    max_w, max_h = maximum
+    if width < min_w or height < min_h:
+        raise ValidationError(
+            {
+                "image": (
+                    f"Image dimensions {width}x{height} are below the "
+                    f"{tier} minimum {min_w}x{min_h}."
+                )
+            }
+        )
+    if width > max_w or height > max_h:
+        raise ValidationError(
+            {
+                "image": (
+                    f"Image dimensions {width}x{height} exceed the "
+                    f"{tier} maximum {max_w}x{max_h}."
+                )
+            }
+        )
+
+
+def validate_hero_image(file: IO[bytes]) -> Tuple[str, Tuple[int, int]]:
+    """Validate a GeoStory hero image. Returns (mime, (width, height))."""
+    mime, dimensions = _validate_common(file)
+    _validate_dimensions(
+        dimensions,
+        minimum=HERO_MIN_DIMENSIONS,
+        maximum=HERO_MAX_DIMENSIONS,
+        tier="hero",
+    )
+    return mime, dimensions
+
+
+def validate_inline_image(file: IO[bytes]) -> Tuple[str, Tuple[int, int]]:
+    """Validate an inline EditorJS image. Returns (mime, (width, height))."""
+    mime, dimensions = _validate_common(file)
+    _validate_dimensions(
+        dimensions,
+        minimum=INLINE_MIN_DIMENSIONS,
+        maximum=INLINE_MAX_DIMENSIONS,
+        tier="inline",
+    )
+    return mime, dimensions

--- a/tosca_api/apps/core/tests/test_image_policy.py
+++ b/tosca_api/apps/core/tests/test_image_policy.py
@@ -1,0 +1,186 @@
+"""
+Tests for the tiered image validation policy (Task 9.2).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+
+import pytest
+from django.core.exceptions import ValidationError
+from django.core.files.uploadedfile import SimpleUploadedFile
+from PIL import Image
+
+from tosca_api.apps.core.image_policy import (
+    MAX_FILE_SIZE_BYTES,
+    validate_hero_image,
+    validate_inline_image,
+)
+
+
+def _make_image_bytes(
+    *,
+    width: int,
+    height: int,
+    fmt: str = "PNG",
+    color: tuple[int, int, int] = (200, 100, 50),
+    exif: bytes | None = None,
+) -> bytes:
+    img = Image.new("RGB", (width, height), color=color)
+    buf = io.BytesIO()
+    save_kwargs: dict = {"format": fmt}
+    if exif is not None:
+        save_kwargs["exif"] = exif
+    img.save(buf, **save_kwargs)
+    return buf.getvalue()
+
+
+def _uploaded(
+    name: str,
+    content: bytes,
+    *,
+    content_type: str = "application/octet-stream",
+) -> SimpleUploadedFile:
+    return SimpleUploadedFile(name, content, content_type=content_type)
+
+
+# ---- Boundary dimension tests ---------------------------------------------
+
+
+@pytest.mark.parametrize("fmt,mime", [("JPEG", "image/jpeg"), ("PNG", "image/png"), ("WEBP", "image/webp")])
+def test_hero_accepts_min_boundary(fmt, mime):
+    data = _make_image_bytes(width=800, height=450, fmt=fmt)
+    out_mime, dims = validate_hero_image(_uploaded(f"a.{fmt.lower()}", data))
+    assert out_mime == mime
+    assert dims == (800, 450)
+
+
+def test_hero_rejects_below_min():
+    data = _make_image_bytes(width=799, height=449, fmt="PNG")
+    with pytest.raises(ValidationError):
+        validate_hero_image(_uploaded("a.png", data))
+
+
+def test_hero_accepts_max_boundary():
+    data = _make_image_bytes(width=6000, height=6000, fmt="PNG")
+    _, dims = validate_hero_image(_uploaded("a.png", data))
+    assert dims == (6000, 6000)
+
+
+def test_hero_rejects_above_max():
+    data = _make_image_bytes(width=6001, height=6001, fmt="PNG")
+    with pytest.raises(ValidationError):
+        validate_hero_image(_uploaded("a.png", data))
+
+
+@pytest.mark.parametrize("fmt", ["JPEG", "PNG", "WEBP"])
+def test_inline_accepts_min_boundary(fmt):
+    data = _make_image_bytes(width=200, height=200, fmt=fmt)
+    _, dims = validate_inline_image(_uploaded(f"b.{fmt.lower()}", data))
+    assert dims == (200, 200)
+
+
+def test_inline_rejects_below_min():
+    data = _make_image_bytes(width=199, height=199, fmt="PNG")
+    with pytest.raises(ValidationError):
+        validate_inline_image(_uploaded("b.png", data))
+
+
+def test_inline_accepts_max_boundary():
+    data = _make_image_bytes(width=6000, height=6000, fmt="PNG")
+    _, dims = validate_inline_image(_uploaded("b.png", data))
+    assert dims == (6000, 6000)
+
+
+def test_inline_rejects_above_max():
+    data = _make_image_bytes(width=6001, height=6001, fmt="PNG")
+    with pytest.raises(ValidationError):
+        validate_inline_image(_uploaded("b.png", data))
+
+
+# ---- MIME / format rejection ----------------------------------------------
+
+
+@pytest.mark.parametrize("fmt", ["GIF", "BMP", "TIFF"])
+def test_disallowed_pillow_formats_rejected(fmt):
+    img = Image.new("RGB", (1000, 1000), color=(0, 0, 0))
+    buf = io.BytesIO()
+    img.save(buf, format=fmt)
+    data = buf.getvalue()
+    with pytest.raises(ValidationError):
+        validate_hero_image(_uploaded(f"x.{fmt.lower()}", data))
+    with pytest.raises(ValidationError):
+        validate_inline_image(_uploaded(f"x.{fmt.lower()}", data))
+
+
+def test_svg_rejected():
+    svg = b'<svg xmlns="http://www.w3.org/2000/svg" width="1000" height="1000"></svg>'
+    with pytest.raises(ValidationError):
+        validate_hero_image(_uploaded("x.svg", svg, content_type="image/svg+xml"))
+    with pytest.raises(ValidationError):
+        validate_inline_image(_uploaded("x.svg", svg, content_type="image/svg+xml"))
+
+
+def test_forged_content_type_does_not_bypass_mime_check():
+    """A GIF body labeled image/png is still rejected — MIME comes from header."""
+    img = Image.new("RGB", (1000, 1000), color=(0, 0, 0))
+    buf = io.BytesIO()
+    img.save(buf, format="GIF")
+    with pytest.raises(ValidationError):
+        validate_hero_image(_uploaded("fake.png", buf.getvalue(), content_type="image/png"))
+
+
+def test_undecodable_payload_rejected():
+    junk = b"this is not an image at all" * 100
+    with pytest.raises(ValidationError):
+        validate_hero_image(_uploaded("trash.png", junk, content_type="image/png"))
+    with pytest.raises(ValidationError):
+        validate_inline_image(_uploaded("trash.png", junk, content_type="image/png"))
+
+
+# ---- Size cap --------------------------------------------------------------
+
+
+def test_oversize_file_rejected(monkeypatch):
+    # Build a small valid image, then claim a huge size via SimpleUploadedFile.
+    data = _make_image_bytes(width=1000, height=1000, fmt="PNG")
+    too_big = _uploaded("big.png", data)
+    # Force size to exceed the cap without allocating the bytes.
+    monkeypatch.setattr(too_big, "size", MAX_FILE_SIZE_BYTES + 1, raising=False)
+    with pytest.raises(ValidationError):
+        validate_hero_image(too_big)
+    monkeypatch.setattr(too_big, "size", MAX_FILE_SIZE_BYTES + 1, raising=False)
+    with pytest.raises(ValidationError):
+        validate_inline_image(too_big)
+
+
+# ---- Read-only / byte preservation ----------------------------------------
+
+
+def test_validation_does_not_mutate_upload_bytes():
+    """Stored bytes match upload bytes after validation runs (no re-encode)."""
+    # Build a JPEG with EXIF metadata (camera Make/Model + Orientation).
+    exif = Image.Exif()
+    exif[0x010F] = "TestMake"  # Make
+    exif[0x0110] = "TestModel"  # Model
+    exif[0x0112] = 6  # Orientation = rotated 90 CW
+    exif_blob = exif.tobytes()
+    data = _make_image_bytes(width=1000, height=600, fmt="JPEG", exif=exif_blob)
+    # Sanity-check the original carries EXIF before validation runs.
+    with Image.open(io.BytesIO(data)) as probe:
+        assert probe.getexif().get(0x0112) == 6
+    sha_before = hashlib.sha256(data).hexdigest()
+
+    upload = _uploaded("hero.jpg", data, content_type="image/jpeg")
+    validate_hero_image(upload)
+
+    upload.seek(0)
+    after = upload.read()
+    assert hashlib.sha256(after).hexdigest() == sha_before
+    assert after == data
+
+
+def test_no_provided_file_rejected():
+    with pytest.raises(ValidationError):
+        validate_hero_image(None)  # type: ignore[arg-type]


### PR DESCRIPTION
Add a shared server-side validator with hero and inline tiers. MIME is detected from file header bytes via Pillow rather than the request Content-Type, so forged headers cannot bypass the allowlist. Both tiers share an 8 MB cap and decode check; dimension bounds differ per tier.

Validation is read-only — stored bytes stay byte-for-byte identical to the upload. EXIF stripping is deferred to derivative re-encode time, not done on ingest.

## Summary

- [ ] Description of changes
- [ ] Related issue link

## Testing

- [ ] `uv run pytest`
- [ ] Other (describe)
