### PR TITLE
feat(media): add image derivatives and schema docs

### DIFF
--- a/tosca_api/apps/core/image_derivatives.py
+++ b/tosca_api/apps/core/image_derivatives.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import hashlib
+import io
+from dataclasses import dataclass
+from urllib.parse import urlencode
+
+from django.core.files.base import ContentFile
+from django.core.files.storage import default_storage
+from PIL import Image, ImageOps
+
+ALLOWED_DERIVATIVE_FORMATS = {"webp", "avif"}
+ALLOWED_DERIVATIVE_WIDTHS = {480, 960, 1440, 1920}
+
+
+class DerivativeError(ValueError):
+    """Base class for derivative request errors."""
+
+
+class UnsupportedDerivativeFormat(DerivativeError):
+    """Raised when a requested derivative format is not allowed."""
+
+
+class UnsupportedDerivativeWidth(DerivativeError):
+    """Raised when a requested derivative width is not allowed."""
+
+
+class UnsupportedDerivativeSource(DerivativeError):
+    """Raised when a requested source path is outside storage-path shape."""
+
+
+class DerivativeSourceMissing(FileNotFoundError):
+    """Raised when the source image is not present in storage."""
+
+
+class DerivativeFormatUnavailable(RuntimeError):
+    """Raised when Pillow cannot encode an otherwise allowed format."""
+
+
+@dataclass(frozen=True)
+class DerivativeResult:
+    storage_path: str
+    content_type: str
+
+
+def derivative_url(original_path: str, *, fmt: str, width: int | None = None) -> str:
+    params = {"src": original_path, "fmt": fmt}
+    if width is not None:
+        params["w"] = str(width)
+    return f"/api/v1/media/derivative/?{urlencode(params)}"
+
+
+def image_url_with_derivatives(original_path: str, request) -> dict:
+    original_url = default_storage.url(original_path)
+    if request is not None:
+        original_url = request.build_absolute_uri(original_url)
+
+    variants: dict[str, dict[str, str | dict[int, str]]] = {"original": original_url}
+    for fmt in sorted(ALLOWED_DERIVATIVE_FORMATS):
+        variants[fmt] = {
+            "original": _absolute_derivative_url(
+                request, derivative_url(original_path, fmt=fmt)
+            ),
+            "widths": {
+                width: _absolute_derivative_url(
+                    request, derivative_url(original_path, fmt=fmt, width=width)
+                )
+                for width in sorted(ALLOWED_DERIVATIVE_WIDTHS)
+            },
+        }
+    return variants
+
+
+def generate_derivative(
+    original_path: str, *, fmt: str, width: int | None = None
+) -> DerivativeResult:
+    normalized_path = _normalize_source_path(original_path)
+    normalized_format = _normalize_format(fmt)
+    normalized_width = _normalize_width(width)
+    cache_path = _cache_path(normalized_path, fmt=normalized_format, width=normalized_width)
+    content_type = f"image/{normalized_format}"
+
+    if default_storage.exists(cache_path):
+        return DerivativeResult(storage_path=cache_path, content_type=content_type)
+
+    if not default_storage.exists(normalized_path):
+        raise DerivativeSourceMissing(normalized_path)
+
+    try:
+        with default_storage.open(normalized_path, "rb") as source:
+            with Image.open(source) as image:
+                derivative = ImageOps.exif_transpose(image)
+                derivative.load()
+    except FileNotFoundError as exc:
+        raise DerivativeSourceMissing(normalized_path) from exc
+
+    if normalized_width is not None and derivative.width > normalized_width:
+        height = max(1, round(derivative.height * (normalized_width / derivative.width)))
+        derivative = derivative.resize((normalized_width, height), Image.Resampling.LANCZOS)
+
+    encoded = _encode_derivative(derivative, normalized_format)
+    if default_storage.exists(cache_path):
+        return DerivativeResult(storage_path=cache_path, content_type=content_type)
+
+    saved_path = default_storage.save(cache_path, ContentFile(encoded))
+    return DerivativeResult(storage_path=saved_path, content_type=content_type)
+
+
+def _normalize_format(fmt: str) -> str:
+    normalized = (fmt or "").lower()
+    if normalized not in ALLOWED_DERIVATIVE_FORMATS:
+        raise UnsupportedDerivativeFormat(f"Unsupported derivative format '{fmt}'.")
+    return normalized
+
+
+def _normalize_source_path(original_path: str) -> str:
+    if not original_path or original_path.startswith("/"):
+        raise UnsupportedDerivativeSource("Source must be a relative storage path.")
+    parts = original_path.split("/")
+    if any(part in {"", ".", ".."} for part in parts):
+        raise UnsupportedDerivativeSource("Source must be a normalized storage path.")
+    return original_path
+
+
+def _normalize_width(width: int | None) -> int | None:
+    if width is None:
+        return None
+    try:
+        normalized = int(width)
+    except (TypeError, ValueError) as exc:
+        raise UnsupportedDerivativeWidth("Derivative width must be an integer.") from exc
+    if normalized not in ALLOWED_DERIVATIVE_WIDTHS:
+        raise UnsupportedDerivativeWidth(f"Unsupported derivative width '{width}'.")
+    return normalized
+
+
+def _cache_path(original_path: str, *, fmt: str, width: int | None) -> str:
+    digest = hashlib.sha1(original_path.encode("utf-8")).hexdigest()
+    width_key = str(width) if width is not None else "original"
+    return f"derivatives/{digest}/{width_key}.{fmt}"
+
+
+def _encode_derivative(image: Image.Image, fmt: str) -> bytes:
+    save_format = fmt.upper()
+    output = io.BytesIO()
+    if image.mode not in {"RGB", "RGBA"}:
+        image = image.convert("RGBA" if "A" in image.getbands() else "RGB")
+    try:
+        image.save(output, format=save_format)
+    except (KeyError, OSError, ValueError) as exc:
+        if fmt == "avif":
+            raise DerivativeFormatUnavailable("AVIF encoding is not available.") from exc
+        raise
+    return output.getvalue()
+
+
+def _absolute_derivative_url(request, url: str) -> str:
+    if request is None:
+        return url
+    return request.build_absolute_uri(url)

--- a/tosca_api/apps/core/tests/test_docs.py
+++ b/tosca_api/apps/core/tests/test_docs.py
@@ -13,3 +13,29 @@ def test_swagger_docs_accessible():
     # /api/docs/
     response = client.get(reverse("swagger-ui"))
     assert response.status_code == 200
+
+
+def test_phase_image_schema_surfaces_are_documented(client):
+    response = client.get(reverse("schema"))
+    assert response.status_code == 200
+
+    schema = response.content.decode()
+    assert "hero_image_url" in schema
+    assert "hero_image_alt" in schema
+    assert "/api/v1/geocontext/editorjs/upload-by-file/" in schema
+    assert "/api/v1/geocontext/editorjs/upload-by-url/" in schema
+    assert "/api/v1/media/derivative/" in schema
+
+
+def test_phase_image_decisions_are_recorded():
+    decisions = open("docs/features-to-add_local/decisions.md", encoding="utf-8").read()
+    for header in (
+        "### [9.1]",
+        "### [9.2]",
+        "### [9.2b]",
+        "### [9.4]",
+        "### [9.5]",
+        "### [9.6]",
+        "### [9.7]",
+    ):
+        assert header in decisions

--- a/tosca_api/apps/core/tests/test_image_derivatives.py
+++ b/tosca_api/apps/core/tests/test_image_derivatives.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import hashlib
+import io
+
+from django.core.files.base import ContentFile
+from django.core.files.storage import default_storage
+from django.test import override_settings
+from PIL import Image
+
+from tosca_api.apps.core.image_derivatives import generate_derivative
+
+
+def _image_bytes(*, width: int = 320, height: int = 240, fmt: str = "PNG") -> bytes:
+    buf = io.BytesIO()
+    Image.new("RGB", (width, height), color=(60, 90, 120)).save(buf, format=fmt)
+    return buf.getvalue()
+
+
+def _oriented_jpeg_bytes() -> bytes:
+    buf = io.BytesIO()
+    image = Image.new("RGB", (80, 40), color=(60, 90, 120))
+    exif = Image.Exif()
+    exif[274] = 6
+    image.save(buf, format="JPEG", exif=exif)
+    return buf.getvalue()
+
+
+def test_webp_derivative_is_generated_and_cached(tmp_path):
+    original = _image_bytes()
+    with override_settings(MEDIA_ROOT=tmp_path, MEDIA_URL="/media/"):
+        default_storage.save("uploads/original.png", ContentFile(original))
+
+        first = generate_derivative("uploads/original.png", fmt="webp", width=480)
+        second = generate_derivative("uploads/original.png", fmt="webp", width=480)
+
+        assert first == second
+        assert first.storage_path.startswith("derivatives/")
+        with default_storage.open(first.storage_path, "rb") as stored:
+            with Image.open(stored) as image:
+                assert image.format == "WEBP"
+                assert not image.getexif()
+
+
+def test_derivative_generation_does_not_mutate_original(tmp_path):
+    original = _image_bytes()
+    original_sha = hashlib.sha256(original).hexdigest()
+
+    with override_settings(MEDIA_ROOT=tmp_path, MEDIA_URL="/media/"):
+        default_storage.save("uploads/original.png", ContentFile(original))
+        generate_derivative("uploads/original.png", fmt="webp")
+
+        with default_storage.open("uploads/original.png", "rb") as stored:
+            assert hashlib.sha256(stored.read()).hexdigest() == original_sha
+
+
+def test_derivative_view_documents_and_serves_webp(client, tmp_path):
+    with override_settings(MEDIA_ROOT=tmp_path, MEDIA_URL="/media/"):
+        default_storage.save("uploads/original.png", ContentFile(_image_bytes()))
+        response = client.get(
+            "/api/v1/media/derivative/",
+            {"src": "uploads/original.png", "fmt": "webp", "w": "480"},
+        )
+
+    assert response.status_code == 200
+    assert response["Content-Type"] == "image/webp"
+    assert "immutable" in response["Cache-Control"]
+
+
+def test_derivative_view_rejects_unknown_width(client, tmp_path):
+    with override_settings(MEDIA_ROOT=tmp_path, MEDIA_URL="/media/"):
+        default_storage.save("uploads/original.png", ContentFile(_image_bytes()))
+        response = client.get(
+            "/api/v1/media/derivative/",
+            {"src": "uploads/original.png", "fmt": "webp", "w": "999"},
+        )
+
+    assert response.status_code == 400
+
+
+def test_derivative_view_rejects_unknown_format(client, tmp_path):
+    with override_settings(MEDIA_ROOT=tmp_path, MEDIA_URL="/media/"):
+        default_storage.save("uploads/original.png", ContentFile(_image_bytes()))
+        response = client.get(
+            "/api/v1/media/derivative/",
+            {"src": "uploads/original.png", "fmt": "jp2"},
+        )
+
+    assert response.status_code == 400
+
+
+def test_derivative_view_rejects_non_normalized_source(client, tmp_path):
+    with override_settings(MEDIA_ROOT=tmp_path, MEDIA_URL="/media/"):
+        response = client.get(
+            "/api/v1/media/derivative/",
+            {"src": "../secret.png", "fmt": "webp"},
+        )
+
+    assert response.status_code == 400
+
+
+def test_derivative_view_returns_404_for_missing_original(client, tmp_path):
+    with override_settings(MEDIA_ROOT=tmp_path, MEDIA_URL="/media/"):
+        response = client.get(
+            "/api/v1/media/derivative/",
+            {"src": "uploads/missing.png", "fmt": "webp"},
+        )
+
+    assert response.status_code == 404
+
+
+def test_avif_returns_501_when_encoder_is_unavailable(client, monkeypatch, tmp_path):
+    original_save = Image.Image.save
+
+    def fake_save(self, fp, format=None, **params):
+        if format == "AVIF":
+            raise KeyError("AVIF")
+        return original_save(self, fp, format=format, **params)
+
+    monkeypatch.setattr(Image.Image, "save", fake_save)
+    with override_settings(MEDIA_ROOT=tmp_path, MEDIA_URL="/media/"):
+        default_storage.save("uploads/original.png", ContentFile(_image_bytes()))
+        response = client.get(
+            "/api/v1/media/derivative/",
+            {"src": "uploads/original.png", "fmt": "avif"},
+        )
+
+    assert response.status_code == 501
+
+
+def test_exif_orientation_is_baked_into_derivative(tmp_path):
+    with override_settings(MEDIA_ROOT=tmp_path, MEDIA_URL="/media/"):
+        default_storage.save("uploads/oriented.jpg", ContentFile(_oriented_jpeg_bytes()))
+
+        result = generate_derivative("uploads/oriented.jpg", fmt="webp")
+
+        with default_storage.open(result.storage_path, "rb") as stored:
+            with Image.open(stored) as image:
+                assert image.size == (40, 80)
+                assert not image.getexif()

--- a/tosca_api/apps/core/urls.py
+++ b/tosca_api/apps/core/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from .views import ImageDerivativeView
+
+urlpatterns = [
+    path("media/derivative/", ImageDerivativeView.as_view(), name="media-image-derivative"),
+]

--- a/tosca_api/apps/core/views.py
+++ b/tosca_api/apps/core/views.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from django.core.files.storage import default_storage
+from django.http import FileResponse
+from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from tosca_api.apps.core.image_derivatives import (
+    DerivativeFormatUnavailable,
+    DerivativeSourceMissing,
+    UnsupportedDerivativeFormat,
+    UnsupportedDerivativeSource,
+    UnsupportedDerivativeWidth,
+    generate_derivative,
+)
+
+
+class ImageDerivativeView(APIView):
+    authentication_classes = []
+    permission_classes = []
+
+    @extend_schema(
+        tags=["media"],
+        operation_id="media_image_derivative",
+        summary="Serve an optimized image derivative",
+        parameters=[
+            OpenApiParameter(
+                name="src",
+                description="Django storage path for the original image.",
+                required=True,
+                type=str,
+            ),
+            OpenApiParameter(
+                name="fmt",
+                description="Derivative format: webp or avif.",
+                required=True,
+                type=str,
+            ),
+            OpenApiParameter(
+                name="w",
+                description="Optional width: 480, 960, 1440, or 1920.",
+                required=False,
+                type=int,
+            ),
+        ],
+        responses={
+            200: OpenApiResponse(description="Optimized image body."),
+            400: OpenApiResponse(description="Unsupported format or width."),
+            404: OpenApiResponse(description="Original image not found."),
+            501: OpenApiResponse(description="Requested encoder is unavailable."),
+        },
+    )
+    def get(self, request, *args, **kwargs):
+        source = request.query_params.get("src")
+        fmt = request.query_params.get("fmt")
+        width = request.query_params.get("w")
+
+        if not source or not fmt:
+            return Response(
+                {"detail": "Both 'src' and 'fmt' are required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        try:
+            result = generate_derivative(source, fmt=fmt, width=width or None)
+        except (
+            UnsupportedDerivativeFormat,
+            UnsupportedDerivativeSource,
+            UnsupportedDerivativeWidth,
+        ) as exc:
+            return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+        except DerivativeSourceMissing:
+            return Response(
+                {"detail": "Original image not found."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        except DerivativeFormatUnavailable as exc:
+            return Response({"detail": str(exc)}, status=status.HTTP_501_NOT_IMPLEMENTED)
+
+        response = FileResponse(
+            default_storage.open(result.storage_path, "rb"),
+            content_type=result.content_type,
+        )
+        response["Cache-Control"] = "public, max-age=31536000, immutable"
+        return response

--- a/tosca_api/apps/geocontext/views.py
+++ b/tosca_api/apps/geocontext/views.py
@@ -223,6 +223,26 @@ class EditorJSImageUploadByUrlView(APIView):
             200: OpenApiResponse(response=_UPLOAD_SUCCESS_SERIALIZER),
             400: OpenApiResponse(response=_UPLOAD_FAILURE_SERIALIZER),
         },
+        examples=[
+            OpenApiExample(
+                "Remote upload request",
+                value={"url": "https://remote.example.test/photos/inline.webp"},
+                request_only=True,
+            ),
+            OpenApiExample(
+                "Uploaded remote image",
+                value={
+                    "success": 1,
+                    "file": {
+                        "url": "https://example.test/media/geocontext/editorjs/context/inline.webp",
+                        "mime": "image/webp",
+                        "width": 960,
+                        "height": 640,
+                    },
+                },
+                response_only=True,
+            ),
+        ],
     )
     def post(self, request, *args, **kwargs):
         url = (request.data or {}).get("url")

--- a/tosca_api/apps/geostories/views.py
+++ b/tosca_api/apps/geostories/views.py
@@ -1,3 +1,4 @@
+from drf_spectacular.utils import OpenApiExample, OpenApiResponse, extend_schema, extend_schema_view
 from rest_framework import permissions, viewsets
 from rest_framework.pagination import CursorPagination
 from rest_framework.parsers import FormParser, JSONParser, MultiPartParser
@@ -17,6 +18,51 @@ class GeoStoryCursorPagination(CursorPagination):
     ordering = "-created_at"
 
 
+@extend_schema_view(
+    list=extend_schema(
+        tags=["geostories"],
+        summary="List GeoStories",
+        responses={200: GeoStoryListSerializer},
+        examples=[
+            OpenApiExample(
+                "GeoStory card",
+                value={
+                    "id": "4a7b90a6-31bd-4b84-9bc0-9a94d61b4d15",
+                    "title": "Waterfront adaptation",
+                    "summary": "A story about planned public-space changes.",
+                    "hero_image_url": "https://example.test/media/geostories/story/hero.jpg",
+                    "hero_image_alt": "A waterfront promenade with new tree planting.",
+                    "campaign": "b0c2d2d5-cd1d-49db-8f4d-a56e37798e80",
+                    "created_at": "2026-04-30T10:30:00Z",
+                },
+                response_only=True,
+            )
+        ],
+    ),
+    retrieve=extend_schema(
+        tags=["geostories"],
+        summary="Retrieve a GeoStory",
+        responses={200: GeoStoryDetailSerializer},
+    ),
+    create=extend_schema(
+        tags=["geostories"],
+        summary="Create a GeoStory",
+        request=GeoStoryWriteSerializer,
+        responses={201: OpenApiResponse(response=GeoStoryWriteSerializer)},
+    ),
+    update=extend_schema(
+        tags=["geostories"],
+        summary="Replace a GeoStory",
+        request=GeoStoryWriteSerializer,
+        responses={200: OpenApiResponse(response=GeoStoryWriteSerializer)},
+    ),
+    partial_update=extend_schema(
+        tags=["geostories"],
+        summary="Update a GeoStory",
+        request=GeoStoryWriteSerializer,
+        responses={200: OpenApiResponse(response=GeoStoryWriteSerializer)},
+    ),
+)
 class GeoStoryViewSet(viewsets.ModelViewSet):
     """
     API endpoint for GeoStory operations.

--- a/tosca_api/urls.py
+++ b/tosca_api/urls.py
@@ -27,6 +27,7 @@ urlpatterns = [
     path('api/v1/', include('tosca_api.apps.geostories.urls')),
     path('api/v1/', include('tosca_api.apps.events.urls')),
     path("api/v1/", include("tosca_api.apps.feedback.urls")),
+    path("api/v1/", include("tosca_api.apps.core.urls")),
     path("api/v1/", include("tosca_api.apps.geocontext.urls")),
     path('api/v1/catalog/', include('tosca_api.apps.catalog_api.urls'), name='catalog_api'),
     path('admin/logout/', KeycloakLogoutView.as_view(), name='admin_logout'),


### PR DESCRIPTION
Add cached optimized image derivatives, document the image block contract, and update schema coverage for hero images and EditorJS uploads.

## Summary

- [ ] Description of changes
- [ ] Related issue link

## Testing

- [ ] `uv run pytest`
- [ ] Other (describe)
