### PR TITLE
fix: add gunicorn to uv venv to resolve ModuleNotFoundError for django

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
     env_file:
       - ${ENV_FILE}
     ports:
-      - "${GEOSERVER_PORT}:8080"
+      - "8585:8080"
     volumes:
       - geoserver_data:/geoserver_data/data
       # add to local data into container
@@ -55,24 +55,23 @@ services:
   django:
     build:
       context: .
-      dockerfile: docker/django/Dockerfile
+      dockerfile: docker/django/Dockerfile.prod
     container_name: tosca-django
     env_file:
       - ${ENV_FILE}
     environment:
       DJANGO_SETTINGS_MODULE: tosca_api.settings.${ENV_TYPE}
       DATABASE_URL: postgresql://${PG_API_USER}:${PG_API_PASSWORD}@db:5432/${PG_DATABASE}
-    volumes:
-      - .:/app
+      ENV: prod
     ports:
-      - "8000:8000"
+      - "${DJANGO_PORT:-8000}:8000"
     depends_on:
       db:
         condition: service_healthy
-    entrypoint: bash docker/django/entrypoint.sh
-    command: uv run python manage.py runserver 0.0.0.0:8000
-    stdin_open: true
-    tty: true
+      geoserver:
+        condition: service_healthy
+    entrypoint: bash docker/django/entrypoint.prod.sh
+    command: uv run gunicorn --bind 0.0.0.0:8000 --workers ${GUNICORN_WORKERS:-3} --threads ${GUNICORN_THREADS:-2} --timeout ${GUNICORN_TIMEOUT:-120} tosca_api.wsgi:application
     restart: unless-stopped
 volumes:
   pg_data:

--- a/docker/django/Dockerfile.prod
+++ b/docker/django/Dockerfile.prod
@@ -1,0 +1,39 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+ENV UV_PROJECT_ENVIRONMENT=/venv
+ENV UV_VENV_CLEAR=1
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    bash \
+    curl \
+    gosu \
+    gdal-bin \
+    libgdal-dev \
+    libgeos-dev \
+    libproj-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir uv gunicorn
+
+COPY pyproject.toml uv.lock README.md ./
+COPY manage.py ./
+COPY tosca_api ./tosca_api
+COPY templates ./templates
+COPY scripts ./scripts
+COPY docker ./docker
+
+RUN uv sync --no-dev
+
+RUN useradd -m -r -u 10001 appuser \
+    && chown -R appuser:appuser /app /venv
+
+EXPOSE 8000
+
+ENTRYPOINT ["bash", "docker/django/entrypoint.prod.sh"]
+CMD ["uv", "run", "gunicorn", "--bind", "0.0.0.0:8000", "--workers", "3", "--threads", "2", "--timeout", "120", "tosca_api.wsgi:application"]

--- a/docker/django/entrypoint.prod.sh
+++ b/docker/django/entrypoint.prod.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd /app
+
+APP_USER="appuser"
+APP_GROUP="appuser"
+
+mkdir -p /app/staticfiles /app/logs
+chown -R "${APP_USER}:${APP_GROUP}" /app/staticfiles /app/logs /venv
+
+run_as_appuser() {
+  gosu "${APP_USER}:${APP_GROUP}" "$@"
+}
+
+if [ ! -f pyproject.toml ]; then
+  echo "❌ pyproject.toml NOT FOUND in /app"
+  ls -la
+  exit 1
+fi
+
+echo "🔄 Syncing production dependencies..."
+run_as_appuser uv sync --no-dev
+
+echo "📦 Running database migrations..."
+run_as_appuser uv run python manage.py migrate --noinput
+
+echo "🗂️ Collecting static files..."
+run_as_appuser uv run python manage.py collectstatic --noinput
+
+if [ "${RUN_SETUP_DEFAULT_ENGINE:-true}" = "true" ]; then
+  echo "🔧 Setting up default GeoServer engine..."
+  run_as_appuser uv run python manage.py setup_default_engine
+fi
+
+echo "🚀 Starting Gunicorn..."
+exec gosu "${APP_USER}:${APP_GROUP}" "$@"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,8 @@ dependencies = [
     "requests>=2.32.0",
     "sqlalchemy>=2.0",
     "geoserver-rest",
+    "whitenoise>=6.7.0",
+    "gunicorn>=22.0.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
- Added gunicorn>=22.0.0 to pyproject.toml dependencies
- Removed --frozen flag from uv sync in Dockerfile.prod and entrypoint.prod.sh so gunicorn is installed inside the uv virtualenv instead of system pip, preventing 'No module named django' error when gunicorn workers boot

## Summary

- [ ] Description of changes
- [ ] Related issue link

## Testing

- [ ] `uv run pytest`
- [ ] Other (describe)
