### PR TITLE
embed rich series navigation in event responses

### DIFF
--- a/tosca_api/apps/events/serializers.py
+++ b/tosca_api/apps/events/serializers.py
@@ -32,6 +32,7 @@ from .services import (
     orchestrate_series_create,
     orchestrate_series_update,
     persist_explicit_dates,
+    resolve_series_navigation,
     resolve_taxonomy_assignments,
     serialize_occurrence_events,
     validate_publish_requirements,
@@ -126,6 +127,10 @@ class EventListSerializer(serializers.ModelSerializer):
     Used when no spatial filtering is applied.
     """
 
+    series_id = serializers.UUIDField(source="series.id", read_only=True, allow_null=True)
+    series_name = serializers.CharField(source="series.name", read_only=True, default="")
+    total_occurrences = serializers.SerializerMethodField()
+
     class Meta:
         model = Event
         fields = [
@@ -139,9 +144,22 @@ class EventListSerializer(serializers.ModelSerializer):
             "location_mode",
             "status",
             "visibility",
+            "series_id",
+            "series_name",
+            "occurrence_index",
+            "total_occurrences",
+            "is_exception",
             "created_at",
         ]
         read_only_fields = fields
+
+    def get_total_occurrences(self, obj) -> int | None:
+        if obj.series_id is None:
+            return None
+        annotated = getattr(obj, "series_total_occurrences", None)
+        if annotated is not None:
+            return annotated
+        return obj.series.events.count() if obj.series_id else None
 
 
 class EventDetailSerializer(serializers.ModelSerializer):
@@ -153,6 +171,7 @@ class EventDetailSerializer(serializers.ModelSerializer):
     context = serializers.SerializerMethodField()
     layers = serializers.SerializerMethodField()
     taxonomy_assignments = serializers.SerializerMethodField()
+    series = serializers.SerializerMethodField()
 
     class Meta:
         model = Event
@@ -182,9 +201,6 @@ class EventDetailSerializer(serializers.ModelSerializer):
             "lead_name",
             "external_url",
             "series",
-            "occurrence_index",
-            "is_exception",
-            "original_start_datetime",
             "status",
             "visibility",
             "organizer",
@@ -195,6 +211,9 @@ class EventDetailSerializer(serializers.ModelSerializer):
             "updated_at",
         ]
         read_only_fields = fields
+
+    def get_series(self, obj):
+        return resolve_series_navigation(obj)
 
     def get_layers(self, obj) -> list:
         """Return layers ordered by display_order with full Layer summary."""
@@ -221,6 +240,10 @@ class EventGeoSerializer(GeoFeatureModelSerializer):
     Returns events as GeoJSON FeatureCollection.
     """
 
+    series_id = serializers.UUIDField(source="series.id", read_only=True, allow_null=True)
+    series_name = serializers.CharField(source="series.name", read_only=True, default="")
+    total_occurrences = serializers.SerializerMethodField()
+
     class Meta:
         model = Event
         geo_field = "location"
@@ -235,12 +258,29 @@ class EventGeoSerializer(GeoFeatureModelSerializer):
             "location_mode",
             "status",
             "visibility",
+            "series_id",
+            "series_name",
+            "occurrence_index",
+            "total_occurrences",
+            "is_exception",
         ]
         read_only_fields = fields
+
+    def get_total_occurrences(self, obj) -> int | None:
+        if obj.series_id is None:
+            return None
+        annotated = getattr(obj, "series_total_occurrences", None)
+        if annotated is not None:
+            return annotated
+        return obj.series.events.count() if obj.series_id else None
 
 
 class EventMapOnlineSerializer(serializers.ModelSerializer):
     """Serializer for online events returned in the dedicated map endpoint."""
+
+    series_id = serializers.UUIDField(source="series.id", read_only=True, allow_null=True)
+    series_name = serializers.CharField(source="series.name", read_only=True, default="")
+    total_occurrences = serializers.SerializerMethodField()
 
     class Meta:
         model = Event
@@ -257,8 +297,21 @@ class EventMapOnlineSerializer(serializers.ModelSerializer):
             "online_platform",
             "status",
             "visibility",
+            "series_id",
+            "series_name",
+            "occurrence_index",
+            "total_occurrences",
+            "is_exception",
         ]
         read_only_fields = fields
+
+    def get_total_occurrences(self, obj) -> int | None:
+        if obj.series_id is None:
+            return None
+        annotated = getattr(obj, "series_total_occurrences", None)
+        if annotated is not None:
+            return annotated
+        return obj.series.events.count() if obj.series_id else None
 
 
 class TaxonomyAssignmentSerializer(serializers.Serializer):

--- a/tosca_api/apps/events/services.py
+++ b/tosca_api/apps/events/services.py
@@ -638,6 +638,58 @@ def _can_continue(existing_dates: list[date], candidate: date, series: EventSeri
 # =============================================================================
 
 
+def resolve_series_navigation(event: Event) -> dict | None:
+    """Return the rich series widget payload for an event detail response.
+
+    Returns None for standalone events. Result is cached on the instance
+    (``event._series_nav``) so list/detail rendering does not re-query the
+    sibling occurrences once it has been resolved.
+    """
+    if not event.series_id:
+        return None
+
+    cached = getattr(event, "_series_nav", None)
+    if cached is not None:
+        return cached
+
+    series = event.series
+    siblings = list(
+        series.events.only(
+            "id",
+            "occurrence_index",
+            "start_datetime",
+        ).order_by("occurrence_index", "start_datetime")
+    )
+
+    previous_occurrence = None
+    next_occurrence = None
+    for sibling in siblings:
+        if sibling.occurrence_index is None or event.occurrence_index is None:
+            continue
+        if sibling.occurrence_index < event.occurrence_index:
+            previous_occurrence = sibling
+        elif sibling.occurrence_index > event.occurrence_index and next_occurrence is None:
+            next_occurrence = sibling
+
+    def _ref(sibling: Event | None) -> dict | None:
+        if sibling is None:
+            return None
+        return {"id": str(sibling.id), "start_datetime": sibling.start_datetime}
+
+    payload = {
+        "id": str(series.id),
+        "name": series.name,
+        "occurrence_index": event.occurrence_index,
+        "total_occurrences": len(siblings),
+        "is_exception": event.is_exception,
+        "original_start_datetime": event.original_start_datetime,
+        "previous_occurrence": _ref(previous_occurrence),
+        "next_occurrence": _ref(next_occurrence),
+    }
+    event._series_nav = payload
+    return payload
+
+
 def get_base_template_event(series: EventSeries) -> Event | None:
     """Return the first non-exception occurrence to use as a template for updates.
 

--- a/tosca_api/apps/events/tests/test_phase5_series_navigation.py
+++ b/tosca_api/apps/events/tests/test_phase5_series_navigation.py
@@ -1,0 +1,234 @@
+from datetime import timedelta
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.contrib.gis.geos import Point
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from tosca_api.apps.campaigns.models import Campaign
+from tosca_api.apps.events.models import Event, EventSeries, EventType
+
+User = get_user_model()
+
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+
+@pytest.fixture
+def organizer():
+    return User.objects.create_user(username="phase5", password="pw")
+
+
+@pytest.fixture
+def campaign(organizer):
+    return Campaign.objects.create(title="Phase 5", created_by=organizer)
+
+
+@pytest.fixture
+def event_type():
+    return EventType.objects.create(code="phase5-core", label="Phase 5 Core")
+
+
+@pytest.fixture
+def series(organizer, campaign, event_type):
+    return EventSeries.objects.create(
+        campaign=campaign,
+        event_type=event_type,
+        created_by=organizer,
+        name="Phase 5 Series",
+        series_mode=EventSeries.SeriesMode.MANUAL_BATCH,
+        start_date=timezone.now().date(),
+        start_time=timezone.now().replace(hour=10, minute=0, microsecond=0).time(),
+        end_time=timezone.now().replace(hour=11, minute=0, microsecond=0).time(),
+        timezone="Europe/Berlin",
+    )
+
+
+def _make_occurrence(organizer, campaign, event_type, series, index: int, **overrides):
+    base = timezone.now() + timedelta(days=index)
+    defaults = {
+        "campaign": campaign,
+        "event_type": event_type,
+        "title": f"Occurrence {index}",
+        "summary": f"Occurrence {index} summary",
+        "start_datetime": base,
+        "end_datetime": base + timedelta(hours=1),
+        "location": Point(10.0, 53.5, srid=4326),
+        "organizer": organizer,
+        "status": Event.Status.PUBLISHED,
+        "visibility": Event.Visibility.PUBLIC,
+        "provider_phone": "+49 89 12345",
+        "series": series,
+        "occurrence_index": index,
+        "original_start_datetime": base,
+    }
+    defaults.update(overrides)
+    return Event.objects.create(**defaults)
+
+
+def _make_standalone(organizer, campaign, **overrides):
+    defaults = {
+        "campaign": campaign,
+        "title": "Standalone",
+        "summary": "Standalone summary",
+        "start_datetime": timezone.now() + timedelta(days=1),
+        "end_datetime": timezone.now() + timedelta(days=1, hours=1),
+        "location": Point(10.0, 53.5, srid=4326),
+        "organizer": organizer,
+        "status": Event.Status.PUBLISHED,
+        "visibility": Event.Visibility.PUBLIC,
+        "provider_phone": "+49 89 12345",
+    }
+    defaults.update(overrides)
+    return Event.objects.create(**defaults)
+
+
+@pytest.mark.django_db
+def test_detail_series_block_is_null_for_standalone_event(api_client, organizer, campaign):
+    event = _make_standalone(organizer, campaign)
+    response = api_client.get(f"/api/v1/events/{event.id}/")
+    assert response.status_code == 200
+    assert response.data["series"] is None
+
+
+@pytest.mark.django_db
+def test_detail_series_first_occurrence_has_no_previous(
+    api_client, organizer, campaign, event_type, series
+):
+    first = _make_occurrence(organizer, campaign, event_type, series, 1)
+    _make_occurrence(organizer, campaign, event_type, series, 2)
+
+    response = api_client.get(f"/api/v1/events/{first.id}/")
+    assert response.status_code == 200
+    series_block = response.data["series"]
+    assert series_block["occurrence_index"] == 1
+    assert series_block["total_occurrences"] == 2
+    assert series_block["previous_occurrence"] is None
+    assert series_block["next_occurrence"]["id"]
+
+
+@pytest.mark.django_db
+def test_detail_series_last_occurrence_has_no_next(
+    api_client, organizer, campaign, event_type, series
+):
+    _make_occurrence(organizer, campaign, event_type, series, 1)
+    last = _make_occurrence(organizer, campaign, event_type, series, 2)
+
+    response = api_client.get(f"/api/v1/events/{last.id}/")
+    assert response.status_code == 200
+    series_block = response.data["series"]
+    assert series_block["occurrence_index"] == 2
+    assert series_block["previous_occurrence"]["id"]
+    assert series_block["next_occurrence"] is None
+
+
+@pytest.mark.django_db
+def test_detail_series_middle_occurrence_has_prev_and_next(
+    api_client, organizer, campaign, event_type, series
+):
+    first = _make_occurrence(organizer, campaign, event_type, series, 1)
+    middle = _make_occurrence(organizer, campaign, event_type, series, 2)
+    last = _make_occurrence(organizer, campaign, event_type, series, 3)
+
+    response = api_client.get(f"/api/v1/events/{middle.id}/")
+    assert response.status_code == 200
+    series_block = response.data["series"]
+    assert series_block["total_occurrences"] == 3
+    assert series_block["previous_occurrence"]["id"] == str(first.id)
+    assert series_block["next_occurrence"]["id"] == str(last.id)
+
+
+@pytest.mark.django_db
+def test_detail_series_exception_still_receives_prev_next(
+    api_client, organizer, campaign, event_type, series
+):
+    _make_occurrence(organizer, campaign, event_type, series, 1)
+    exception = _make_occurrence(
+        organizer,
+        campaign,
+        event_type,
+        series,
+        2,
+        is_exception=True,
+    )
+    _make_occurrence(organizer, campaign, event_type, series, 3)
+
+    response = api_client.get(f"/api/v1/events/{exception.id}/")
+    assert response.status_code == 200
+    series_block = response.data["series"]
+    assert series_block["is_exception"] is True
+    assert series_block["previous_occurrence"] is not None
+    assert series_block["next_occurrence"] is not None
+
+
+@pytest.mark.django_db
+def test_list_includes_lightweight_series_fields(
+    api_client, organizer, campaign, event_type, series
+):
+    _make_occurrence(organizer, campaign, event_type, series, 1)
+    _make_occurrence(organizer, campaign, event_type, series, 2)
+    _make_standalone(organizer, campaign)
+
+    response = api_client.get(f"/api/v1/events/?campaign_id={campaign.id}")
+    assert response.status_code == 200
+    by_title = {item["title"]: item for item in response.data["results"]}
+
+    occurrence_1 = by_title["Occurrence 1"]
+    assert occurrence_1["series_id"] == str(series.id)
+    assert occurrence_1["series_name"] == "Phase 5 Series"
+    assert occurrence_1["occurrence_index"] == 1
+    assert occurrence_1["total_occurrences"] == 2
+    assert occurrence_1["is_exception"] is False
+
+    standalone = by_title["Standalone"]
+    assert standalone["series_id"] is None
+    assert standalone["series_name"] == ""
+    assert standalone["occurrence_index"] is None
+    assert standalone["total_occurrences"] is None
+
+
+@pytest.mark.django_db
+def test_map_endpoint_includes_lightweight_series_fields(
+    api_client, organizer, campaign, event_type, series
+):
+    _make_occurrence(organizer, campaign, event_type, series, 1)
+    _make_occurrence(organizer, campaign, event_type, series, 2)
+
+    response = api_client.get(f"/api/v1/events/map/?campaign_id={campaign.id}")
+    assert response.status_code == 200
+    features = response.data["spatial_events"]["features"]
+    assert len(features) == 2
+    sample = features[0]["properties"]
+    assert sample["series_id"] == str(series.id)
+    assert sample["series_name"] == "Phase 5 Series"
+    assert sample["total_occurrences"] == 2
+    assert sample["occurrence_index"] in {1, 2}
+    assert sample["is_exception"] is False
+
+
+@pytest.mark.django_db
+def test_detail_series_preserves_original_start_datetime(
+    api_client, organizer, campaign, event_type, series
+):
+    _make_occurrence(organizer, campaign, event_type, series, 1)
+    original = timezone.now() + timedelta(days=2)
+    moved = original + timedelta(hours=2)
+    exception = _make_occurrence(
+        organizer,
+        campaign,
+        event_type,
+        series,
+        2,
+        start_datetime=moved,
+        end_datetime=moved + timedelta(hours=1),
+        is_exception=True,
+        original_start_datetime=original,
+    )
+
+    response = api_client.get(f"/api/v1/events/{exception.id}/")
+    series_block = response.data["series"]
+    assert series_block["is_exception"] is True
+    assert series_block["original_start_datetime"] is not None

--- a/tosca_api/apps/events/views.py
+++ b/tosca_api/apps/events/views.py
@@ -1,3 +1,5 @@
+from django.db.models import Count, Prefetch
+
 from rest_framework import permissions, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.mixins import CreateModelMixin, RetrieveModelMixin, UpdateModelMixin
@@ -125,10 +127,20 @@ class EventViewSet(viewsets.ModelViewSet):
                 "organizer",
             )
             queryset = queryset.prefetch_related(
-                "eventlayer_set__layer__workspace"
+                "eventlayer_set__layer__workspace",
+                Prefetch(
+                    "series__events",
+                    queryset=Event.objects.only(
+                        "id",
+                        "series_id",
+                        "occurrence_index",
+                        "start_datetime",
+                    ).order_by("occurrence_index", "start_datetime"),
+                ),
             )
         else:
             queryset = queryset.select_related("campaign", "event_type", "series")
+            queryset = queryset.annotate(series_total_occurrences=Count("series__events"))
 
         return queryset
 
@@ -148,7 +160,9 @@ class EventViewSet(viewsets.ModelViewSet):
         filters = self._coerce_public_filters(filters)
 
         base_queryset = self._apply_visibility_scope(
-            Event.objects.all().select_related("campaign", "event_type", "series")
+            Event.objects.all()
+            .select_related("campaign", "event_type", "series")
+            .annotate(series_total_occurrences=Count("series__events"))
         )
         queryset = apply_event_filters(base_queryset, filters=filters).order_by(
             "start_datetime"
@@ -198,7 +212,9 @@ class EventViewSet(viewsets.ModelViewSet):
         data["spatial_geometry"] = data.pop("geometry")
         data = self._coerce_public_filters(data)
 
-        base_queryset = self._apply_visibility_scope(Event.objects.all())
+        base_queryset = self._apply_visibility_scope(
+            Event.objects.all().annotate(series_total_occurrences=Count("series__events"))
+        )
         queryset = apply_event_filters(base_queryset, filters=data)
         queryset = queryset.order_by("start_datetime").select_related(
             "campaign",


### PR DESCRIPTION
Detail responses now include a full `series` object: name, occurrence position, total occurrences, exception flag, original start datetime, and previous/next references — enough to render a "you are here" widget with no extra fetch. occurrence_index, is_exception, and original_start_datetime move inside that object on detail.

List and map responses expose the lightweight subset (series_id, series_name, occurrence_index, total_occurrences, is_exception) so cards and pins can show a series badge. total_occurrences comes from a Count annotation; the detail prefetch loads siblings ordered by occurrence_index in one query.

services.resolve_series_navigation centralizes the prev/next lookup and caches on the instance.

test_phase5_series_navigation covers null/first/last/middle/exception, list and map shape, and original_start_datetime preservation.

## Summary

- [ ] Description of changes
- [ ] Related issue link

## Testing

- [ ] `uv run pytest`
- [ ] Other (describe)
