### PR TITLE
Feature/prod docker compose media static

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,134 +1,175 @@
+############################
+# Global
+############################
+COMPOSE_PROJECT_NAME=tosca_prod
+# Critical: Keep ENV and ENV_TYPE consistent with the compose profile you run.
+# Wrong values here can boot the app with wrong settings module.
+ENV=prod
+ENV_TYPE=production
+ENV_FILE=.env.prod
+PROD_MODE=true
 
 ############################
-# GLOBAL
+# PostgreSQL ports
 ############################
-COMPOSE_PROJECT_NAME=tosca_api_dev
-ENV_TYPE=development
-ENV_FILE=.env.dev
-# COMPOSE_FILE=/Users/hsadmin/Desktop/coding/dcs-django-api/docker-compose-dev.yml
-# HOST_INIT_DIR=/Users/hsadmin/Desktop/coding/dcs-django-api/docker/geoserver_docker/docker/geoserver-init
+POSTGRES_HOST_PORT=5441
+POSTGRES_CONTAINER_PORT=5432
+
+# Backward-compatible aliases
+PG_PORT=${POSTGRES_HOST_PORT}
+PG_DOCKER_PORT=${POSTGRES_CONTAINER_PORT}
+
 ############################
-# POSTGRES (Shared DB)
+# PostgreSQL shared database
 ############################
 PG_HOST=db
-PG_PORT=5438
 PG_DATABASE=tosca
-PG_DOCKER_PORT=5432 # dont change this, it's the internal docker port
-
-# PostgreSQL superuser
 PG_SUPERUSER=postgres
-PG_SUPERPASS=postgres
+# Critical (prod): Change this immediately. Never keep default superuser password.
+PG_SUPERPASS=CHANGE_ME_POSTGRES_SUPERPASS
 
 ############################
-# APPLICATION ROLES
+# Application database users
 ############################
-
-# Django (API)
 PG_API_USER=tosca_api
-PG_API_PASSWORD=postgres_api
-
-# GeoServer
+# Critical (prod): This is the Django DB credential used at runtime.
+PG_API_PASSWORD=CHANGE_ME_API_DB_PASSWORD
 PG_GS_USER=tosca_gs
-PG_GS_PASSWORD=postgres_gs
+# Critical (prod): GeoServer JDBC access depends on this credential.
+PG_GS_PASSWORD=CHANGE_ME_GEOSERVER_DB_PASSWORD
 
 ############################
-# POSTGRES SCHEMAS
+# PostgreSQL schemas
 ############################
 PG_SCHEMA_API=api_schema
 PG_SCHEMA_GEOSERVER=gs_auth_role_schema
 PG_SCHEMA_GIS=gis_schema
 PG_SCHEMA_JDBCCONF=gs_jdbcconfig_schema
+
 ############################
-# GEOSERVER CORE
+# GeoServer core
 ############################
-GEOSERVER_VERSION=2.27.2
+GEOSERVER_VERSION=2.28.3
+GEOSERVER_HOST=geoserver
 GEOSERVER_PORT=8080
+GEOSERVER_HOST_PORT=8585
+GEOSERVER_CONTAINER_PORT=8080
 GEOSERVER_DATA_DIR=/geoserver_data/data
-# Optional: absolute path to local geodata to mount into GeoServer at /mnt/home.
-# Set this in your local .env.dev (which is gitignored). Leave unset if not needed.
-# GEOSERVER_LOCAL_DATA_PATH=/your/local/path/to/TOSCA-Geodata
-
-GEOSERVER_ADMIN_USER=admin2
-GEOSERVER_ADMIN_PASSWORD=geoserver2
+# Optional preset. The GEOSERVER_ENABLE_JDBC_* flags below are the source of truth.
+GEOSERVER_SECURITY_MODE=default
 
 ############################
-# GEOSERVER – JDBC BACKEND
+# GeoServer admin bootstrap
+############################
+GEOSERVER_ADMIN_USER=admin
+# Critical (prod): Rotate this password before exposing GeoServer.
+GEOSERVER_ADMIN_PASSWORD=CHANGE_ME_GEOSERVER_ADMIN_PASSWORD
+# Optional override. If unset, the built-in admin user is disabled automatically
+# when GEOSERVER_ADMIN_USER is changed from "admin".
+# GEOSERVER_DISABLE_DEFAULT_ADMIN=false
+
+############################
+# GeoServer URLs and reverse proxy
+############################
+GEOSERVER_INTERNAL_URL=http://localhost:8080/geoserver
+# Critical (prod): Must be real external URL; affects redirects and generated links.
+GEOSERVER_PUBLIC_URL=https://geoserver.example.com/geoserver
+# Critical (prod): Must match public URL path used behind reverse proxy.
+PROXY_BASE_URL=https://geoserver.example.com/geoserver
+GEOSERVER_USE_HEADERS_PROXY_URL=true
+
+############################
+# GeoServer CORS and CSRF
+############################
+GEOSERVER_CORS_ENABLED=true
+GEOSERVER_CORS_ALLOWED_ORIGINS=*
+GEOSERVER_CORS_ALLOWED_METHODS=GET,POST,PUT,DELETE,HEAD,OPTIONS
+GEOSERVER_CORS_ALLOWED_HEADERS=Authorization,Content-Type,X-Requested-With
+GEOSERVER_ALLOW_WILDCARD_CORS=true
+GEOSERVER_CSRF_WHITELIST=geoserver.example.com,localhost,127.0.0.1
+GEOSERVER_CSRF_DISABLED=true
+
+############################
+# GeoServer plugins
+############################
+OFFICIAL_PLUGINS=mbstyle,vectortiles
+COMMUNITY_PLUGINS=
+# Important: set true only when building image with JDBC config plugin support.
+BUILD_JDBC_PLUGINS=false
+
+############################
+# GeoServer JDBC optional
+############################
+# Enables JDBC role service (role mappings from DB).
+GEOSERVER_ENABLE_JDBC_ROLE=false
+# Enables JDBC auth/login flow from DB. Implies JDBC role support.
+GEOSERVER_ENABLE_JDBC_AUTH=false
+# Enables advanced JDBCConfig catalog/config persistence.
+GEOSERVER_ENABLE_JDBC_CONFIG=false
+GEOSERVER_JDBC_EXTRA_ROLES=
+GEOSERVER_JDBC_CONFIG_IMPORT=false
+
+############################
+# GeoServer JDBC backend compatibility
 ############################
 GEOSERVER_DB_BACKEND=POSTGRES
 GEOSERVER_DB_HOST=${PG_HOST}
-GEOSERVER_DB_PORT=${PG_DOCKER_PORT}
+GEOSERVER_DB_PORT=${POSTGRES_CONTAINER_PORT}
 GEOSERVER_DB_NAME=${PG_DATABASE}
 GEOSERVER_DB_USER=${PG_GS_USER}
 GEOSERVER_DB_PASSWORD=${PG_GS_PASSWORD}
 GEOSERVER_DB_SCHEMA=${PG_SCHEMA_GEOSERVER}
+GS_JDBC_URL=jdbc:postgresql://${PG_HOST}:${POSTGRES_CONTAINER_PORT}/${PG_DATABASE}?currentSchema=${PG_SCHEMA_GEOSERVER}
 
-# JDBC URL (roles + jdbcconfig)
-GS_JDBC_URL=jdbc:postgresql://${PG_HOST}:${PG_DOCKER_PORT}/${PG_DATABASE}?currentSchema=${PG_SCHEMA_GEOSERVER}
+ENABLE_JDBC_CONFIG=${GEOSERVER_ENABLE_JDBC_CONFIG}
+# Compatibility alias used by existing scripts for JDBC login enablement.
+ENABLE_JDBC_LOGIN=${GEOSERVER_ENABLE_JDBC_AUTH}
+JDBC_LOGIN_SERVICE_NAME=jdbc_login
+JDBC_AUTH_SERVICE_NAME=jdbc_auth
 
-############################
-# GEOSERVER – ROLE SERVICE
-############################
 GS_ROLE_SERVICE_NAME=jdbc_role
 GS_ADMIN_ROLE=ADMIN
 GS_GROUP_ADMIN_ROLE=GROUP_ADMIN
 
 ############################
-# GEOSERVER – JVM
+# GeoServer JVM and optional features
 ############################
 GEOSERVER_JVM_XMS=1G
 GEOSERVER_JVM_XMX=2G
-
-############################
-# GEOSERVER – PLUGINS
-#When you add new plugin, it will be installed automatically on GeoServer startup but it will take while for first startup.
-# !!!    so be patient !!!!
-############################
-
-OFFICIAL_PLUGINS=gdal,monitor,vectortiles,mbstyle
-COMMUNITY_PLUGINS=jdbcconfig,jdbcstore,sec-oauth2-openid-connect
-
-############################
-# GEOSERVER – JDBC CONFIG
-ENABLE_JDBC_CONFIG=true
-ENABLE_JDBC_LOGIN=true
-JDBC_LOGIN_SERVICE_NAME=jdbc_login
-JDBC_AUTH_SERVICE_NAME=jdbc_auth
-
-############################
-# GEOSERVER – CORS
-############################
-GEOSERVER_CORS_ENABLED=true
-GEOSERVER_CORS_ALLOWED_ORIGINS=*
-GEOSERVER_CORS_ALLOWED_METHODS=GET,POST,PUT,DELETE,HEAD,OPTIONS
-GEOSERVER_CORS_ALLOWED_HEADERS=*
-
-############################
-# GEOSERVER – OPTIONAL
-############################
+JAVA_OPTS=-Xms512m -Xmx1024m
 DISK_QUOTA_ENABLED=false
 
-
+############################
+# Django core
+############################
+DJANGO_PORT=8001
+# Critical (prod): Use a long random value. Rotating invalidates old sessions/tokens.
+DJANGO_SECRET_KEY=CHANGE_ME_LONG_RANDOM_SECRET_KEY_AT_LEAST_50_CHARS
+# Critical (prod): Must be a valid Fernet key. Needed to decrypt encrypted fields.
+FIELD_ENCRYPTION_KEY=CHANGE_ME_FIELD_ENCRYPTION_KEY
+# Critical (prod): Keep False in production.
+DJANGO_DEBUG=False
+# Critical (prod): Add all real domains that can call Django.
+DJANGO_ALLOWED_HOSTS=example.com,www.example.com
+DJANGO_CORS_ALLOWED_ORIGINS=https://example.com
+# Critical: Keep DB host/port aligned with compose network values.
+DATABASE_URL=postgresql://${PG_API_USER}:${PG_API_PASSWORD}@db:${POSTGRES_CONTAINER_PORT}/${PG_DATABASE}
+GUNICORN_WORKERS=3
+GUNICORN_THREADS=2
+GUNICORN_TIMEOUT=120
+RUN_SETUP_DEFAULT_ENGINE=true
 
 ############################
-# DJANGO
+# Keycloak configuration
 ############################
-DJANGO_SECRET_KEY=21234567890abcdefghijklmnopqrstuvwxyz
-FIELD_ENCRYPTION_KEY="Create your own encryription key"
-DJANGO_DEBUG=true
-DJANGO_ALLOWED_HOSTS=localhost,127.0.0.1
-DJANGO_CORS_ALLOWED_ORIGINS=http://localhost:5173,http://127.0.0.1:5173
-DJANGO_PORT=8000
-
-DATABASE_URL=postgresql://${PG_API_USER}:${PG_API_PASSWORD}@${PG_HOST}:${PG_PORT}/${PG_DATABASE}
-
-###########################
-# Keycloak Configuration
-KEYCLOAK_SERVER_URL=http://keycloak:8080/auth/
-KEYCLOAK_REALM=test 
-KEYCLOAK_CLIENT_ID=django-dev
-KEYCLOAK_CLIENT_SECRET=
-# JWKS endpoint and issuer (used by backend to verify tokens) - REQUIRED
-KEYCLOAK_JWKS_URL=http://keycloak:8080/auth/realms/test/protocol/openid-connect/certs
-KEYCLOAK_ISSUER=http://keycloak:8080/auth/realms/test
-# List of allowed audiences for JWT tokens - REQUIRED
-ALLOWED_TOKEN_AUDIENCES=django-dev,geoserver,account
+KEYCLOAK_SERVER_URL=https://auth.example.com/
+KEYCLOAK_REALM=CHANGE_ME_REALM
+KEYCLOAK_CLIENT_ID=CHANGE_ME_CLIENT_ID
+# Critical (prod): Keep secret out of git and rotate if leaked.
+KEYCLOAK_CLIENT_SECRET=CHANGE_ME_CLIENT_SECRET
+# Critical: JWKS and ISSUER must belong to the same realm.
+KEYCLOAK_JWKS_URL=https://auth.example.com/realms/CHANGE_ME_REALM/protocol/openid-connect/certs
+KEYCLOAK_ISSUER=https://auth.example.com/realms/CHANGE_ME_REALM
+ALLOWED_TOKEN_AUDIENCES=CHANGE_ME_CLIENT_ID,geoserver,account
+KEYCLOAK_ADMIN_USER=CHANGE_ME_KEYCLOAK_ADMIN_USER
+KEYCLOAK_ADMIN_PASSWORD=CHANGE_ME_KEYCLOAK_ADMIN_PASSWORD

--- a/.env.example
+++ b/.env.example
@@ -152,12 +152,24 @@ DJANGO_DEBUG=False
 # Critical (prod): Add all real domains that can call Django.
 DJANGO_ALLOWED_HOSTS=example.com,www.example.com
 DJANGO_CORS_ALLOWED_ORIGINS=https://example.com
+DJANGO_HEALTHCHECK_HOST=example.com
+DJANGO_STATIC_URL=/static/
+DJANGO_STATIC_ROOT=/app/staticfiles
+DJANGO_MEDIA_URL=/media/
+DJANGO_MEDIA_ROOT=/app/media
 # Critical: Keep DB host/port aligned with compose network values.
 DATABASE_URL=postgresql://${PG_API_USER}:${PG_API_PASSWORD}@db:${POSTGRES_CONTAINER_PORT}/${PG_DATABASE}
 GUNICORN_WORKERS=3
 GUNICORN_THREADS=2
 GUNICORN_TIMEOUT=120
 RUN_SETUP_DEFAULT_ENGINE=true
+
+############################
+# Production web/Nginx
+############################
+NGINX_HTTP_PORT=80
+# Set this to the immutable production SPA image built by your web app pipeline.
+WEB_IMAGE=registry.example.com/tosca-web:latest
 
 ############################
 # Keycloak configuration
@@ -171,5 +183,6 @@ KEYCLOAK_CLIENT_SECRET=CHANGE_ME_CLIENT_SECRET
 KEYCLOAK_JWKS_URL=https://auth.example.com/realms/CHANGE_ME_REALM/protocol/openid-connect/certs
 KEYCLOAK_ISSUER=https://auth.example.com/realms/CHANGE_ME_REALM
 ALLOWED_TOKEN_AUDIENCES=CHANGE_ME_CLIENT_ID,geoserver,account
+ALLOWED_TOKEN_CLIENTS=CHANGE_ME_CLIENT_ID,geoserver,tosca-web
 KEYCLOAK_ADMIN_USER=CHANGE_ME_KEYCLOAK_ADMIN_USER
 KEYCLOAK_ADMIN_PASSWORD=CHANGE_ME_KEYCLOAK_ADMIN_PASSWORD

--- a/Makefile
+++ b/Makefile
@@ -1,42 +1,60 @@
-.PHONY: help which-env build up down restart logs rebuild rmvolumes \
+.PHONY: help set-env which-env initialize-project jdbc-settings-activation build up down restart logs rebuild rmvolumes \
 	django-restart django-logs django-cmd django-shell django-migrate django-makemigrations \
 	django-test django-test-unit django-test-integration test-geoserver \
 	django-createsuperuser uv-sync uv-install uv-add uv-lock ps clean \
-	sync-django-geoengine smoke-test
+	sync-django-geoengine smoke-test test test-integration
 
 # -------------------------------------------------
 # ENV selection (DEFAULT = dev) or prod
 # -------------------------------------------------
+ENV_CONFIG := .make.env
+-include $(ENV_CONFIG)
+
 ENV ?= dev
 
 ENV_FILE := .env.$(ENV)
 COMPOSE_FILE := docker-compose-$(ENV).yml
+DEV_COMPOSE_FILE := docker-compose-dev.yml
+PROD_COMPOSE_FILE_PRIMARY := docker-compose-prod.yml
+PROD_COMPOSE_FILE_FALLBACK := docker-compose.yml
 
 # Safety: allow only dev / prod
 ifeq ($(ENV),dev)
-  COMPOSE_FILE := docker-compose-dev.yml
+	COMPOSE_FILE := $(DEV_COMPOSE_FILE)
 endif
 
 ifeq ($(ENV),prod)
-  COMPOSE_FILE := docker-compose-prod.yml
+	ifneq ("$(wildcard $(PROD_COMPOSE_FILE_PRIMARY))","")
+		COMPOSE_FILE := $(PROD_COMPOSE_FILE_PRIMARY)
+	else
+		COMPOSE_FILE := $(PROD_COMPOSE_FILE_FALLBACK)
+	endif
+endif
+
+ifneq ($(filter $(ENV),dev prod),$(ENV))
+  $(error ❌ Invalid ENV=$(ENV). Allowed values: dev, prod)
 endif
 
 # -------------------------------------------------
 # Load env file
 # -------------------------------------------------
+ifeq ($(filter set-env,$(MAKECMDGOALS)),)
 ifneq ("$(wildcard $(ENV_FILE))","")
   include $(ENV_FILE)
   export $(shell sed -n 's/^\s*\([A-Za-z_][A-Za-z0-9_]*\)\s*=.*/\1/p' $(ENV_FILE))
 else
   $(error ❌ Missing $(ENV_FILE))
 endif
+endif
 
 # -------------------------------------------------
 # Check compose file
 # -------------------------------------------------
+ifeq ($(filter set-env,$(MAKECMDGOALS)),)
 ifneq ("$(wildcard $(COMPOSE_FILE))","")
 else
   $(error ❌ Missing $(COMPOSE_FILE))
+endif
 endif
 
 # -------------------------------------------------
@@ -93,12 +111,17 @@ help:
 	@echo "$(COLOR_GREEN)Project Initialization:$(COLOR_RESET)"
 	@echo "  make initialize-project - Build, start all services, run migrations, restart Django"
 	@echo "  make jdbc-settings-activation - Run GeoServer JDBC settings activation script"
-	@echo "$(COLOR_GREEN)Environment:$(COLOR_RESET) ENV=$(ENV)"
+	@echo ""
+	@echo "$(COLOR_GREEN)Environment Selection:$(COLOR_RESET)"
+	@echo "  make set-env ENV=dev    - Persist dev environment for future make commands"
+	@echo "  make set-env ENV=prod   - Persist prod environment for future make commands"
+	@echo "  make which-env          - Show active environment and compose file"
+	@echo "$(COLOR_GREEN)Environment:$(COLOR_RESET) ENV=$(ENV) | ENV_FILE=$(ENV_FILE) | COMPOSE_FILE=$(COMPOSE_FILE)"
 	@echo ""
 	@echo "  make test                     # Run pytest suite excluding integration tests"
 	@echo "  make test-integration         # Run integration tests only"
 	@echo "  make test APP=authentication  # Run tests for a single app"
-	@echo "  make test PATH=path/to/tests  # Run tests for a specific path"
+	@echo "  make test TEST_PATH=path/to/tests  # Run tests for a specific path"
 	@echo ""
 
 	
@@ -108,7 +131,6 @@ help:
 # Builds all Docker images, starts all services, runs Django migrations, and restarts only the Django container.
 initialize-project: which-env
 	@echo "$(COLOR_GREEN)🚀 Initializing project: build, up, migrate, restart Django...$(COLOR_RESET)"
-	cp docker-compose.yml $(COMPOSE_FILE)
 	docker compose --env-file $(ENV_FILE) -f $(COMPOSE_FILE) build
 	docker compose --env-file $(ENV_FILE) -f $(COMPOSE_FILE) up -d
 	@echo "$(COLOR_BLUE)📦 Running Django migrations...$(COLOR_RESET)"
@@ -118,22 +140,38 @@ initialize-project: which-env
 	@echo "$(COLOR_GREEN)✅ Project initialized!$(COLOR_RESET)"
 	@echo ""
 	@sleep 2
-	@echo "$(COLOR_RED)📋 Please initialize PostgreSQL schemas and roles before proceeding. 
-	@echo "make jdbc-settings-activation"$(COLOR_RESET)"
+	@echo "$(COLOR_RED)📋 Please initialize PostgreSQL schemas and roles before proceeding.$(COLOR_RESET)"
+	@echo "  make jdbc-settings-activation"
 
 # -------------------------------------------------
 # Run GeoServer JDBC settings activation script
 jdbc-settings-activation: which-env
-	@echo "Activating GeoServer JDBC settings with ENV_FILE=$(ENV_FILE)"
+	@echo "$(COLOR_BLUE)⚙️  Activating GeoServer JDBC settings (ENV_FILE=$(ENV_FILE))...$(COLOR_RESET)"
 	@cd docker/geoserver_docker && \
 	ENV_FILE="$(abspath $(ENV_FILE))" \
 	./scripts/activate_jdbcS_settings.sh
-	@echo "$(COLOR_GREEN)✅ If you want to see the all system log " make logs" only for django "make django-logs"$(COLOR_RESET)"
+	@echo "$(COLOR_GREEN)✅ Done. For all logs: make logs | For Django only: make django-logs$(COLOR_RESET)"
 
 
 # -------------------------------------------------
 # Helpers
 # -------------------------------------------------
+set-env:
+	@if [ "$(ENV)" != "dev" ] && [ "$(ENV)" != "prod" ]; then \
+		echo "$(COLOR_RED)❌ Invalid ENV=$(ENV). Allowed values: dev, prod$(COLOR_RESET)"; \
+		exit 1; \
+	fi
+	@if [ ! -f ".env.$(ENV)" ]; then \
+		echo "$(COLOR_RED)❌ Missing .env.$(ENV)$(COLOR_RESET)"; \
+		exit 1; \
+	fi
+	@if [ ! -f "$(COMPOSE_FILE)" ]; then \
+		echo "$(COLOR_RED)❌ Missing $(COMPOSE_FILE)$(COLOR_RESET)"; \
+		exit 1; \
+	fi
+	@printf "ENV := %s\n" "$(ENV)" > $(ENV_CONFIG)
+	@echo "$(COLOR_GREEN)✅ Saved ENV=$(ENV) in $(ENV_CONFIG)$(COLOR_RESET)"
+
 which-env:
 	@echo "🔧 ENV=$(ENV)"
 	@echo "📄 ENV_FILE=$(ENV_FILE)"
@@ -239,20 +277,12 @@ rmvolumes: which-env
 # Pytest via uv inside container
 # Usage:
 #   make test
-#   make test app=authentication
-#   make test path=tosca_api/apps/authentication/tests
+#   make test APP=authentication
+#   make test TEST_PATH=tosca_api/apps/authentication/tests
 # -------------------------------------------------
-test:
-	@if [ -n "$(app)" ]; then \
-		docker exec -it tosca-django bash -lc 'APP_PATH=tosca_api/apps/$(app); APP_PKG=tosca_api.apps.$(app); if [ -d "$$APP_PATH/tests" ]; then TARGET="$$APP_PKG.tests"; else TARGET="$$APP_PKG"; fi; DJANGO_SETTINGS_MODULE=tosca_api.settings.test uv run pytest --pyargs -m "not integration" --ds=tosca_api.settings.test "$$TARGET"'; \
-	elif [ -n "$(path)" ]; then \
-		docker exec -it tosca-django bash -lc "DJANGO_SETTINGS_MODULE=tosca_api.settings.test uv run pytest -m 'not integration' --ds=tosca_api.settings.test $(path)"; \
-	else \
-		docker exec -it tosca-django bash -lc "DJANGO_SETTINGS_MODULE=tosca_api.settings.test uv run pytest -m 'not integration' --ds=tosca_api.settings.test"; \
-	fi
+test: django-test
 
-test-integration:
-	docker exec -it tosca-django bash -lc "DJANGO_SETTINGS_MODULE=tosca_api.settings.test uv run pytest -m integration --ds=tosca_api.settings.test"
+test-integration: django-test-integration
 
 # -------------------------------------------------
 # Django test commands
@@ -264,24 +294,27 @@ test-integration:
 # -------------------------------------------------
 django-test: which-env
 	@echo "$(COLOR_BLUE)🧪 Running Django pytest suite without integration tests...$(COLOR_RESET)"
-	@if [ -n "$(app)" ]; then \
-		APP_PATH=tosca_api/apps/$(app); \
-		docker exec -it tosca-django bash -lc 'APP_PATH=tosca_api/apps/$(app); APP_PKG=tosca_api.apps.$(app); TARGET=$$([ -d "$$APP_PATH/tests" ] && echo "$$APP_PKG.tests" || echo "$$APP_PKG"); DJANGO_SETTINGS_MODULE=tosca_api.settings.test uv run pytest --pyargs -m "not integration" --ds=tosca_api.settings.test "$$TARGET"'; \
+	@if [ -n "$(APP)" ] || [ -n "$(app)" ]; then \
+		APP_NAME=$${APP:-$(app)}; \
+		docker compose --env-file $(ENV_FILE) -f $(COMPOSE_FILE) exec -T django bash -lc "APP_PATH=tosca_api/apps/$$APP_NAME; APP_PKG=tosca_api.apps.$$APP_NAME; TARGET=\$\$([ -d \"\$\$APP_PATH/tests\" ] && echo \"\$\$APP_PKG.tests\" || echo \"\$\$APP_PKG\"); DJANGO_SETTINGS_MODULE=tosca_api.settings.test uv run pytest --pyargs -m 'not integration' --ds=tosca_api.settings.test \"\$\$TARGET\""; \
+	elif [ -n "$(TEST_PATH)" ] || [ -n "$(path)" ]; then \
+		TEST_PATH_VALUE=$${TEST_PATH:-$(path)}; \
+		docker compose --env-file $(ENV_FILE) -f $(COMPOSE_FILE) exec -T django bash -lc "DJANGO_SETTINGS_MODULE=tosca_api.settings.test uv run pytest -m 'not integration' --ds=tosca_api.settings.test $$TEST_PATH_VALUE"; \
 	elif [ -n "$(test)" ]; then \
-		docker exec -it tosca-django bash -lc "DJANGO_SETTINGS_MODULE=tosca_api.settings.test uv run pytest -m 'not integration' --ds=tosca_api.settings.test $(test)"; \
+		docker compose --env-file $(ENV_FILE) -f $(COMPOSE_FILE) exec -T django bash -lc "DJANGO_SETTINGS_MODULE=tosca_api.settings.test uv run pytest -m 'not integration' --ds=tosca_api.settings.test $(test)"; \
 	else \
-		docker exec -it tosca-django bash -lc "DJANGO_SETTINGS_MODULE=tosca_api.settings.test uv run pytest -m 'not integration' --ds=tosca_api.settings.test"; \
+		docker compose --env-file $(ENV_FILE) -f $(COMPOSE_FILE) exec -T django bash -lc "DJANGO_SETTINGS_MODULE=tosca_api.settings.test uv run pytest -m 'not integration' --ds=tosca_api.settings.test"; \
 	fi
 
 # Run unit tests with mocks (fast, no external dependencies)
 django-test-unit: which-env
 	@echo "$(COLOR_BLUE)⚡ Running unit tests without integration markers...$(COLOR_RESET)"
-	docker exec -it tosca-django bash -lc "DJANGO_SETTINGS_MODULE=tosca_api.settings.test uv run pytest -m 'not integration' --ds=tosca_api.settings.test -v --tb=short"
+	docker compose --env-file $(ENV_FILE) -f $(COMPOSE_FILE) exec -T django bash -lc "DJANGO_SETTINGS_MODULE=tosca_api.settings.test uv run pytest -m 'not integration' --ds=tosca_api.settings.test -v --tb=short"
 
 # Run integration tests with real GeoServer (slower, needs services)
 django-test-integration: which-env
 	@echo "$(COLOR_BLUE)🌐 Running integration tests (real services)...$(COLOR_RESET)"
-	docker exec -it tosca-django bash -lc "DJANGO_SETTINGS_MODULE=tosca_api.settings.test uv run pytest -m integration --ds=tosca_api.settings.test -v"
+	docker compose --env-file $(ENV_FILE) -f $(COMPOSE_FILE) exec -T django bash -lc "DJANGO_SETTINGS_MODULE=tosca_api.settings.test uv run pytest -m integration --ds=tosca_api.settings.test -v"
 
 # Quick alias for integration test
 test-geoserver: django-test-integration

--- a/README.md
+++ b/README.md
@@ -37,6 +37,92 @@ The root Makefile resolves compose files as:
 - `dev` -> `docker-compose-dev.yml`
 - `prod` -> `docker-compose-prod.yml` if present, otherwise `docker-compose.yml`
 
+## Production Docker Compose
+
+The production stack is defined in `docker-compose-prod.yml`. It includes the Django API deployment plus the production GeoServer image published from GitHub Container Registry.
+
+Services:
+
+- `db`: PostgreSQL/PostGIS for Django.
+- `geoserver`: GeoServer from `ghcr.io/digitalcityscience/tosca-geoserver:latest`. Production always pulls this published image; it does not build from `docker/geoserver_docker`.
+- `django`: Gunicorn-backed Django API. Uploaded media is stored under `/app/media`; collected static files are stored under `/app/staticfiles`.
+- `web`: SPA Nginx container. Use `WEB_IMAGE` to point to the production image that contains the built SPA assets.
+- `nginx`: public reverse proxy. It routes `/api/`, `/admin/`, and `/accounts/` to Django, `/geoserver/` to GeoServer, routes the SPA shell to `web`, and serves `/media/` and `/static/` directly.
+
+Shared named volumes:
+
+- `media_files`: mounted at `/app/media` in Django and `/usr/share/nginx/media` in Nginx-based containers.
+- `static_files`: mounted at `/app/staticfiles` in Django and `/usr/share/nginx/staticfiles` in Nginx-based containers.
+
+The production GeoServer service is equivalent to:
+
+```bash
+docker pull ghcr.io/digitalcityscience/tosca-geoserver:latest
+```
+
+`docker-compose-prod.yml` sets `pull_policy: always` for this service so each production deploy checks the published latest image.
+
+Required Django media/static settings for production:
+
+```dotenv
+DJANGO_STATIC_URL=/static/
+DJANGO_STATIC_ROOT=/app/staticfiles
+DJANGO_MEDIA_URL=/media/
+DJANGO_MEDIA_ROOT=/app/media
+```
+
+Start production with:
+
+```bash
+cp .env.example .env.prod
+make set-env ENV=prod
+make up
+```
+
+In a real deployment, set `WEB_IMAGE` to the immutable image produced by the SPA pipeline, for example:
+
+```dotenv
+WEB_IMAGE=registry.example.com/tosca-web:2026-05-21
+```
+
+If you need to test a local SPA build, create a temporary compose override that mounts your built `dist` directory into `/usr/share/nginx/html` for the `web` service. Do not use that pattern as the normal production deployment method.
+
+## SPA Integration And Media/Static Serving
+
+The SPA must load uploaded media and collected static assets from production Nginx, not directly from the Django/Gunicorn container. Django writes files to `/app/media` and `/app/staticfiles`; Nginx serves the same files through shared Docker named volumes:
+
+```text
+Django /app/media        -> media_files  -> Nginx /usr/share/nginx/media       -> https://yourdomain.com/media/...
+Django /app/staticfiles  -> static_files -> Nginx /usr/share/nginx/staticfiles -> https://yourdomain.com/static/...
+```
+
+The Nginx configs use `alias` for these paths:
+
+```nginx
+location /media/ {
+    alias /usr/share/nginx/media/;
+}
+
+location /static/ {
+    alias /usr/share/nginx/staticfiles/;
+}
+```
+
+Integration scenarios:
+
+- Same domain/host: if the SPA and Django API are served under `https://yourdomain.com`, media URLs returned by the API such as `/media/geocontext/editorjs/image.png` work directly in the browser as `https://yourdomain.com/media/geocontext/editorjs/image.png`.
+- Different host/domain: if the SPA is served from another host, for example `https://app.yourdomain.com`, the public production Nginx that owns `https://yourdomain.com/media/...` must mount the same `media_files` volume and serve it. The SPA should render absolute media URLs such as `https://yourdomain.com/media/geocontext/editorjs/image.png`, or prepend the configured API/public asset base URL to relative `/media/...` paths.
+
+Example flow:
+
+1. A user uploads an image through the Django API.
+2. Django stores the file in `/app/media/geocontext/editorjs/example.png`.
+3. The API returns `/media/geocontext/editorjs/example.png`.
+4. The SPA renders `https://yourdomain.com/media/geocontext/editorjs/example.png`.
+5. Production Nginx serves the file from `/usr/share/nginx/media/geocontext/editorjs/example.png` through the shared `media_files` volume.
+
+The same rule applies to Django static assets collected by `collectstatic`: they are served from `https://yourdomain.com/static/...` by Nginx through the shared `static_files` volume.
+
 ## Start
 
 ```bash
@@ -146,3 +232,9 @@ Full command list:
 ```bash
 make help
 ```
+
+## Sık Sorulan Sorular
+
+### SPA ile media entegrasyonu neden böyle?
+
+Production ortamında Django/Gunicorn dosya sunucusu olarak kullanılmamalıdır. Django upload edilen dosyaları üretir ve diske yazar; tarayıcıya yüksek performanslı, cache edilebilir dosya servisini Nginx yapar. Bu yüzden SPA, media dosyalarını doğrudan Django container'ından değil, production Nginx üzerinden almalıdır. Docker ortamında bunun çalışması için Django'nun yazdığı `/app/media` dizini ile Nginx'in servis ettiği `/usr/share/nginx/media` dizini aynı named volume'a bağlanır. Böylece API'nin döndürdüğü `/media/...` URL'leri hem aynı domain senaryosunda hem de ayrı SPA host senaryosunda tutarlı şekilde çalışır.

--- a/README.md
+++ b/README.md
@@ -1,63 +1,148 @@
-# TOSCA-Web API
+# TOSCA Django API
 
-TOSCA Django REST backend for the TOSCA-Web geospatial platform.
+Backend for the TOSCA geospatial platform. The local stack runs:
 
-## Quick Start
+- PostgreSQL/PostGIS
+- GeoServer
+- Django API
 
-1. **Clone & Enter Directory**
+## Docker Model
 
-   ```bash
-   git clone <repo-url>
-   cd dcs-django-api
-   ```
+Development and production intentionally use different GeoServer image sources:
 
-2. **Choose Environment**
-   - Default: `dev`
-   - For production: `make ENV=prod ...`
-   - Copy `.env.example` to `.env.dev` and fill in your values
+- `docker-compose-dev.yml` builds GeoServer from the local submodule at `docker/geoserver_docker`. Use this when changing GeoServer Docker scripts/templates and testing them quickly.
+- `docker-compose.yml` is the production fallback compose and uses `ghcr.io/digitalcityscience/tosca-geoserver:latest`. Production should consume the CI-built image from the GeoServer Docker repository main branch.
 
-   **Optional – local GeoServer data mount:**
-   If you have local geodata to expose inside GeoServer at `/mnt/home`, add this
-   line to your `.env.dev` (the file is gitignored, so it stays off GitHub):
+That means GeoServer Docker changes should be validated in dev, merged in `geoserver_docker`, then picked up by the CI-built production image.
 
-   ```dotenv
-   GEOSERVER_LOCAL_DATA_PATH=/absolute/path/to/your/geodata
-   ```
+## Environment
 
-   Leave it unset if you don't need it — GeoServer will start normally without it.
+Create an env file and select the active environment:
 
-3. **Initialize Project (build, start, migrate)**
+```bash
+cp .env.example .env.dev
+make set-env ENV=dev
+make which-env
+```
 
-   ```bash
-   make initialize-project
-   ```
+For production, create `.env.prod` and run:
 
-4. **Activate GeoServer JDBC Settings**
+```bash
+make set-env ENV=prod
+make which-env
+```
 
-   ```bash
-   make jdbc-settings-activation
-   ```
+The root Makefile resolves compose files as:
 
-5. **Create Django Superuser**
+- `dev` -> `docker-compose-dev.yml`
+- `prod` -> `docker-compose-prod.yml` if present, otherwise `docker-compose.yml`
 
-   ```bash
-   make django-createsuperuser
-   ```
+## Start
 
-6. **View Logs**
+```bash
+make initialize-project
+```
 
-   ```bash
-   make logs         # All services
-   make django-logs  # Django only
-   ```
+This builds images, starts containers, runs Django migrations, and restarts Django.
 
-## Common Makefile Commands
+For day-to-day work:
 
-- `make up` / `make down` — Start/stop all services
-- `make build` / `make rebuild` — Build/rebuild Docker images
-- `make django-shell` — Open Django shell
-- `make django-migrate` — Run migrations
-- `make django-test` — Run Django tests
-- `make uv-sync` — Sync Python dependencies
+```bash
+make up
+make down
+make rebuild
+make logs
+make ps
+```
 
-See `make help` for all available commands.
+`make rebuild`, `make up`, `make down`, and `make rmvolumes` all use the same active `ENV_FILE` and `COMPOSE_FILE` shown by `make which-env`.
+
+## GeoServer Admin Bootstrap
+
+GeoServer admin is controlled by:
+
+```dotenv
+GEOSERVER_ADMIN_USER=admin2
+GEOSERVER_ADMIN_PASSWORD=geoserver2
+```
+
+On first startup the container uses GeoServer's built-in `admin/geoserver` only as a bootstrap credential. It then creates or updates `GEOSERVER_ADMIN_USER`, grants `ADMIN`, and disables the built-in `admin` user by default when the configured user is not `admin`.
+
+This happens before JDBC role/auth/config activation.
+
+## JDBC Feature Flags
+
+The JDBC features are related but independent:
+
+```dotenv
+GEOSERVER_ENABLE_JDBC_ROLE=true
+GEOSERVER_ENABLE_JDBC_AUTH=true
+GEOSERVER_ENABLE_JDBC_CONFIG=false
+```
+
+- `GEOSERVER_ENABLE_JDBC_ROLE=true` enables JDBC role service files and role mapping.
+- `GEOSERVER_ENABLE_JDBC_AUTH=true` enables JDBC user/group service and auth provider. It implies role support.
+- `GEOSERVER_ENABLE_JDBC_CONFIG=true` enables the advanced JDBCConfig/catalog path.
+
+`GEOSERVER_SECURITY_MODE` can still be used as a preset (`jdbc-role`, `jdbc-auth-role`, `jdbc-config`), but the `GEOSERVER_ENABLE_JDBC_*` flags are the actual feature toggles. Do not rely on mode alone when reviewing production env.
+
+## JDBC Activation
+
+After services are running, apply GeoServer JDBC security/config files:
+
+```bash
+make jdbc-settings-activation
+```
+
+This runs the activation script from `docker/geoserver_docker` with the active root env file.
+
+For JDBC role/auth, complete the GeoServer UI steps described in:
+
+- `docker/geoserver_docker/readme_jdbc.md`
+
+## Plugins And Images
+
+JDBC-related GeoServer extensions should be baked into the GeoServer Docker image by the GeoServer Docker repository CI. Production should not depend on slow runtime plugin downloads.
+
+For local dev builds, `docker-compose-dev.yml` passes plugin build args from `.env.dev` into the submodule Dockerfile.
+
+## Common Checks
+
+If something looks wrong:
+
+```bash
+make which-env
+make ps
+make logs
+make jdbc-settings-activation
+```
+
+For a fresh GeoServer security test, remove volumes intentionally:
+
+```bash
+make rmvolumes
+make rebuild
+```
+
+Expected admin result when `GEOSERVER_ADMIN_USER=admin2`:
+
+```text
+admin2:<configured password> -> works
+admin:geoserver              -> rejected
+```
+
+## Django Commands
+
+```bash
+make django-migrate
+make django-createsuperuser
+make django-shell
+make django-test
+make django-test-integration
+```
+
+Full command list:
+
+```bash
+make help
+```

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -33,7 +33,15 @@ services:
     restart: unless-stopped
 
   geoserver:
-    image: ghcr.io/digitalcityscience/tosca-geoserver:latest
+    build:
+      context: ./docker/geoserver_docker
+      dockerfile: docker/Dockerfile
+      args:
+        GEOSERVER_VERSION: ${GEOSERVER_VERSION}
+        DEFAULT_OFFICIAL_PLUGINS: ${OFFICIAL_PLUGINS:-gdal,monitor,vectortiles,mbstyle}
+        DEFAULT_COMMUNITY_PLUGINS: ${COMMUNITY_PLUGINS:-}
+        BUILD_JDBC_PLUGINS: ${BUILD_JDBC_PLUGINS:-false}
+    image: tosca-geoserver-dev:${GEOSERVER_VERSION}
     container_name: tosca-geoserver
     env_file:
       - ${ENV_FILE}
@@ -43,7 +51,7 @@ services:
       - geoserver_data:/geoserver_data/data
       # Optional: set GEOSERVER_LOCAL_DATA_PATH in your .env.dev to mount local geodata.
       # Falls back to an empty directory when the variable is not set.
-      - /Users/gokturkburakkose/Documents/dev/TOSCA-Geodata:/mnt/home
+
     depends_on:
       db:
         condition: service_healthy
@@ -58,7 +66,7 @@ services:
     build:
       context: .
       dockerfile: docker/django/Dockerfile
-    container_name: tosca-django
+    container_name: tosca-django-api
     env_file:
       - ${ENV_FILE}
     environment:

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -1,0 +1,211 @@
+# Production Docker Compose for PostgreSQL/PostGIS, GeoServer, Django API, SPA web, and public Nginx.
+# Production GeoServer always uses the CI-published GitHub Container Registry image.
+
+services:
+  # PostgreSQL/PostGIS database used by the Django API.
+  db:
+    image: postgis/postgis:16-3.4
+    container_name: tosca-db
+    env_file:
+      - ${ENV_FILE}
+    environment:
+      POSTGRES_DB: ${PG_DATABASE}
+      POSTGRES_USER: ${PG_SUPERUSER}
+      POSTGRES_PASSWORD: ${PG_SUPERPASS}
+      PG_API_USER: ${PG_API_USER}
+      PG_API_PASSWORD: ${PG_API_PASSWORD}
+      PG_GS_USER: ${PG_GS_USER}
+      PG_GS_PASSWORD: ${PG_GS_PASSWORD}
+      PG_SCHEMA_API: ${PG_SCHEMA_API}
+      PG_SCHEMA_GEOSERVER: ${PG_SCHEMA_GEOSERVER}
+      PG_SCHEMA_GIS: ${PG_SCHEMA_GIS}
+      PG_SCHEMA_JDBCCONF: ${PG_SCHEMA_JDBCCONF}
+    volumes:
+      # Persist PostgreSQL data across container restarts/redeployments.
+      - prod_pg_data:/var/lib/postgresql/data
+      # Initialize DB users/schemas from the Django API repository only.
+      - ./docker/postgis:/docker-entrypoint-initdb.d:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB} -h 127.0.0.1 -p 5432"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
+    restart: unless-stopped
+
+  # GeoServer in production is always pulled from GHCR; no local submodule build is used here.
+  geoserver:
+    image: ghcr.io/digitalcityscience/tosca-geoserver:latest
+    pull_policy: always
+    container_name: tosca-geoserver-prod
+    env_file:
+      - ${ENV_FILE}
+    environment:
+      GEOSERVER_DATA_DIR: ${GEOSERVER_DATA_DIR:-/geoserver_data/data}
+      GEOSERVER_ADMIN_USER: ${GEOSERVER_ADMIN_USER}
+      GEOSERVER_ADMIN_PASSWORD: ${GEOSERVER_ADMIN_PASSWORD}
+      GEOSERVER_DB_HOST: db
+      GEOSERVER_DB_PORT: 5432
+      GEOSERVER_DB_NAME: ${PG_DATABASE}
+      GEOSERVER_DB_USER: ${PG_GS_USER}
+      GEOSERVER_DB_PASSWORD: ${PG_GS_PASSWORD}
+      GEOSERVER_DB_SCHEMA: ${PG_SCHEMA_GEOSERVER}
+    ports:
+      - "${GEOSERVER_HOST_PORT:-8585}:8080"
+    volumes:
+      # Persistent GeoServer data directory used by the published production image.
+      - geoserver_data:/geoserver_data/data
+    depends_on:
+      db:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:8080/geoserver/web"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 60s
+    restart: unless-stopped
+
+  # Django API backend. It writes uploads to /app/media and collectstatic output to /app/staticfiles.
+  django:
+    build:
+      context: .
+      dockerfile: docker/django/Dockerfile.prod
+    image: ${DJANGO_IMAGE:-tosca-django-api:prod}
+    container_name: tosca-django
+    env_file:
+      - ${ENV_FILE}
+    environment:
+      ENV: prod
+      ENV_TYPE: production
+      DJANGO_SETTINGS_MODULE: tosca_api.settings.${ENV_TYPE}
+      DJANGO_SECRET_KEY: ${DJANGO_SECRET_KEY}
+      FIELD_ENCRYPTION_KEY: ${FIELD_ENCRYPTION_KEY}
+      DJANGO_DEBUG: ${DJANGO_DEBUG}
+      DJANGO_ALLOWED_HOSTS: ${DJANGO_ALLOWED_HOSTS}
+      DJANGO_CORS_ALLOWED_ORIGINS: ${DJANGO_CORS_ALLOWED_ORIGINS}
+      DJANGO_CORS_ALLOW_CREDENTIALS: ${DJANGO_CORS_ALLOW_CREDENTIALS:-true}
+      DJANGO_HEALTHCHECK_HOST: ${DJANGO_HEALTHCHECK_HOST:-localhost}
+      DATABASE_URL: postgresql://${PG_API_USER}:${PG_API_PASSWORD}@db:5432/${PG_DATABASE}
+      PG_HOST: db
+      PG_DATABASE: ${PG_DATABASE}
+      PG_API_USER: ${PG_API_USER}
+      PG_API_PASSWORD: ${PG_API_PASSWORD}
+      PG_DOCKER_PORT: 5432
+      PG_SCHEMA_API: ${PG_SCHEMA_API}
+      PG_SCHEMA_GIS: ${PG_SCHEMA_GIS}
+      DJANGO_STATIC_URL: /static/
+      DJANGO_STATIC_ROOT: /app/staticfiles
+      DJANGO_MEDIA_URL: /media/
+      DJANGO_MEDIA_ROOT: /app/media
+      INTERNAL_API_BASE_URL: ${INTERNAL_API_BASE_URL:-http://localhost:8000/api/v1/providers/provider}
+      KEYCLOAK_SERVER_URL: ${KEYCLOAK_SERVER_URL}
+      KEYCLOAK_REALM: ${KEYCLOAK_REALM}
+      KEYCLOAK_CLIENT_ID: ${KEYCLOAK_CLIENT_ID}
+      KEYCLOAK_CLIENT_SECRET: ${KEYCLOAK_CLIENT_SECRET}
+      KEYCLOAK_JWKS_URL: ${KEYCLOAK_JWKS_URL}
+      KEYCLOAK_ISSUER: ${KEYCLOAK_ISSUER}
+      ALLOWED_TOKEN_AUDIENCES: ${ALLOWED_TOKEN_AUDIENCES}
+      ALLOWED_TOKEN_CLIENTS: ${ALLOWED_TOKEN_CLIENTS}
+      GEOSERVER_HOST: ${GEOSERVER_HOST}
+      GEOSERVER_PORT: ${GEOSERVER_PORT}
+      GEOSERVER_ADMIN_USER: ${GEOSERVER_ADMIN_USER}
+      GEOSERVER_ADMIN_PASSWORD: ${GEOSERVER_ADMIN_PASSWORD}
+      GUNICORN_WORKERS: ${GUNICORN_WORKERS:-3}
+      GUNICORN_THREADS: ${GUNICORN_THREADS:-2}
+      GUNICORN_TIMEOUT: ${GUNICORN_TIMEOUT:-120}
+      RUN_SETUP_DEFAULT_ENGINE: ${RUN_SETUP_DEFAULT_ENGINE:-true}
+    volumes:
+      # Shared upload volume. Django writes files here; Nginx/web containers serve them read-only.
+      - media_files:/app/media
+      # Shared collectstatic volume. Django writes collectstatic output here; Nginx/web containers serve it read-only.
+      - static_files:/app/staticfiles
+      # Persist Django log files independently from the application image.
+      - prod_django_logs:/app/logs
+    ports:
+      - "${DJANGO_PORT}:8000"
+    depends_on:
+      db:
+        condition: service_healthy
+      geoserver:
+        condition: service_healthy
+    entrypoint: bash docker/django/entrypoint.prod.sh
+    command: >
+      uv run gunicorn
+      --bind 0.0.0.0:8000
+      --workers ${GUNICORN_WORKERS:-3}
+      --threads ${GUNICORN_THREADS:-2}
+      --timeout ${GUNICORN_TIMEOUT:-120}
+      tosca_api.wsgi:application
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS -H \"Host: $${DJANGO_HEALTHCHECK_HOST:-localhost}\" http://127.0.0.1:8000/ >/dev/null"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 60s
+    restart: unless-stopped
+
+  # SPA web container. Use WEB_IMAGE for a production image that already contains the built SPA.
+  # It also mounts the shared media/static volumes so a same-host SPA can serve returned URLs directly.
+  web:
+    image: ${WEB_IMAGE:-nginx:1.27-alpine}
+    container_name: tosca-prod-web
+    environment:
+      NGINX_ENTRYPOINT_QUIET_LOGS: "1"
+    volumes:
+      # SPA Nginx config with /media and /static aliases.
+      - ./docker/web/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+      # Shared upload volume mounted read-only for browser access at /media/...
+      - media_files:/usr/share/nginx/media:ro
+      # Shared collectstatic volume mounted read-only for browser access at /static/...
+      - static_files:/usr/share/nginx/staticfiles:ro
+    depends_on:
+      django:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://127.0.0.1/healthz"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    restart: unless-stopped
+
+  # Public Nginx reverse proxy. It terminates the single public HTTP entry point.
+  nginx:
+    image: nginx:1.27-alpine
+    container_name: tosca-prod-nginx
+    ports:
+      - "${NGINX_HTTP_PORT:-80}:80"
+    environment:
+      NGINX_ENTRYPOINT_QUIET_LOGS: "1"
+    volumes:
+      # Reverse proxy config for API/admin/web plus /media and /static aliases.
+      - ./docker/nginx/prod.conf:/etc/nginx/conf.d/default.conf:ro
+      # Shared upload volume mounted read-only and served at /media/...
+      - media_files:/usr/share/nginx/media:ro
+      # Shared collectstatic volume mounted read-only and served at /static/...
+      - static_files:/usr/share/nginx/staticfiles:ro
+    depends_on:
+      django:
+        condition: service_healthy
+      web:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://127.0.0.1/healthz"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    restart: unless-stopped
+
+volumes:
+  # PostgreSQL persistent data volume.
+  prod_pg_data:
+  # GeoServer persistent data volume for the GHCR production image.
+  geoserver_data:
+  # User-uploaded media shared between Django and Nginx/web containers.
+  media_files:
+  # Django collectstatic output shared between Django and Nginx/web containers.
+  static_files:
+  # Django production logs.
+  prod_django_logs:

--- a/docker/django/entrypoint.prod.sh
+++ b/docker/django/entrypoint.prod.sh
@@ -6,8 +6,8 @@ cd /app
 APP_USER="appuser"
 APP_GROUP="appuser"
 
-mkdir -p /app/staticfiles /app/logs
-chown -R "${APP_USER}:${APP_GROUP}" /app/staticfiles /app/logs /venv
+mkdir -p /app/media /app/staticfiles /app/logs
+chown -R "${APP_USER}:${APP_GROUP}" /app/media /app/staticfiles /app/logs /venv
 
 run_as_appuser() {
   gosu "${APP_USER}:${APP_GROUP}" "$@"

--- a/docker/nginx/prod.conf
+++ b/docker/nginx/prod.conf
@@ -1,0 +1,85 @@
+upstream django_backend {
+    server django:8000;
+}
+
+upstream spa_web {
+    server web:80;
+}
+
+upstream geoserver_backend {
+    server geoserver:8080;
+}
+
+server {
+    listen 80;
+    server_name _;
+
+    client_max_body_size 100m;
+
+    location = /healthz {
+        access_log off;
+        add_header Content-Type text/plain;
+        return 200 "ok\n";
+    }
+
+    location /media/ {
+        alias /usr/share/nginx/media/;
+        access_log off;
+        expires 30d;
+        add_header Cache-Control "public, max-age=2592000";
+        try_files $uri =404;
+    }
+
+    location /static/ {
+        alias /usr/share/nginx/staticfiles/;
+        access_log off;
+        expires 30d;
+        add_header Cache-Control "public, max-age=2592000, immutable";
+        try_files $uri =404;
+    }
+
+    location /api/ {
+        proxy_pass http://django_backend;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /admin/ {
+        proxy_pass http://django_backend;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /accounts/ {
+        proxy_pass http://django_backend;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /geoserver/ {
+        proxy_pass http://geoserver_backend/geoserver/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location / {
+        proxy_pass http://spa_web;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/docker/web/nginx.conf
+++ b/docker/web/nginx.conf
@@ -1,0 +1,33 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location = /healthz {
+        access_log off;
+        add_header Content-Type text/plain;
+        return 200 "ok\n";
+    }
+
+    location /media/ {
+        alias /usr/share/nginx/media/;
+        access_log off;
+        expires 30d;
+        add_header Cache-Control "public, max-age=2592000";
+        try_files $uri =404;
+    }
+
+    location /static/ {
+        alias /usr/share/nginx/staticfiles/;
+        access_log off;
+        expires 30d;
+        add_header Cache-Control "public, max-age=2592000, immutable";
+        try_files $uri =404;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/tosca_api/settings/base.py
+++ b/tosca_api/settings/base.py
@@ -167,10 +167,10 @@ USE_I18N = True
 USE_TZ = True
 
 STATICFILES_DIRS = [ROOT_DIR / "static"]
-STATIC_URL = "static/"
-STATIC_ROOT = ROOT_DIR / "staticfiles"
-MEDIA_URL = "/media/"
-MEDIA_ROOT = ROOT_DIR / "media"
+STATIC_URL = env("DJANGO_STATIC_URL", default="/static/")
+STATIC_ROOT = Path(env("DJANGO_STATIC_ROOT", default=os.fspath(ROOT_DIR / "staticfiles")))
+MEDIA_URL = env("DJANGO_MEDIA_URL", default="/media/")
+MEDIA_ROOT = Path(env("DJANGO_MEDIA_ROOT", default=os.fspath(ROOT_DIR / "media")))
 
 # Soft cap; remove or relax once UX validates.
 GEOCONTEXT_MAX_INLINE_IMAGES = 5
@@ -272,8 +272,14 @@ KEYCLOAK_JWKS_URL = env("KEYCLOAK_JWKS_URL", default=f"{KEYCLOAK_SERVER_URL}real
 KEYCLOAK_ISSUER = env("KEYCLOAK_ISSUER", default=f"{KEYCLOAK_SERVER_URL}realms/{KEYCLOAK_REALM}")
 
 # Allow tokens from multiple clients (geoserver, tosca-web, mobile-app)
-ALLOWED_TOKEN_AUDIENCES = ["django-dev", "geoserver", "account"]
-ALLOWED_TOKEN_CLIENTS = ["django-dev", "geoserver", "tosca-web"]
+ALLOWED_TOKEN_AUDIENCES = env.list(
+    "ALLOWED_TOKEN_AUDIENCES",
+    default=["django-dev", "geoserver", "account"],
+)
+ALLOWED_TOKEN_CLIENTS = env.list(
+    "ALLOWED_TOKEN_CLIENTS",
+    default=["django-dev", "geoserver", "tosca-web"],
+)
 
 SOCIALACCOUNT_PROVIDERS = {
     "openid_connect": {

--- a/uv.lock
+++ b/uv.lock
@@ -468,6 +468,18 @@ wheels = [
 ]
 
 [[package]]
+name = "gunicorn"
+version = "26.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/b7/a4a3f632f823e432ce6bc65f62961b7980c898c77f075a2f7118cb3846fe/gunicorn-26.0.0.tar.gz", hash = "sha256:ca9346f85e3a4aeeb64d491045c16b9a35647abd37ea15efe53080eb8b090baf", size = 727286, upload-time = "2026-05-05T06:38:25.529Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/40/9c2384fc2be4ad25dd4a49decd5ad9ea5a3639814c11bd40ab77cb9f0a14/gunicorn-26.0.0-py3-none-any.whl", hash = "sha256:40233d26a5f0d1872916188c276e21641155111c2853f0c2cd55260aec0d24fc", size = 212009, upload-time = "2026-05-05T06:38:23.007Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1221,6 +1233,7 @@ dependencies = [
     { name = "djangorestframework-gis" },
     { name = "drf-spectacular" },
     { name = "geoserver-rest" },
+    { name = "gunicorn" },
     { name = "nh3" },
     { name = "pillow" },
     { name = "psycopg", extra = ["binary"] },
@@ -1230,6 +1243,7 @@ dependencies = [
     { name = "requests" },
     { name = "ruff" },
     { name = "sqlalchemy" },
+    { name = "whitenoise" },
     { name = "xmltodict" },
 ]
 
@@ -1261,6 +1275,7 @@ requires-dist = [
     { name = "djangorestframework-gis", specifier = ">=1.2.0" },
     { name = "drf-spectacular", specifier = ">=0.29.0" },
     { name = "geoserver-rest", editable = "tosca_api/apps/geodata_providers/geoserver/geoserver-rest" },
+    { name = "gunicorn", specifier = ">=22.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11.0" },
     { name = "nh3", specifier = ">=0.3.2" },
     { name = "pillow", specifier = ">=10.0.0" },
@@ -1274,6 +1289,7 @@ requires-dist = [
     { name = "ruff", specifier = ">=0.14.7" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.5.0" },
     { name = "sqlalchemy", specifier = ">=2.0" },
+    { name = "whitenoise", specifier = ">=6.7.0" },
     { name = "xmltodict", specifier = ">=1.0.2" },
 ]
 provides-extras = ["dev"]
@@ -1319,6 +1335,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "whitenoise"
+version = "6.12.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cb/2a/55b3f3a4ec326cd077c1c3defeee656b9298372a69229134d930151acd01/whitenoise-6.12.0.tar.gz", hash = "sha256:f723ebb76a112e98816ff80fcea0a6c9b8ecde835f8ddda25df7a30a3c2db6ad", size = 26841, upload-time = "2026-02-27T00:05:42.028Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/eb/d5583a11486211f3ebd4b385545ae787f32363d453c19fffd81106c9c138/whitenoise-6.12.0-py3-none-any.whl", hash = "sha256:fc5e8c572e33ebf24795b47b6a7da8da3c00cff2349f5b04c02f28d0cc5a3cc2", size = 20302, upload-time = "2026-02-27T00:05:40.086Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add production compose media static serving

- Add docker-compose-prod.yml for production db, GeoServer, Django, SPA web, and Nginx services
- Pull GeoServer from ghcr.io/digitalcityscience/tosca-geoserver:latest with pull_policy always
- Share media_files and static_files volumes between Django and Nginx-based containers
- Serve /media/ and /static/ from Nginx alias paths backed by shared volumes
- Add production Nginx reverse proxy config for API, admin, accounts, GeoServer, SPA, media, and static routes
- Add SPA web Nginx config with media/static aliases and healthcheck endpoint
- Make Django STATIC_ROOT, MEDIA_ROOT, STATIC_URL, and MEDIA_URL configurable via environment
- Prepare /app/media and /app/staticfiles permissions in the production Django entrypoint
- Read token audiences and clients from environment for production Keycloak integration
- Document SPA media/static integration scenarios and FAQ in README