### PR TITLE
collapse list endpoints onto GET /api/v1/events/

### DIFF
--- a/tosca_api/apps/events/tests/test_api.py
+++ b/tosca_api/apps/events/tests/test_api.py
@@ -317,7 +317,7 @@ def test_events_list_v2_returns_mixed_modes_ordered_by_start_datetime(
     )
 
     api_client.force_authenticate(user=user)
-    response = api_client.get("/api/v1/events/list/")
+    response = api_client.get("/api/v1/events/")
 
     assert response.status_code == 200
     titles = [event["title"] for event in response.data["results"]]
@@ -356,7 +356,7 @@ def test_events_list_v2_paginates_mixed_event_types(api_client, user, campaign):
         Event.objects.create(**kwargs)
 
     api_client.force_authenticate(user=user)
-    response = api_client.get("/api/v1/events/list/")
+    response = api_client.get("/api/v1/events/")
 
     assert response.status_code == 200
     assert len(response.data["results"]) == 20
@@ -364,65 +364,78 @@ def test_events_list_v2_paginates_mixed_event_types(api_client, user, campaign):
 
 
 @pytest.mark.django_db
-def test_events_list_v2_area_filter_keeps_eligible_online_events(
-    api_client, user, campaign
-):
-    """Area-filtered list results should include matching mapped events plus online events."""
+def test_events_list_ignores_bbox_query_param(api_client, user, campaign):
+    """`bbox` on the list endpoint is accepted but does not change the result shape."""
     Event.objects.create(
         campaign=campaign,
         title="Inside Physical Event",
+        summary="Inside",
         start_datetime=timezone.now() + timedelta(days=1),
         end_datetime=timezone.now() + timedelta(days=1, hours=1),
         location=Point(10.0, 53.5, srid=4326),
         organizer=user,
         status=Event.Status.PUBLISHED,
+        provider_phone="+49 89 12345",
     )
     Event.objects.create(
         campaign=campaign,
         title="Outside Physical Event",
+        summary="Outside",
         start_datetime=timezone.now() + timedelta(days=2),
         end_datetime=timezone.now() + timedelta(days=2, hours=1),
         location=Point(13.4, 52.5, srid=4326),
         organizer=user,
         status=Event.Status.PUBLISHED,
+        provider_phone="+49 89 12345",
     )
     Event.objects.create(
         campaign=campaign,
         title="Eligible Online Event",
+        summary="Online",
         start_datetime=timezone.now() + timedelta(days=3),
         end_datetime=timezone.now() + timedelta(days=3, hours=1),
         location_mode=Event.LocationMode.ONLINE,
         online_url="https://example.org/live",
         organizer=user,
         status=Event.Status.PUBLISHED,
+        provider_phone="+49 89 12345",
     )
 
-    api_client.force_authenticate(user=user)
-    response = api_client.get("/api/v1/events/list/?bbox=9.5,53.0,10.5,54.0")
-
+    response = api_client.get("/api/v1/events/?bbox=9.5,53.0,10.5,54.0")
     assert response.status_code == 200
-    titles = [event["title"] for event in response.data["results"]]
-    assert titles == ["Inside Physical Event", "Eligible Online Event"]
+    # Plain paginated JSON, not GeoJSON. bbox is ignored on the list endpoint;
+    # the spatial response lives at /events/map/.
+    assert "results" in response.data
+    assert "features" not in response.data
+    titles = {item["title"] for item in response.data["results"]}
+    assert titles == {
+        "Inside Physical Event",
+        "Outside Physical Event",
+        "Eligible Online Event",
+    }
 
 
 @pytest.mark.django_db
-def test_events_list_v2_payload_remains_stable_when_no_online_events_match(
+def test_events_list_staff_visibility_private_filter(
     api_client, user, staff_user, campaign
 ):
-    """The dedicated list payload should remain a normal paginated list without online matches."""
+    """Staff can narrow the list to private events via the visibility filter."""
     Event.objects.create(
         campaign=campaign,
-        title="Inside Physical Event",
+        title="Private Physical Event",
+        summary="Private",
         start_datetime=timezone.now() + timedelta(days=1),
         end_datetime=timezone.now() + timedelta(days=1, hours=1),
         location=Point(10.0, 53.5, srid=4326),
         organizer=user,
         status=Event.Status.PUBLISHED,
         visibility=Event.Visibility.PRIVATE,
+        provider_phone="+49 89 12345",
     )
     Event.objects.create(
         campaign=campaign,
-        title="Filtered Online Event",
+        title="Public Online Event",
+        summary="Public",
         start_datetime=timezone.now() + timedelta(days=2),
         end_datetime=timezone.now() + timedelta(days=2, hours=1),
         location_mode=Event.LocationMode.ONLINE,
@@ -430,16 +443,14 @@ def test_events_list_v2_payload_remains_stable_when_no_online_events_match(
         organizer=user,
         status=Event.Status.PUBLISHED,
         visibility=Event.Visibility.PUBLIC,
+        provider_phone="+49 89 12345",
     )
 
     api_client.force_authenticate(user=staff_user)
-    response = api_client.get(
-        "/api/v1/events/list/?bbox=9.5,53.0,10.5,54.0&visibility=private"
-    )
-
+    response = api_client.get("/api/v1/events/?visibility=private")
     assert response.status_code == 200
-    assert "results" in response.data
-    assert response.data["results"][0]["title"] == "Inside Physical Event"
+    titles = [item["title"] for item in response.data["results"]]
+    assert titles == ["Private Physical Event"]
 
 
 # =============================================================================
@@ -643,76 +654,8 @@ def test_events_map_v2_empty_spatial_bucket_still_returns_feature_collection(
 
 
 @pytest.mark.django_db
-def test_events_bbox_returns_geojson(api_client, user, future_event):
-    """Test that bbox filter returns GeoJSON format."""
-    api_client.force_authenticate(user=user)
-    response = api_client.get("/api/v1/events/?bbox=9.0,53.0,11.0,54.0")
-    assert response.status_code == 200
-
-    # GeoJSON FeatureCollection structure
-    assert response.data["type"] == "FeatureCollection"
-    assert "features" in response.data
-    assert len(response.data["features"]) >= 1
-
-    feature = response.data["features"][0]
-    assert feature["type"] == "Feature"
-    assert "geometry" in feature
-    assert "properties" in feature
-    assert feature["properties"]["title"] == "Future Event"
-
-
-@pytest.mark.django_db
-def test_events_bbox_keeps_online_events_after_non_spatial_filtering(
-    api_client, user, future_event, event_without_location
-):
-    """Spatial filters should not drop eligible online events."""
-    api_client.force_authenticate(user=user)
-    response = api_client.get("/api/v1/events/?bbox=9.0,53.0,11.0,54.0")
-    assert response.status_code == 200
-
-    titles = [f["properties"]["title"] for f in response.data["features"]]
-    assert "Future Event" in titles
-    assert "No Location Event" in titles
-
-
-@pytest.mark.django_db
-def test_events_bbox_excludes_events_outside_bbox(api_client, user, campaign):
-    """Test that bbox filter excludes events outside the bounding box."""
-    # Create event in Hamburg
-    Event.objects.create(
-        campaign=campaign,
-        title="Hamburg Event",
-        start_datetime=timezone.now() + timedelta(days=1),
-        end_datetime=timezone.now() + timedelta(days=1, hours=1),
-        location=Point(10.0, 53.5, srid=4326),
-        organizer=user,
-        status=Event.Status.PUBLISHED,
-    )
-
-    # Create event in Berlin (outside Hamburg bbox)
-    Event.objects.create(
-        campaign=campaign,
-        title="Berlin Event",
-        start_datetime=timezone.now() + timedelta(days=1),
-        end_datetime=timezone.now() + timedelta(days=1, hours=1),
-        location=Point(13.4, 52.5, srid=4326),  # Berlin
-        organizer=user,
-        status=Event.Status.PUBLISHED,
-    )
-
-    api_client.force_authenticate(user=user)
-    # Hamburg area bbox
-    response = api_client.get("/api/v1/events/?bbox=9.5,53.0,10.5,54.0")
-    assert response.status_code == 200
-
-    titles = [f["properties"]["title"] for f in response.data["features"]]
-    assert "Hamburg Event" in titles
-    assert "Berlin Event" not in titles
-
-
-@pytest.mark.django_db
-def test_events_bbox_invalid_format(api_client, user):
-    """Test that invalid bbox returns 400."""
+def test_events_list_invalid_bbox_format(api_client, user):
+    """Even though bbox is ignored on the list endpoint, malformed values still 400."""
     api_client.force_authenticate(user=user)
     response = api_client.get("/api/v1/events/?bbox=invalid")
     assert response.status_code == 400
@@ -902,33 +845,6 @@ def test_events_shared_filters_match_between_list_and_within(api_client, user, s
     within_titles = [feature["properties"]["title"] for feature in within_response.data["features"]]
     assert list_titles == ["Matching Event"]
     assert within_titles == ["Matching Event"]
-
-
-@pytest.mark.django_db
-def test_events_bbox_non_spatial_filters_remove_non_matching_online_events(
-    api_client, user, campaign
-):
-    """Online events should still be removed when they fail non-spatial filters."""
-    Event.objects.create(
-        campaign=campaign,
-        title="Private Online Event",
-        start_datetime=timezone.now() + timedelta(days=1),
-        end_datetime=timezone.now() + timedelta(days=1, hours=1),
-        location_mode=Event.LocationMode.ONLINE,
-        online_url="https://example.org/live",
-        organizer=user,
-        status=Event.Status.PUBLISHED,
-        visibility=Event.Visibility.PRIVATE,
-    )
-
-    api_client.force_authenticate(user=user)
-    response = api_client.get(
-        "/api/v1/events/?bbox=9.0,53.0,11.0,54.0&visibility=public"
-    )
-
-    assert response.status_code == 200
-    titles = [feature["properties"]["title"] for feature in response.data["features"]]
-    assert "Private Online Event" not in titles
 
 
 @pytest.mark.django_db

--- a/tosca_api/apps/events/views.py
+++ b/tosca_api/apps/events/views.py
@@ -33,38 +33,34 @@ class EventViewSet(viewsets.ModelViewSet):
     """
     API endpoint for Event operations.
 
-    ## List Endpoints
+    ## Read Endpoints
 
-    ### Calendar View (default)
+    ### Calendar / chronological list
     ```
     GET /api/v1/events/
+    GET /api/v1/events/?campaign_id=<uuid>&start_after=<...>&start_before=<...>
     ```
-    Returns all events (with or without location) as JSON.
-    By default, only future events are returned.
+    Always paginated JSON ordered by start_datetime. Accepts the shared
+    filter contract documented in BBoxSerializer (campaign_id, event_type_id,
+    dimension_id, term_id, include_past, start_after, start_before, status,
+    visibility). The `bbox` parameter is ignored here; use `/events/map/`
+    for the spatial response.
 
-    **Query Parameters:**
-    - `campaign_id`: Filter by campaign UUID
-    - `include_past`: Set to `true` to include past events (default: false)
-    - `start_after`: Filter events starting after this datetime
-    - `start_before`: Filter events starting before this datetime
-    - `status`: Filter by status (default: published)
-
-    ### Map View (bbox)
+    ### Map response
     ```
-    GET /api/v1/events/?bbox=min_lon,min_lat,max_lon,max_lat
+    GET /api/v1/events/map/?bbox=min_lon,min_lat,max_lon,max_lat
     ```
-    Returns events WITH location inside bounding box as GeoJSON FeatureCollection.
+    Returns `{spatial_events: FeatureCollection, online_events: [...]}`.
+    Spatial bucket contains mapped physical/hybrid events; online bucket
+    contains online, by_arrangement, and home_visit events.
 
-    ### Map View (polygon) - POST
+    ### Polygon filter
     ```
     POST /api/v1/events/within/
-    {
-        "geometry": {GeoJSON Polygon/MultiPolygon},
-        "campaign_id": "uuid",
-        "include_past": false
-    }
+    { "geometry": {GeoJSON Polygon/MultiPolygon}, ... }
     ```
-    Returns events WITH location inside geometry as GeoJSON FeatureCollection.
+    Returns events whose geometry is inside the supplied polygon as a
+    GeoJSON FeatureCollection.
     """
 
     queryset = Event.objects.all()
@@ -95,13 +91,7 @@ class EventViewSet(viewsets.ModelViewSet):
         return filters
 
     def get_serializer_class(self):
-        """Return appropriate serializer based on action and request."""
         if self.action == "list":
-            # Check if spatial filter is applied
-            if self._is_spatial_request():
-                return EventGeoSerializer
-            return EventListSerializer
-        if self.action == "list_v2":
             return EventListSerializer
         if self.action == "map_v2":
             return EventMapOnlineSerializer
@@ -111,31 +101,21 @@ class EventViewSet(viewsets.ModelViewSet):
             return EventGeoSerializer
         return EventWriteSerializer
 
-    def _is_spatial_request(self) -> bool:
-        """Check if request has bbox parameter."""
-        return bool(self.request.query_params.get("bbox"))
-
     def get_queryset(self):
-        """
-        Filter queryset based on request parameters.
-
-        - Default: Only upcoming events (start_datetime >= now)
-        - Spatial requests (bbox): Only events with location
-        - Status filtering
-        - Campaign filtering
-        """
         queryset = self._apply_visibility_scope(super().get_queryset())
 
-        if self.action in ("list", "list_v2"):
+        if self.action == "list":
             bbox_serializer = BBoxSerializer(data=self.request.query_params)
             bbox_serializer.is_valid(raise_exception=True)
             validated_filters = dict(bbox_serializer.validated_data)
-            validated_filters["spatial_geometry"] = validated_filters.pop("bbox", None)
+            # bbox is accepted on /events/map/ only; ignore it here so list
+            # results never silently change shape based on query params.
+            validated_filters.pop("bbox", None)
+            validated_filters["spatial_geometry"] = None
             validated_filters = self._coerce_public_filters(validated_filters)
 
             queryset = apply_event_filters(queryset, filters=validated_filters)
 
-        # Optimize queries
         if self.action == "retrieve":
             queryset = queryset.select_related(
                 "context",
@@ -155,35 +135,6 @@ class EventViewSet(viewsets.ModelViewSet):
     def perform_create(self, serializer):
         """Set the organizer to the current user."""
         serializer.save(organizer=self.request.user)
-
-    def list(self, request, *args, **kwargs):
-        """
-        Override list to return GeoJSON FeatureCollection for spatial requests.
-        Non-spatial requests use standard paginated response.
-        """
-        if self._is_spatial_request():
-            queryset = self.filter_queryset(self.get_queryset()).order_by("start_datetime")
-            serializer = self.get_serializer(queryset, many=True)
-            return Response(serializer.data)
-        return super().list(request, *args, **kwargs)
-
-    @action(detail=False, methods=["get"], url_path="list")
-    def list_v2(self, request):
-        """
-        Return a paginated chronological mixed stream of events.
-
-        This endpoint keeps list responses in JSON form even when spatial
-        filters are supplied, unlike the legacy `/events/` route which still
-        switches to GeoJSON for bbox requests.
-        """
-        queryset = self.filter_queryset(self.get_queryset()).order_by("start_datetime")
-        page = self.paginate_queryset(queryset)
-        if page is not None:
-            serializer = self.get_serializer(page, many=True)
-            return self.get_paginated_response(serializer.data)
-
-        serializer = self.get_serializer(queryset, many=True)
-        return Response(serializer.data)
 
     @action(detail=False, methods=["get"], url_path="map")
     def map_v2(self, request):


### PR DESCRIPTION
Removes the bbox shape-switch on bare GET /api/v1/events/ and deletes the /events/list/ action. The chronological JSON list now lives at GET /api/v1/events/, and /events/map/ remains the only endpoint that returns the spatial split. Both accept the same query parameters so the frontend can drive a synced list+map view from one filter state.

bbox is still parsed on the list endpoint so malformed values keep returning 400, but it is popped before applying filters; the response shape never depends on query params. The spatial response lives at /events/map/.

Tests: removed the four bbox-on-list assertions that asserted GeoJSON shape; renamed the two retained list_v2 cases to /events/; replaced the area-filter/payload-stable cases with a new pair that asserts bbox is ignored and that staff can still narrow by visibility=private.

## Summary

- [ ] Description of changes
- [ ] Related issue link

## Testing

- [ ] `uv run pytest`
- [ ] Other (describe)
