### PR TITLE
test(geocontext): complete EditorJS image upload coverage

### DIFF
--- a/tosca_api/apps/geocontext/tests/test_admin.py
+++ b/tosca_api/apps/geocontext/tests/test_admin.py
@@ -3,10 +3,15 @@ Tests for GeoContext Django admin Editor.js authoring.
 """
 
 import json
+import io
 
 import pytest
 from django.contrib.auth import get_user_model
+from django.core.files.base import ContentFile
+from django.core.files.storage import default_storage
 from django.urls import reverse
+from django.test import override_settings
+from PIL import Image
 
 from tosca_api.apps.geocontext.admin import GeoContextAdmin, _extract_plain_text
 from tosca_api.apps.geocontext.forms import GeoContextAdminForm
@@ -38,6 +43,7 @@ def test_widget_media_includes_vendored_assets():
     assert "geocontext/editorjs/vendor/quote.umd.js" in js
     assert "geocontext/editorjs/vendor/delimiter.umd.js" in js
     assert "geocontext/editorjs/vendor/code.umd.js" in js
+    assert "geocontext/editorjs/vendor/image.umd.js" in js
     assert "geocontext/editorjs/init.js" in js
     assert "geocontext/editorjs/editor.css" in media._css["all"]
 
@@ -53,10 +59,21 @@ def test_vendor_license_files_present():
     from pathlib import Path
 
     base = Path(__file__).resolve().parents[1] / "static" / "geocontext" / "editorjs" / "vendor"
-    for name in ("editorjs", "header", "list", "quote", "delimiter", "code"):
+    for name in ("editorjs", "header", "list", "quote", "delimiter", "code", "image"):
         path = base / f"LICENSE.{name}"
         assert path.exists(), f"missing {path}"
         assert path.stat().st_size > 0
+
+
+def test_editorjs_admin_assets_do_not_reference_cdn():
+    from pathlib import Path
+
+    static_root = Path(__file__).resolve().parents[1] / "static" / "geocontext" / "editorjs"
+    for path in static_root.rglob("*"):
+        if path.is_file():
+            text = path.read_text(errors="ignore")
+            for needle in ("cdn.jsdelivr.net", "unpkg.com", "cdnjs."):
+                assert needle not in text
 
 
 @pytest.mark.django_db
@@ -101,6 +118,57 @@ def test_admin_form_parses_json_and_persists(admin_client, superuser):
     assert ctx.content == {
         "blocks": [{"type": "paragraph", "data": {"text": "Saved"}}]
     }
+
+
+@pytest.mark.django_db
+def test_admin_form_persists_image_block_with_caption_alt_fallback(
+    admin_client, superuser, tmp_path
+):
+    image_buf = io.BytesIO()
+    Image.new("RGB", (240, 240), color=(20, 80, 140)).save(image_buf, format="PNG")
+
+    with override_settings(MEDIA_ROOT=tmp_path, MEDIA_URL="/media/"):
+        storage_path = default_storage.save(
+            "geocontext/editorjs/context-id/admin.png",
+            ContentFile(image_buf.getvalue()),
+        )
+        url = reverse("admin:geocontext_geocontext_add")
+        payload = {
+            "content": json.dumps(
+                {
+                    "blocks": [
+                        {
+                            "type": "image",
+                            "data": {
+                                "file": {
+                                    "url": f"/media/{storage_path}",
+                                    "mime": "image/jpeg",
+                                    "width": 1,
+                                    "height": 1,
+                                },
+                                "caption": "<strong>Admin caption</strong>",
+                                "withBorder": True,
+                                "withBackground": False,
+                                "stretched": True,
+                            },
+                        }
+                    ]
+                }
+            ),
+            "created_by": str(superuser.id),
+            "_save": "Save",
+        }
+        response = admin_client.post(url, payload, follow=True)
+
+    assert response.status_code == 200
+    ctx = GeoContext.objects.get(created_by=superuser)
+    block = ctx.content["blocks"][0]
+    assert block["type"] == "image"
+    assert block["data"]["alt"] == "Admin caption"
+    assert block["data"]["caption"] == "<strong>Admin caption</strong>"
+    assert block["data"]["file"]["mime"] == "image/png"
+    assert block["data"]["file"]["width"] == 240
+    assert block["data"]["file"]["height"] == 240
 
 
 @pytest.mark.django_db

--- a/tosca_api/apps/geocontext/tests/test_editorjs_uploads.py
+++ b/tosca_api/apps/geocontext/tests/test_editorjs_uploads.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import io
+from types import SimpleNamespace
+
+import pytest
+from django.core.files.storage import default_storage
+from django.test import override_settings
+from PIL import Image
+from rest_framework.test import APIClient
+
+from tosca_api.apps.geocontext import views
+
+
+def _image_bytes(*, width: int = 240, height: int = 240, fmt: str = "PNG") -> bytes:
+    buf = io.BytesIO()
+    Image.new("RGB", (width, height), color=(80, 120, 160)).save(buf, format=fmt)
+    return buf.getvalue()
+
+
+def _upload_file(name: str, data: bytes):
+    from django.core.files.uploadedfile import SimpleUploadedFile
+
+    return SimpleUploadedFile(name, data, content_type="application/octet-stream")
+
+
+@pytest.fixture
+def api_client():
+    client = APIClient()
+    client.force_authenticate(
+        user=SimpleNamespace(is_authenticated=True, pk=1, is_active=True)
+    )
+    return client
+
+
+def test_upload_by_file_stores_original_bytes_and_returns_editorjs_contract(
+    api_client, tmp_path
+):
+    data = _image_bytes()
+    with override_settings(MEDIA_ROOT=tmp_path, MEDIA_URL="/media/"):
+        response = api_client.post(
+            "/api/v1/geocontext/editorjs/upload-by-file/",
+            {"image": _upload_file("inline.png", data)},
+            format="multipart",
+        )
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["success"] == 1
+        file_info = payload["file"]
+        assert file_info["url"].startswith("http://testserver/media/")
+        assert file_info["mime"] == "image/png"
+        assert file_info["width"] == 240
+        assert file_info["height"] == 240
+
+        storage_path = file_info["url"].split("/media/", 1)[1]
+        assert storage_path.startswith("geocontext/editorjs/")
+        with default_storage.open(storage_path, "rb") as stored:
+            assert stored.read() == data
+
+
+def test_upload_by_file_rejects_invalid_image(api_client, tmp_path):
+    with override_settings(MEDIA_ROOT=tmp_path, MEDIA_URL="/media/"):
+        response = api_client.post(
+            "/api/v1/geocontext/editorjs/upload-by-file/",
+            {"image": _upload_file("tiny.png", _image_bytes(width=100, height=100))},
+            format="multipart",
+        )
+
+    assert response.status_code == 400
+    assert response.json()["success"] == 0
+    assert "minimum" in response.json()["error"]
+
+
+@pytest.mark.parametrize(
+    "endpoint,payload",
+    [
+        (
+            "/api/v1/geocontext/editorjs/upload-by-file/",
+            lambda: {"image": _upload_file("inline.png", _image_bytes())},
+        ),
+        (
+            "/api/v1/geocontext/editorjs/upload-by-url/",
+            lambda: {"url": "https://remote.test/inline.png"},
+        ),
+    ],
+)
+def test_upload_endpoints_require_authentication(client, tmp_path, endpoint, payload):
+    with override_settings(MEDIA_ROOT=tmp_path, MEDIA_URL="/media/"):
+        response = client.post(endpoint, payload())
+
+    assert response.status_code in {401, 403}
+
+
+class _FakeResponse:
+    def __init__(
+        self,
+        body: bytes,
+        *,
+        url: str = "https://remote.test/image.png",
+        status_code: int = 200,
+        history: list | None = None,
+    ):
+        self.body = body
+        self.url = url
+        self.status_code = status_code
+        self.history = history or []
+
+    def iter_content(self, chunk_size: int):
+        for start in range(0, len(self.body), chunk_size):
+            yield self.body[start : start + chunk_size]
+
+
+def test_upload_by_url_downloads_rehosts_and_preserves_bytes(
+    api_client, monkeypatch, tmp_path
+):
+    data = _image_bytes(fmt="WEBP")
+
+    def fake_get(url, **kwargs):
+        assert kwargs["stream"] is True
+        assert kwargs["allow_redirects"] is True
+        return _FakeResponse(data, url=url)
+
+    monkeypatch.setattr(views.requests, "get", fake_get)
+
+    with override_settings(MEDIA_ROOT=tmp_path, MEDIA_URL="/media/"):
+        response = api_client.post(
+            "/api/v1/geocontext/editorjs/upload-by-url/",
+            {"url": "https://remote.test/path/inline.webp"},
+            format="json",
+        )
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["success"] == 1
+        assert payload["file"]["mime"] == "image/webp"
+
+        storage_path = payload["file"]["url"].split("/media/", 1)[1]
+        assert storage_path.startswith("geocontext/editorjs/")
+        with default_storage.open(storage_path, "rb") as stored:
+            assert stored.read() == data
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        ("ftp://remote.test/image.png", "not allowed"),
+        ("http://testserver/media/geocontext/editorjs/a.png", "picker"),
+    ],
+)
+def test_upload_by_url_rejects_disallowed_sources(api_client, tmp_path, url, expected):
+    with override_settings(MEDIA_ROOT=tmp_path, MEDIA_URL="/media/"):
+        response = api_client.post(
+            "/api/v1/geocontext/editorjs/upload-by-url/",
+            {"url": url},
+            format="json",
+        )
+
+    assert response.status_code == 400
+    assert response.json()["success"] == 0
+    assert expected in response.json()["error"]
+
+
+def test_upload_by_url_rejects_oversized_download(api_client, monkeypatch, tmp_path):
+    data = b"x" * (views.MAX_FILE_SIZE_BYTES + 1)
+
+    monkeypatch.setattr(
+        views.requests,
+        "get",
+        lambda *args, **kwargs: _FakeResponse(data),
+    )
+
+    with override_settings(MEDIA_ROOT=tmp_path, MEDIA_URL="/media/"):
+        response = api_client.post(
+            "/api/v1/geocontext/editorjs/upload-by-url/",
+            {"url": "https://remote.test/large.png"},
+            format="json",
+        )
+
+    assert response.status_code == 400
+    assert response.json()["success"] == 0
+    assert "exceeds" in response.json()["error"]
+
+
+def test_media_library_lists_previous_editorjs_uploads(api_client, tmp_path):
+    data = _image_bytes()
+    with override_settings(MEDIA_ROOT=tmp_path, MEDIA_URL="/media/"):
+        default_storage.save(
+            "geocontext/editorjs/context-id/library.png",
+            _upload_file("library.png", data),
+        )
+
+        response = api_client.get("/api/v1/geocontext/editorjs/media/")
+
+    assert response.status_code == 200
+    results = response.json()["results"]
+    assert len(results) == 1
+    assert results[0]["name"] == "library.png"
+    assert results[0]["mime"] == "image/png"
+    assert results[0]["url"].endswith("/media/geocontext/editorjs/context-id/library.png")
+
+
+def test_openapi_schema_documents_editorjs_image_endpoints(client):
+    response = client.get("/api/v1/schema/")
+    assert response.status_code == 200
+
+    schema = response.content.decode()
+    assert "/api/v1/geocontext/editorjs/upload-by-file/" in schema
+    assert "/api/v1/geocontext/editorjs/upload-by-url/" in schema
+    assert "/api/v1/geocontext/editorjs/media/" in schema
+    assert "EditorJSImageUploadSuccess" in schema

--- a/tosca_api/apps/geocontext/views.py
+++ b/tosca_api/apps/geocontext/views.py
@@ -26,14 +26,16 @@ from urllib.parse import urlparse
 import requests
 from django.conf import settings
 from django.core.exceptions import ValidationError as DjangoValidationError
-from django.core.files.base import ContentFile
 from django.core.files.storage import default_storage
 from django.core.files.uploadedfile import SimpleUploadedFile
+from drf_spectacular.utils import OpenApiExample, OpenApiResponse, extend_schema, inline_serializer
 from PIL import Image
+from rest_framework import serializers
 from rest_framework import status
 from rest_framework.parsers import JSONParser, MultiPartParser
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
+from rest_framework.throttling import UserRateThrottle
 from rest_framework.views import APIView
 
 from tosca_api.apps.core.image_policy import (
@@ -46,6 +48,54 @@ _UPLOAD_SUBDIR = "geocontext/editorjs"
 _DOWNLOAD_TIMEOUT_SECONDS = 5
 _MAX_REDIRECTS = 1
 _ALLOWED_REMOTE_SCHEMES = {"http", "https"}
+
+_UPLOAD_SUCCESS_SERIALIZER = inline_serializer(
+    name="EditorJSImageUploadSuccess",
+    fields={
+        "success": serializers.IntegerField(),
+        "file": inline_serializer(
+            name="EditorJSImageFile",
+            fields={
+                "url": serializers.URLField(),
+                "mime": serializers.CharField(),
+                "width": serializers.IntegerField(),
+                "height": serializers.IntegerField(),
+            },
+        ),
+    },
+)
+_UPLOAD_FAILURE_SERIALIZER = inline_serializer(
+    name="EditorJSImageUploadFailure",
+    fields={
+        "success": serializers.IntegerField(),
+        "error": serializers.CharField(),
+    },
+)
+_UPLOAD_BY_FILE_REQUEST_SERIALIZER = inline_serializer(
+    name="EditorJSImageUploadByFileRequest",
+    fields={"image": serializers.ImageField()},
+)
+_UPLOAD_BY_URL_REQUEST_SERIALIZER = inline_serializer(
+    name="EditorJSImageUploadByUrlRequest",
+    fields={"url": serializers.URLField()},
+)
+_MEDIA_LIBRARY_SERIALIZER = inline_serializer(
+    name="EditorJSImageMediaLibrary",
+    fields={
+        "results": serializers.ListField(
+            child=inline_serializer(
+                name="EditorJSImageMediaItem",
+                fields={
+                    "url": serializers.URLField(),
+                    "mime": serializers.CharField(),
+                    "width": serializers.IntegerField(),
+                    "height": serializers.IntegerField(),
+                    "name": serializers.CharField(),
+                },
+            )
+        )
+    },
+)
 
 
 def _media_url_prefix() -> str:
@@ -118,7 +168,34 @@ class EditorJSImageUploadByFileView(APIView):
 
     permission_classes = [IsAuthenticated]
     parser_classes = [MultiPartParser]
+    throttle_classes = [UserRateThrottle]
 
+    @extend_schema(
+        tags=["geocontext"],
+        operation_id="geocontext_editorjs_upload_by_file",
+        summary="Upload an EditorJS image file",
+        request=_UPLOAD_BY_FILE_REQUEST_SERIALIZER,
+        responses={
+            200: OpenApiResponse(
+                response=_UPLOAD_SUCCESS_SERIALIZER,
+                examples=[
+                    OpenApiExample(
+                        "Uploaded",
+                        value={
+                            "success": 1,
+                            "file": {
+                                "url": "https://example.test/media/geocontext/editorjs/context/image.png",
+                                "mime": "image/png",
+                                "width": 800,
+                                "height": 600,
+                            },
+                        },
+                    )
+                ],
+            ),
+            400: OpenApiResponse(response=_UPLOAD_FAILURE_SERIALIZER),
+        },
+    )
     def post(self, request, *args, **kwargs):
         # ``@editorjs/image`` defaults the multipart field name to ``image``;
         # accept legacy ``file`` for resilience.
@@ -135,7 +212,18 @@ class EditorJSImageUploadByUrlView(APIView):
 
     permission_classes = [IsAuthenticated]
     parser_classes = [JSONParser]
+    throttle_classes = [UserRateThrottle]
 
+    @extend_schema(
+        tags=["geocontext"],
+        operation_id="geocontext_editorjs_upload_by_url",
+        summary="Upload an EditorJS image from a remote URL",
+        request=_UPLOAD_BY_URL_REQUEST_SERIALIZER,
+        responses={
+            200: OpenApiResponse(response=_UPLOAD_SUCCESS_SERIALIZER),
+            400: OpenApiResponse(response=_UPLOAD_FAILURE_SERIALIZER),
+        },
+    )
     def post(self, request, *args, **kwargs):
         url = (request.data or {}).get("url")
         if not isinstance(url, str) or not url.strip():
@@ -171,7 +259,14 @@ class EditorJSImageLibraryView(APIView):
     """List previously uploaded EditorJS images for the admin picker."""
 
     permission_classes = [IsAuthenticated]
+    throttle_classes = [UserRateThrottle]
 
+    @extend_schema(
+        tags=["geocontext"],
+        operation_id="geocontext_editorjs_media_library",
+        summary="List uploaded EditorJS images",
+        responses={200: _MEDIA_LIBRARY_SERIALIZER},
+    )
     def get(self, request, *args, **kwargs):
         items = list(_list_existing_uploads(request, limit=100))
         return Response({"results": items})


### PR DESCRIPTION
Add schema annotations and throttle hooks for image upload and media endpoints. Cover upload contracts, byte preservation, media listing, admin asset wiring, no-CDN checks, and image block admin persistence; record the vendored EditorJS image/list pins.

## Summary

- [ ] Description of changes
- [ ] Related issue link

## Testing

- [ ] `uv run pytest`
- [ ] Other (describe)
