### PR TITLE
feat(geostories): expose hero image in API and admin

### DIFF
--- a/tosca_api/apps/geostories/admin.py
+++ b/tosca_api/apps/geostories/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+from django.utils.html import format_html
 
 from .forms import GeoStoryLayerFormSet
 from .models import GeoStory, GeoStoryLayer
@@ -9,15 +10,52 @@ class GeoStoryLayerInline(admin.TabularInline):
     formset = GeoStoryLayerFormSet
     extra = 1
     autocomplete_fields = ["layer"]
-    
+
     class Media:
         js = ("geostories/js/admin_geostory.js",)
 
 
 @admin.register(GeoStory)
 class GeoStoryAdmin(admin.ModelAdmin):
-    list_display = ("title", "status", "campaign", "author", "created_at")
+    list_display = ("title", "hero_image_thumbnail", "status", "campaign", "author", "created_at")
     list_filter = ("status", "created_at", "campaign")
     search_fields = ("title", "summary")
     autocomplete_fields = ["campaign", "author", "context"]
     inlines = [GeoStoryLayerInline]
+    readonly_fields = ("hero_image_preview",)
+    fieldsets = (
+        (None, {"fields": ("title", "summary", "status", "campaign", "author", "context")}),
+        (
+            "Hero image",
+            {
+                "fields": ("hero_image", "hero_image_alt", "hero_image_preview"),
+                "description": (
+                    "API responses expose hero_image_url as an absolute URL via "
+                    "request.build_absolute_uri; the model field stores the "
+                    "relative storage path."
+                ),
+            },
+        ),
+    )
+
+    @admin.display(description="Hero")
+    def hero_image_thumbnail(self, obj: GeoStory) -> str:
+        if not obj.hero_image:
+            return "—"
+        return format_html(
+            '<img src="{}" alt="{}" style="max-height:40px;max-width:80px;'
+            'object-fit:cover;border-radius:2px;" />',
+            obj.hero_image.url,
+            obj.hero_image_alt or "",
+        )
+
+    @admin.display(description="Hero image preview")
+    def hero_image_preview(self, obj: GeoStory) -> str:
+        if not obj or not obj.hero_image:
+            return "No image uploaded."
+        return format_html(
+            '<img src="{}" alt="{}" style="max-height:240px;max-width:480px;'
+            'object-fit:contain;" />',
+            obj.hero_image.url,
+            obj.hero_image_alt or "",
+        )

--- a/tosca_api/apps/geostories/serializers.py
+++ b/tosca_api/apps/geostories/serializers.py
@@ -5,6 +5,7 @@ from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db import transaction
 from rest_framework import serializers
 
+from tosca_api.apps.core.image_policy import validate_hero_image
 from tosca_api.apps.featurelinks.models import FeatureLink
 from tosca_api.apps.geocontext.models import GeoContext
 from tosca_api.apps.geodata_providers.api.serializers import (
@@ -13,6 +14,16 @@ from tosca_api.apps.geodata_providers.api.serializers import (
 )
 
 from .models import GeoStory, GeoStoryLayer
+
+
+def _absolute_hero_image_url(obj: GeoStory, request) -> str | None:
+    """Resolve hero image storage value into an absolute URL when possible."""
+    if not obj.hero_image:
+        return None
+    url = obj.hero_image.url
+    if request is not None:
+        return request.build_absolute_uri(url)
+    return url
 
 
 # =============================================================================
@@ -75,16 +86,23 @@ class GeoStoryListSerializer(serializers.ModelSerializer):
     Optimized for fast loading of story cards.
     """
 
+    hero_image_url = serializers.SerializerMethodField()
+
     class Meta:
         model = GeoStory
         fields = [
             "id",
             "title",
             "summary",
+            "hero_image_url",
+            "hero_image_alt",
             "campaign",
             "created_at",
         ]
         read_only_fields = fields
+
+    def get_hero_image_url(self, obj) -> str | None:
+        return _absolute_hero_image_url(obj, self.context.get("request"))
 
 
 class GeoStoryDetailSerializer(serializers.ModelSerializer):
@@ -96,6 +114,7 @@ class GeoStoryDetailSerializer(serializers.ModelSerializer):
     context = GeoContextSerializer(read_only=True)
     layers = serializers.SerializerMethodField()
     feature_links = serializers.SerializerMethodField()
+    hero_image_url = serializers.SerializerMethodField()
 
     class Meta:
         model = GeoStory
@@ -103,6 +122,8 @@ class GeoStoryDetailSerializer(serializers.ModelSerializer):
             "id",
             "title",
             "summary",
+            "hero_image_url",
+            "hero_image_alt",
             "status",
             "campaign",
             "context",
@@ -112,6 +133,9 @@ class GeoStoryDetailSerializer(serializers.ModelSerializer):
             "updated_at",
         ]
         read_only_fields = fields
+
+    def get_hero_image_url(self, obj) -> str | None:
+        return _absolute_hero_image_url(obj, self.context.get("request"))
 
     def get_layers(self, obj) -> list:
         """
@@ -167,6 +191,23 @@ class GeoStoryWriteSerializer(serializers.ModelSerializer):
 
     def validate(self, attrs):
         """Invoke model clean() for DB-level validation."""
+        # Route any incoming hero image upload through the hero tier of the
+        # shared image policy before model-level checks run. Validation is
+        # read-only — the underlying file bytes are not mutated.
+        hero_image = attrs.get("hero_image")
+        if hero_image is not None and hasattr(hero_image, "read"):
+            try:
+                validate_hero_image(hero_image)
+            except DjangoValidationError as exc:
+                detail = (
+                    exc.message_dict
+                    if hasattr(exc, "message_dict")
+                    else {"hero_image": exc.messages}
+                )
+                raise serializers.ValidationError(
+                    {"hero_image": detail.get("image", detail)}
+                ) from exc
+
         layer_attrs = {k: v for k, v in attrs.items() if k != "layers"}
         if self.instance:
             instance = copy.copy(self.instance)

--- a/tosca_api/apps/geostories/tests/test_api.py
+++ b/tosca_api/apps/geostories/tests/test_api.py
@@ -133,9 +133,11 @@ def test_geostory_list_payload_fields(api_client, user, geostory):
     assert "id" in story_data
     assert "title" in story_data
     assert "summary" in story_data
+    assert "hero_image_url" in story_data
+    assert "hero_image_alt" in story_data
     assert "campaign" in story_data
     assert "created_at" in story_data
-    
+
     # These should NOT be in list (detail only)
     assert "context" not in story_data
     assert "layers" not in story_data
@@ -441,6 +443,234 @@ def test_geostory_write_serializer_surfaces_hero_alt_error(api_client, user, geo
 
     assert response.status_code == 400
     assert "hero_image_alt" in response.data
+
+
+@pytest.mark.django_db
+def test_geostory_list_includes_hero_fields(api_client, user, geostory):
+    """List payload exposes hero_image_url + hero_image_alt."""
+    api_client.force_authenticate(user=user)
+    response = api_client.get("/api/v1/stories/")
+    assert response.status_code == 200
+
+    story_data = next(r for r in response.data["results"] if r["id"] == str(geostory.id))
+    assert "hero_image_url" in story_data
+    assert "hero_image_alt" in story_data
+    assert story_data["hero_image_url"] is None  # No hero set on the fixture
+
+
+@pytest.mark.django_db
+def test_geostory_detail_includes_hero_fields_no_image(api_client, user, geostory):
+    """Detail payload exposes hero fields even when no image is set."""
+    api_client.force_authenticate(user=user)
+    response = api_client.get(f"/api/v1/stories/{geostory.id}/")
+    assert response.status_code == 200
+    assert response.data["hero_image_url"] is None
+    assert response.data["hero_image_alt"] == ""
+
+
+@pytest.mark.django_db
+def test_geostory_create_with_hero_image_multipart(api_client, user, campaign):
+    """Multipart POST persists the hero image and returns absolute URL on detail."""
+    import io
+    from django.core.files.uploadedfile import SimpleUploadedFile
+    from PIL import Image
+
+    buf = io.BytesIO()
+    Image.new("RGB", (1200, 800), color=(10, 20, 30)).save(buf, format="JPEG")
+    upload = SimpleUploadedFile("hero.jpg", buf.getvalue(), content_type="image/jpeg")
+
+    api_client.force_authenticate(user=user)
+    response = api_client.post(
+        "/api/v1/stories/",
+        {
+            "title": "Hero Story",
+            "campaign": str(campaign.id),
+            "hero_image": upload,
+            "hero_image_alt": "A descriptive alt",
+        },
+        format="multipart",
+    )
+    assert response.status_code == 201, response.data
+
+    story = GeoStory.objects.get(id=response.data["id"])
+    assert bool(story.hero_image) is True
+    assert story.hero_image_alt == "A descriptive alt"
+
+    detail = api_client.get(f"/api/v1/stories/{story.id}/")
+    assert detail.status_code == 200
+    assert detail.data["hero_image_url"].startswith("http")
+    assert detail.data["hero_image_url"].endswith(story.hero_image.url)
+    assert detail.data["hero_image_alt"] == "A descriptive alt"
+
+
+@pytest.mark.django_db
+def test_geostory_create_rejects_undersized_hero(api_client, user, campaign):
+    """Hero policy rejects below the 800x450 minimum."""
+    import io
+    from django.core.files.uploadedfile import SimpleUploadedFile
+    from PIL import Image
+
+    buf = io.BytesIO()
+    Image.new("RGB", (400, 300)).save(buf, format="PNG")
+    upload = SimpleUploadedFile("small.png", buf.getvalue(), content_type="image/png")
+
+    api_client.force_authenticate(user=user)
+    response = api_client.post(
+        "/api/v1/stories/",
+        {
+            "title": "Bad Hero",
+            "campaign": str(campaign.id),
+            "hero_image": upload,
+            "hero_image_alt": "alt",
+        },
+        format="multipart",
+    )
+    assert response.status_code == 400
+    assert "hero_image" in response.data
+
+
+@pytest.mark.django_db
+def test_geostory_create_rejects_disallowed_mime(api_client, user, campaign):
+    """A GIF body with a forged content-type is rejected by header inspection."""
+    import io
+    from django.core.files.uploadedfile import SimpleUploadedFile
+    from PIL import Image
+
+    buf = io.BytesIO()
+    Image.new("RGB", (1200, 800)).save(buf, format="GIF")
+    upload = SimpleUploadedFile(
+        "fake.png", buf.getvalue(), content_type="image/png"
+    )
+
+    api_client.force_authenticate(user=user)
+    response = api_client.post(
+        "/api/v1/stories/",
+        {
+            "title": "Bad Mime",
+            "campaign": str(campaign.id),
+            "hero_image": upload,
+            "hero_image_alt": "alt",
+        },
+        format="multipart",
+    )
+    assert response.status_code == 400
+    assert "hero_image" in response.data
+
+
+@pytest.mark.django_db
+def test_geostory_create_with_hero_requires_alt(api_client, user, campaign):
+    """Uploading a valid hero image without alt returns a field-keyed 400."""
+    import io
+    from django.core.files.uploadedfile import SimpleUploadedFile
+    from PIL import Image
+
+    buf = io.BytesIO()
+    Image.new("RGB", (1200, 800)).save(buf, format="JPEG")
+    upload = SimpleUploadedFile("hero.jpg", buf.getvalue(), content_type="image/jpeg")
+
+    api_client.force_authenticate(user=user)
+    response = api_client.post(
+        "/api/v1/stories/",
+        {
+            "title": "Missing Alt",
+            "campaign": str(campaign.id),
+            "hero_image": upload,
+        },
+        format="multipart",
+    )
+    assert response.status_code == 400
+    assert "hero_image_alt" in response.data
+
+
+@pytest.mark.django_db
+def test_geostory_patch_replaces_hero_image(api_client, user, campaign):
+    """PATCH with a fresh upload swaps the stored file and updates alt."""
+    import io
+    from django.core.files.uploadedfile import SimpleUploadedFile
+    from PIL import Image
+
+    api_client.force_authenticate(user=user)
+
+    buf = io.BytesIO()
+    Image.new("RGB", (1200, 800), color=(1, 2, 3)).save(buf, format="JPEG")
+    initial = SimpleUploadedFile("a.jpg", buf.getvalue(), content_type="image/jpeg")
+    create_response = api_client.post(
+        "/api/v1/stories/",
+        {
+            "title": "Replaceable",
+            "campaign": str(campaign.id),
+            "hero_image": initial,
+            "hero_image_alt": "first",
+        },
+        format="multipart",
+    )
+    assert create_response.status_code == 201
+    story_id = create_response.data["id"]
+    original_path = GeoStory.objects.get(id=story_id).hero_image.name
+
+    buf2 = io.BytesIO()
+    Image.new("RGB", (1600, 900), color=(9, 8, 7)).save(buf2, format="PNG")
+    replacement = SimpleUploadedFile(
+        "b.png", buf2.getvalue(), content_type="image/png"
+    )
+    patch_response = api_client.patch(
+        f"/api/v1/stories/{story_id}/",
+        {"hero_image": replacement, "hero_image_alt": "second"},
+        format="multipart",
+    )
+    assert patch_response.status_code == 200, patch_response.data
+
+    refreshed = GeoStory.objects.get(id=story_id)
+    assert refreshed.hero_image.name != original_path
+    assert refreshed.hero_image_alt == "second"
+
+
+@pytest.mark.django_db
+def test_geostory_patch_clears_hero_image(api_client, user, campaign):
+    """Setting hero_image to null lifts the alt requirement."""
+    import io
+    from django.core.files.uploadedfile import SimpleUploadedFile
+    from PIL import Image
+
+    api_client.force_authenticate(user=user)
+    buf = io.BytesIO()
+    Image.new("RGB", (1200, 800)).save(buf, format="JPEG")
+    upload = SimpleUploadedFile("hero.jpg", buf.getvalue(), content_type="image/jpeg")
+    create_response = api_client.post(
+        "/api/v1/stories/",
+        {
+            "title": "Clearable",
+            "campaign": str(campaign.id),
+            "hero_image": upload,
+            "hero_image_alt": "alt",
+        },
+        format="multipart",
+    )
+    assert create_response.status_code == 201
+    story_id = create_response.data["id"]
+
+    response = api_client.patch(
+        f"/api/v1/stories/{story_id}/",
+        {"hero_image": "", "hero_image_alt": ""},
+        format="multipart",
+    )
+    assert response.status_code == 200, response.data
+
+    refreshed = GeoStory.objects.get(id=story_id)
+    assert not refreshed.hero_image
+    assert refreshed.hero_image_alt == ""
+
+
+@pytest.mark.django_db
+def test_geostory_admin_thumbnail_handles_missing_image(geostory):
+    """Admin thumbnail/preview render harmlessly when no image is set."""
+    from django.contrib.admin.sites import AdminSite
+
+    from tosca_api.apps.geostories.admin import GeoStoryAdmin
+
+    admin_instance = GeoStoryAdmin(GeoStory, AdminSite())
+    assert admin_instance.hero_image_thumbnail(geostory) == "—"
+    assert "No image uploaded." in admin_instance.hero_image_preview(geostory)
 
 
 @pytest.mark.django_db

--- a/tosca_api/apps/geostories/views.py
+++ b/tosca_api/apps/geostories/views.py
@@ -1,5 +1,6 @@
 from rest_framework import permissions, viewsets
 from rest_framework.pagination import CursorPagination
+from rest_framework.parsers import FormParser, JSONParser, MultiPartParser
 
 from .models import GeoStory
 from .serializers import (
@@ -30,6 +31,7 @@ class GeoStoryViewSet(viewsets.ModelViewSet):
     queryset = GeoStory.objects.all()
     permission_classes = [permissions.IsAuthenticated]
     pagination_class = GeoStoryCursorPagination
+    parser_classes = [MultiPartParser, FormParser, JSONParser]
 
     def get_serializer_class(self):
         """


### PR DESCRIPTION
Wire hero_image and hero_image_alt through the GeoStory list, detail and write serializers, including absolute hero_image_url URLs in API responses. Multipart uploads route through the hero tier of the shared image policy, and the admin change form gains a dedicated hero fieldset with thumbnail and preview helpers.feat(geostories): expose hero image in API and admin

Wire hero_image and hero_image_alt through the GeoStory list, detail and write serializers, including absolute hero_image_url URLs in API responses. Multipart uploads route through the hero tier of the shared image policy, and the admin change form gains a dedicated hero fieldset with thumbnail and preview helpers.

## Summary

- [ ] Description of changes
- [ ] Related issue link

## Testing

- [ ] `uv run pytest`
- [ ] Other (describe)
