### PR TITLE
Open events API to anonymous readers, gate by status and visibility

### DIFF
--- a/tosca_api/apps/events/tests/test_api.py
+++ b/tosca_api/apps/events/tests/test_api.py
@@ -145,10 +145,10 @@ def draft_event(user, campaign):
 
 
 @pytest.mark.django_db
-def test_events_list_unauthenticated(api_client):
-    """Test that unauthenticated users cannot list events."""
+def test_events_list_unauthenticated_is_public(api_client):
+    """Reads are public; the list endpoint responds with 200 for anonymous clients."""
     response = api_client.get("/api/v1/events/")
-    assert response.status_code == 403
+    assert response.status_code == 200
 
 
 # =============================================================================
@@ -399,7 +399,7 @@ def test_events_list_v2_area_filter_keeps_eligible_online_events(
 
 @pytest.mark.django_db
 def test_events_list_v2_payload_remains_stable_when_no_online_events_match(
-    api_client, user, campaign
+    api_client, user, staff_user, campaign
 ):
     """The dedicated list payload should remain a normal paginated list without online matches."""
     Event.objects.create(
@@ -424,7 +424,7 @@ def test_events_list_v2_payload_remains_stable_when_no_online_events_match(
         visibility=Event.Visibility.PUBLIC,
     )
 
-    api_client.force_authenticate(user=user)
+    api_client.force_authenticate(user=staff_user)
     response = api_client.get(
         "/api/v1/events/list/?bbox=9.5,53.0,10.5,54.0&visibility=private"
     )
@@ -819,7 +819,7 @@ def test_events_within_excludes_past_events_by_default(api_client, user, campaig
 
 
 @pytest.mark.django_db
-def test_events_shared_filters_match_between_list_and_within(api_client, user, campaign):
+def test_events_shared_filters_match_between_list_and_within(api_client, user, staff_user, campaign):
     """List and within endpoints should apply the same non-spatial filter contract."""
     dimension = TaxonomyDimension.objects.create(code="topic", label="Topic")
     climate = TaxonomyTerm.objects.create(
@@ -854,7 +854,7 @@ def test_events_shared_filters_match_between_list_and_within(api_client, user, c
     start_after = (timezone.now() + timedelta(days=1)).isoformat()
     start_before = (timezone.now() + timedelta(days=3)).isoformat()
 
-    api_client.force_authenticate(user=user)
+    api_client.force_authenticate(user=staff_user)
     list_response = api_client.get(
         "/api/v1/events/",
         {
@@ -1057,7 +1057,7 @@ def test_events_retrieve_detail_returns_grouped_taxonomy_assignments(
 
 @pytest.mark.django_db
 def test_event_series_retrieve_returns_grouped_taxonomy_assignments(
-    api_client, user, campaign, event_type
+    api_client, user, staff_user, campaign, event_type
 ):
     """Series retrieve should derive grouped taxonomy assignments from the base occurrence."""
     dimension = TaxonomyDimension.objects.create(code="topic", label="Topic")
@@ -1067,7 +1067,7 @@ def test_event_series_retrieve_returns_grouped_taxonomy_assignments(
         label="Climate",
     )
 
-    api_client.force_authenticate(user=user)
+    api_client.force_authenticate(user=staff_user)
     create_response = api_client.post(
         "/api/v1/event-series/",
         {
@@ -1104,9 +1104,13 @@ def test_event_series_retrieve_returns_grouped_taxonomy_assignments(
 
 @pytest.mark.django_db
 def test_event_series_retrieve_fails_without_base_occurrence_template(
-    api_client, user, campaign, event_type
+    api_client, user, staff_user, campaign, event_type
 ):
-    """Series retrieve should fail clearly when no base occurrence/template exists."""
+    """Series retrieve should fail clearly when no base occurrence/template exists.
+
+    Uses a staff user because empty series are filtered out of the non-staff
+    queryset (no visible occurrence) and would otherwise return 404.
+    """
     series = EventSeries.objects.create(
         **build_series_kwargs(
             user,
@@ -1116,7 +1120,7 @@ def test_event_series_retrieve_fails_without_base_occurrence_template(
         )
     )
 
-    api_client.force_authenticate(user=user)
+    api_client.force_authenticate(user=staff_user)
     response = api_client.get(f"/api/v1/event-series/{series.id}/")
 
     assert response.status_code == 409
@@ -1283,10 +1287,10 @@ def test_event_series_preview_weekly_preserves_wall_time_across_dst(
 
 @pytest.mark.django_db
 def test_events_patch_marks_generated_occurrence_as_exception(
-    api_client, user, campaign, event_type
+    api_client, user, staff_user, campaign, event_type
 ):
     """Editing a generated occurrence directly should mark it as an exception."""
-    api_client.force_authenticate(user=user)
+    api_client.force_authenticate(user=staff_user)
     create_response = api_client.post(
         "/api/v1/event-series/",
         {
@@ -1332,7 +1336,7 @@ def test_events_patch_marks_generated_occurrence_as_exception(
 
 @pytest.mark.django_db
 def test_event_series_patch_skips_future_exception_occurrences_by_default(
-    api_client, user, campaign, event_type
+    api_client, user, staff_user, campaign, event_type
 ):
     """Future bulk updates should leave exception occurrences untouched by default."""
     today = timezone.localdate()
@@ -1341,7 +1345,7 @@ def test_event_series_patch_skips_future_exception_occurrences_by_default(
         days_until_monday = 7
     start_date = today + timedelta(days=days_until_monday)
 
-    api_client.force_authenticate(user=user)
+    api_client.force_authenticate(user=staff_user)
     create_response = api_client.post(
         "/api/v1/event-series/",
         {

--- a/tosca_api/apps/events/tests/test_event_visibility.py
+++ b/tosca_api/apps/events/tests/test_event_visibility.py
@@ -1,0 +1,311 @@
+from datetime import timedelta
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.contrib.gis.geos import Point
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from tosca_api.apps.campaigns.models import Campaign
+from tosca_api.apps.events.models import Event, EventSeries, EventType
+
+User = get_user_model()
+
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+
+@pytest.fixture
+def organizer():
+    return User.objects.create_user(username="vis-organizer", password="pw")
+
+
+@pytest.fixture
+def regular_user():
+    return User.objects.create_user(username="vis-regular", password="pw")
+
+
+@pytest.fixture
+def staff_user():
+    return User.objects.create_user(
+        username="vis-staff", password="pw", is_staff=True
+    )
+
+
+@pytest.fixture
+def campaign(organizer):
+    return Campaign.objects.create(title="Visibility Campaign", created_by=organizer)
+
+
+@pytest.fixture
+def published_public_event(organizer, campaign):
+    return Event.objects.create(
+        campaign=campaign,
+        title="Published Public",
+        start_datetime=timezone.now() + timedelta(days=1),
+        end_datetime=timezone.now() + timedelta(days=1, hours=1),
+        location=Point(10.0, 53.5, srid=4326),
+        organizer=organizer,
+        status=Event.Status.PUBLISHED,
+        visibility=Event.Visibility.PUBLIC,
+    )
+
+
+@pytest.fixture
+def draft_event(organizer, campaign):
+    return Event.objects.create(
+        campaign=campaign,
+        title="Draft Event",
+        start_datetime=timezone.now() + timedelta(days=2),
+        end_datetime=timezone.now() + timedelta(days=2, hours=1),
+        location=Point(10.0, 53.5, srid=4326),
+        organizer=organizer,
+        status=Event.Status.DRAFT,
+        visibility=Event.Visibility.PUBLIC,
+    )
+
+
+@pytest.fixture
+def private_event(organizer, campaign):
+    return Event.objects.create(
+        campaign=campaign,
+        title="Private Event",
+        start_datetime=timezone.now() + timedelta(days=3),
+        end_datetime=timezone.now() + timedelta(days=3, hours=1),
+        location=Point(10.0, 53.5, srid=4326),
+        organizer=organizer,
+        status=Event.Status.PUBLISHED,
+        visibility=Event.Visibility.PRIVATE,
+    )
+
+
+@pytest.fixture
+def cancelled_event(organizer, campaign):
+    return Event.objects.create(
+        campaign=campaign,
+        title="Cancelled Event",
+        start_datetime=timezone.now() + timedelta(days=4),
+        end_datetime=timezone.now() + timedelta(days=4, hours=1),
+        location=Point(10.0, 53.5, srid=4326),
+        organizer=organizer,
+        status=Event.Status.CANCELLED,
+        visibility=Event.Visibility.PUBLIC,
+    )
+
+
+@pytest.mark.django_db
+def test_anon_list_returns_only_published_and_public(
+    api_client, published_public_event, draft_event, private_event, cancelled_event
+):
+    response = api_client.get("/api/v1/events/")
+    assert response.status_code == 200
+    titles = [item["title"] for item in response.data["results"]]
+    assert titles == ["Published Public"]
+
+
+@pytest.mark.django_db
+def test_anon_list_ignores_status_query_override(
+    api_client, draft_event, published_public_event
+):
+    response = api_client.get("/api/v1/events/?status=draft")
+    assert response.status_code == 200
+    titles = [item["title"] for item in response.data["results"]]
+    assert titles == ["Published Public"]
+
+
+@pytest.mark.django_db
+def test_anon_list_ignores_visibility_query_override(
+    api_client, private_event, published_public_event
+):
+    response = api_client.get("/api/v1/events/?visibility=private")
+    assert response.status_code == 200
+    titles = [item["title"] for item in response.data["results"]]
+    assert titles == ["Published Public"]
+
+
+@pytest.mark.django_db
+def test_anon_map_returns_only_published_and_public(
+    api_client, published_public_event, draft_event, private_event
+):
+    response = api_client.get("/api/v1/events/map/")
+    assert response.status_code == 200
+    titles = [f["properties"]["title"] for f in response.data["spatial_events"]["features"]]
+    assert titles == ["Published Public"]
+
+
+@pytest.mark.django_db
+def test_anon_within_returns_only_published_and_public(
+    api_client, published_public_event, draft_event, private_event
+):
+    payload = {
+        "geometry": {
+            "type": "Polygon",
+            "coordinates": [
+                [
+                    [9.0, 53.0],
+                    [11.0, 53.0],
+                    [11.0, 54.0],
+                    [9.0, 54.0],
+                    [9.0, 53.0],
+                ]
+            ],
+        }
+    }
+    response = api_client.post("/api/v1/events/within/", payload, format="json")
+    assert response.status_code == 200
+    titles = [f["properties"]["title"] for f in response.data["features"]]
+    assert titles == ["Published Public"]
+
+
+@pytest.mark.django_db
+def test_anon_retrieve_draft_returns_404(api_client, draft_event):
+    response = api_client.get(f"/api/v1/events/{draft_event.id}/")
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_anon_retrieve_private_returns_404(api_client, private_event):
+    response = api_client.get(f"/api/v1/events/{private_event.id}/")
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_anon_retrieve_published_public_returns_200(
+    api_client, published_public_event
+):
+    response = api_client.get(f"/api/v1/events/{published_public_event.id}/")
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_regular_user_cannot_retrieve_private_event(
+    api_client, regular_user, private_event
+):
+    api_client.force_authenticate(user=regular_user)
+    response = api_client.get(f"/api/v1/events/{private_event.id}/")
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_regular_user_cannot_retrieve_draft_event(
+    api_client, regular_user, draft_event
+):
+    api_client.force_authenticate(user=regular_user)
+    response = api_client.get(f"/api/v1/events/{draft_event.id}/")
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_staff_user_can_retrieve_draft_event(api_client, staff_user, draft_event):
+    api_client.force_authenticate(user=staff_user)
+    response = api_client.get(f"/api/v1/events/{draft_event.id}/")
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_staff_user_can_retrieve_private_event(
+    api_client, staff_user, private_event
+):
+    api_client.force_authenticate(user=staff_user)
+    response = api_client.get(f"/api/v1/events/{private_event.id}/")
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_staff_user_list_includes_draft_and_private(
+    api_client, staff_user, published_public_event, draft_event, private_event
+):
+    api_client.force_authenticate(user=staff_user)
+    response = api_client.get("/api/v1/events/?status=draft&visibility=public")
+    assert response.status_code == 200
+    titles = {item["title"] for item in response.data["results"]}
+    assert titles == {"Draft Event"}
+
+
+@pytest.mark.django_db
+def test_anon_post_returns_403(api_client, campaign):
+    response = api_client.post(
+        "/api/v1/events/",
+        {
+            "title": "x",
+            "campaign": str(campaign.id),
+            "start_datetime": (timezone.now() + timedelta(days=1)).isoformat(),
+            "end_datetime": (timezone.now() + timedelta(days=1, hours=1)).isoformat(),
+        },
+        format="json",
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_anon_patch_returns_403(api_client, published_public_event):
+    response = api_client.patch(
+        f"/api/v1/events/{published_public_event.id}/",
+        {"title": "new"},
+        format="json",
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_anon_delete_returns_403(api_client, published_public_event):
+    response = api_client.delete(f"/api/v1/events/{published_public_event.id}/")
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_anon_cannot_retrieve_series_with_no_visible_occurrences(
+    api_client, organizer, campaign, draft_event
+):
+    event_type = EventType.objects.create(code="vis-series", label="Vis Series")
+    draft_event.event_type = event_type
+    draft_event.save()
+    series = EventSeries.objects.create(
+        campaign=campaign,
+        event_type=event_type,
+        created_by=organizer,
+        name="All-draft series",
+        series_mode=EventSeries.SeriesMode.MANUAL_BATCH,
+        start_date=timezone.now().date(),
+        start_time=timezone.now().time().replace(microsecond=0),
+        end_time=(timezone.now() + timedelta(hours=1))
+        .time()
+        .replace(microsecond=0),
+        timezone="Europe/Berlin",
+    )
+    draft_event.series = series
+    draft_event.occurrence_index = 1
+    draft_event.save()
+
+    response = api_client.get(f"/api/v1/event-series/{series.id}/")
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_anon_can_retrieve_series_with_at_least_one_visible_occurrence(
+    api_client, organizer, campaign, published_public_event
+):
+    event_type = EventType.objects.create(code="vis-series-2", label="Vis Series 2")
+    published_public_event.event_type = event_type
+    published_public_event.save()
+    series = EventSeries.objects.create(
+        campaign=campaign,
+        event_type=event_type,
+        created_by=organizer,
+        name="Visible series",
+        series_mode=EventSeries.SeriesMode.MANUAL_BATCH,
+        start_date=timezone.now().date(),
+        start_time=timezone.now().time().replace(microsecond=0),
+        end_time=(timezone.now() + timedelta(hours=1))
+        .time()
+        .replace(microsecond=0),
+        timezone="Europe/Berlin",
+    )
+    published_public_event.series = series
+    published_public_event.occurrence_index = 1
+    published_public_event.save()
+
+    response = api_client.get(f"/api/v1/event-series/{series.id}/")
+    assert response.status_code == 200

--- a/tosca_api/apps/events/views.py
+++ b/tosca_api/apps/events/views.py
@@ -68,8 +68,31 @@ class EventViewSet(viewsets.ModelViewSet):
     """
 
     queryset = Event.objects.all()
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [permissions.IsAuthenticatedOrReadOnly]
     pagination_class = EventCursorPagination
+
+    def get_permissions(self):
+        if self.action == "within":
+            return [permissions.AllowAny()]
+        return super().get_permissions()
+
+    def _is_admin_reader(self) -> bool:
+        user = self.request.user
+        return bool(user and user.is_authenticated and user.is_staff)
+
+    def _apply_visibility_scope(self, queryset):
+        if self._is_admin_reader():
+            return queryset
+        return queryset.filter(
+            status=Event.Status.PUBLISHED,
+            visibility=Event.Visibility.PUBLIC,
+        )
+
+    def _coerce_public_filters(self, filters: dict) -> dict:
+        if not self._is_admin_reader():
+            filters["status"] = Event.Status.PUBLISHED
+            filters["visibility"] = Event.Visibility.PUBLIC
+        return filters
 
     def get_serializer_class(self):
         """Return appropriate serializer based on action and request."""
@@ -101,13 +124,14 @@ class EventViewSet(viewsets.ModelViewSet):
         - Status filtering
         - Campaign filtering
         """
-        queryset = super().get_queryset()
+        queryset = self._apply_visibility_scope(super().get_queryset())
 
         if self.action in ("list", "list_v2"):
             bbox_serializer = BBoxSerializer(data=self.request.query_params)
             bbox_serializer.is_valid(raise_exception=True)
             validated_filters = dict(bbox_serializer.validated_data)
             validated_filters["spatial_geometry"] = validated_filters.pop("bbox", None)
+            validated_filters = self._coerce_public_filters(validated_filters)
 
             queryset = apply_event_filters(queryset, filters=validated_filters)
 
@@ -170,11 +194,14 @@ class EventViewSet(viewsets.ModelViewSet):
         bbox_serializer.is_valid(raise_exception=True)
         filters = dict(bbox_serializer.validated_data)
         filters["spatial_geometry"] = filters.pop("bbox", None)
+        filters = self._coerce_public_filters(filters)
 
-        queryset = apply_event_filters(
-            Event.objects.all().select_related("campaign", "event_type", "series"),
-            filters=filters,
-        ).order_by("start_datetime")
+        base_queryset = self._apply_visibility_scope(
+            Event.objects.all().select_related("campaign", "event_type", "series")
+        )
+        queryset = apply_event_filters(base_queryset, filters=filters).order_by(
+            "start_datetime"
+        )
 
         spatial_queryset = queryset.filter(
             location_mode__in=[Event.LocationMode.PHYSICAL, Event.LocationMode.HYBRID],
@@ -212,8 +239,10 @@ class EventViewSet(viewsets.ModelViewSet):
         filter_serializer.is_valid(raise_exception=True)
         data = dict(filter_serializer.validated_data)
         data["spatial_geometry"] = data.pop("geometry")
+        data = self._coerce_public_filters(data)
 
-        queryset = apply_event_filters(Event.objects.all(), filters=data)
+        base_queryset = self._apply_visibility_scope(Event.objects.all())
+        queryset = apply_event_filters(base_queryset, filters=data)
         queryset = queryset.order_by("start_datetime").select_related(
             "campaign",
             "event_type",
@@ -239,7 +268,17 @@ class EventSeriesViewSet(
         "default_context",
         "created_by",
     )
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [permissions.IsAuthenticatedOrReadOnly]
+
+    def get_queryset(self):
+        queryset = super().get_queryset()
+        user = self.request.user
+        if user and user.is_authenticated and user.is_staff:
+            return queryset
+        return queryset.filter(
+            events__status=Event.Status.PUBLISHED,
+            events__visibility=Event.Visibility.PUBLIC,
+        ).distinct()
 
     def get_serializer_class(self):
         if self.action == "retrieve":


### PR DESCRIPTION
Reads on the events endpoints are now public. Anonymous and non-staff clients see only events with status=published and visibility=public on list, map, within, retrieve, and series retrieve. Staff users keep full access.

The viewsets switch to IsAuthenticatedOrReadOnly (within is opened to AllowAny since it is a POST-with-body read). A shared visibility scope plus a filter-coercion helper run on get_queryset, map, and within so client-supplied status/visibility params cannot widen results. EventSeriesViewSet hides series whose occurrences are all hidden from the requester.

Existing tests covering draft/private/empty-series flows are reauthenticated as staff. New test_event_visibility.py covers anon read scoping, draft/private 404s, staff access, and 403 on anon writes.

## Summary

- [ ] Description of changes
- [ ] Related issue link

## Testing

- [ ] `uv run pytest`
- [ ] Other (describe)
