### PR TITLE
embed outgoing feature links in event detail

### DIFF
--- a/tosca_api/apps/events/serializers.py
+++ b/tosca_api/apps/events/serializers.py
@@ -2,12 +2,14 @@ import json
 from collections import Counter
 from zoneinfo import ZoneInfoNotFoundError
 
+from django.contrib.contenttypes.models import ContentType
 from django.contrib.gis.geos import GEOSGeometry, Polygon
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db import transaction
 from rest_framework import serializers
 from rest_framework_gis.serializers import GeoFeatureModelSerializer
 
+from tosca_api.apps.featurelinks.models import FeatureLink
 from tosca_api.apps.geocontext.models import GeoContext
 from tosca_api.apps.geodata_providers.api.serializers import (
     LayerSummarySerializer,
@@ -101,6 +103,20 @@ class EventGeoContextSerializer(serializers.ModelSerializer):
         read_only_fields = fields
 
 
+class EventFeatureLinkSerializer(serializers.ModelSerializer):
+    """Outgoing FeatureLink with target type hydrated for navigation."""
+
+    target_type = serializers.SerializerMethodField()
+
+    class Meta:
+        model = FeatureLink
+        fields = ["id", "target_content_type", "target_object_id", "target_type", "link_type"]
+        read_only_fields = fields
+
+    def get_target_type(self, obj) -> str:
+        return obj.target_content_type.model
+
+
 class EventLayerSerializer(serializers.ModelSerializer):
     """
     Serializer for EventLayer through model.
@@ -172,6 +188,7 @@ class EventDetailSerializer(serializers.ModelSerializer):
     layers = serializers.SerializerMethodField()
     taxonomy_assignments = serializers.SerializerMethodField()
     series = serializers.SerializerMethodField()
+    feature_links = serializers.SerializerMethodField()
 
     class Meta:
         model = Event
@@ -207,6 +224,7 @@ class EventDetailSerializer(serializers.ModelSerializer):
             "context",
             "taxonomy_assignments",
             "layers",
+            "feature_links",
             "created_at",
             "updated_at",
         ]
@@ -214,6 +232,14 @@ class EventDetailSerializer(serializers.ModelSerializer):
 
     def get_series(self, obj):
         return resolve_series_navigation(obj)
+
+    def get_feature_links(self, obj) -> list:
+        event_ct = ContentType.objects.get_for_model(Event)
+        links = FeatureLink.objects.filter(
+            source_content_type=event_ct,
+            source_object_id=obj.id,
+        ).select_related("target_content_type")
+        return EventFeatureLinkSerializer(links, many=True).data
 
     def get_layers(self, obj) -> list:
         """Return layers ordered by display_order with full Layer summary."""

--- a/tosca_api/apps/events/tests/test_phase6_feature_links.py
+++ b/tosca_api/apps/events/tests/test_phase6_feature_links.py
@@ -1,0 +1,166 @@
+from datetime import timedelta
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
+from django.contrib.gis.geos import Point
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from tosca_api.apps.campaigns.models import Campaign
+from tosca_api.apps.events.models import Event
+from tosca_api.apps.featurelinks.models import FeatureLink
+from tosca_api.apps.feedback.models import GeoFeedback
+from tosca_api.apps.geostories.models import GeoStory
+
+User = get_user_model()
+
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+
+@pytest.fixture
+def user():
+    return User.objects.create_user(username="phase6", password="pw")
+
+
+@pytest.fixture
+def campaign(user):
+    return Campaign.objects.create(title="Phase 6", created_by=user)
+
+
+@pytest.fixture
+def source_event(user, campaign):
+    return Event.objects.create(
+        campaign=campaign,
+        title="Source Event",
+        summary="Source",
+        start_datetime=timezone.now() + timedelta(days=1),
+        end_datetime=timezone.now() + timedelta(days=1, hours=1),
+        location=Point(10.0, 53.5, srid=4326),
+        organizer=user,
+        status=Event.Status.PUBLISHED,
+        visibility=Event.Visibility.PUBLIC,
+        provider_phone="+49 89 12345",
+    )
+
+
+@pytest.mark.django_db
+def test_event_detail_returns_empty_feature_links_when_none(api_client, source_event):
+    response = api_client.get(f"/api/v1/events/{source_event.id}/")
+    assert response.status_code == 200
+    assert response.data["feature_links"] == []
+
+
+@pytest.mark.django_db
+def test_event_detail_returns_outgoing_feature_links_to_mixed_targets(
+    api_client, user, campaign, source_event
+):
+    story = GeoStory.objects.create(
+        title="Linked Story",
+        campaign=campaign,
+        author=user,
+        status=GeoStory.Status.PUBLISHED,
+    )
+    sibling_event = Event.objects.create(
+        campaign=campaign,
+        title="Linked Event",
+        summary="Sibling",
+        start_datetime=timezone.now() + timedelta(days=2),
+        end_datetime=timezone.now() + timedelta(days=2, hours=1),
+        location=Point(10.0, 53.5, srid=4326),
+        organizer=user,
+        status=Event.Status.PUBLISHED,
+        visibility=Event.Visibility.PUBLIC,
+        provider_phone="+49 89 12345",
+    )
+    feedback = GeoFeedback.objects.create(
+        campaign=campaign,
+        title="Linked feedback",
+        description="Linked feedback",
+        created_by=user,
+    )
+
+    event_ct = ContentType.objects.get_for_model(Event)
+    story_ct = ContentType.objects.get_for_model(GeoStory)
+    feedback_ct = ContentType.objects.get_for_model(GeoFeedback)
+
+    FeatureLink.objects.create(
+        campaign=campaign,
+        source_content_type=event_ct,
+        source_object_id=source_event.id,
+        target_content_type=story_ct,
+        target_object_id=story.id,
+        link_type=FeatureLink.LinkType.READ_MORE,
+        created_by=user,
+    )
+    FeatureLink.objects.create(
+        campaign=campaign,
+        source_content_type=event_ct,
+        source_object_id=source_event.id,
+        target_content_type=event_ct,
+        target_object_id=sibling_event.id,
+        link_type=FeatureLink.LinkType.DIRECT,
+        created_by=user,
+    )
+    FeatureLink.objects.create(
+        campaign=campaign,
+        source_content_type=event_ct,
+        source_object_id=source_event.id,
+        target_content_type=feedback_ct,
+        target_object_id=feedback.id,
+        link_type=FeatureLink.LinkType.ACTION,
+        created_by=user,
+    )
+
+    response = api_client.get(f"/api/v1/events/{source_event.id}/")
+    assert response.status_code == 200
+    links = response.data["feature_links"]
+    assert len(links) == 3
+
+    by_target_type = {link["target_type"]: link for link in links}
+    assert set(by_target_type) == {"geostory", "event", "geofeedback"}
+
+    assert by_target_type["geostory"]["target_object_id"] == str(story.id)
+    assert by_target_type["geostory"]["link_type"] == "read_more"
+
+    assert by_target_type["event"]["target_object_id"] == str(sibling_event.id)
+    assert by_target_type["event"]["link_type"] == "direct"
+
+    assert by_target_type["geofeedback"]["target_object_id"] == str(feedback.id)
+    assert by_target_type["geofeedback"]["link_type"] == "action"
+
+
+@pytest.mark.django_db
+def test_event_detail_only_returns_outgoing_links_not_incoming(
+    api_client, user, campaign, source_event
+):
+    """FeatureLinks where the event is the *target* must not surface in feature_links."""
+    other_event = Event.objects.create(
+        campaign=campaign,
+        title="Other Event",
+        summary="Other",
+        start_datetime=timezone.now() + timedelta(days=2),
+        end_datetime=timezone.now() + timedelta(days=2, hours=1),
+        location=Point(10.0, 53.5, srid=4326),
+        organizer=user,
+        status=Event.Status.PUBLISHED,
+        visibility=Event.Visibility.PUBLIC,
+        provider_phone="+49 89 12345",
+    )
+    event_ct = ContentType.objects.get_for_model(Event)
+    FeatureLink.objects.create(
+        campaign=campaign,
+        source_content_type=event_ct,
+        source_object_id=other_event.id,
+        target_content_type=event_ct,
+        target_object_id=source_event.id,
+        link_type=FeatureLink.LinkType.DIRECT,
+        created_by=user,
+    )
+
+    response = api_client.get(f"/api/v1/events/{source_event.id}/")
+    assert response.status_code == 200
+    assert response.data["feature_links"] == []

--- a/tosca_api/apps/events/views.py
+++ b/tosca_api/apps/events/views.py
@@ -128,6 +128,7 @@ class EventViewSet(viewsets.ModelViewSet):
             )
             queryset = queryset.prefetch_related(
                 "eventlayer_set__layer__workspace",
+                "feature_links_source__target_content_type",
                 Prefetch(
                     "series__events",
                     queryset=Event.objects.only(


### PR DESCRIPTION
Event detail now returns a `feature_links` array mirroring the GeoStory contract: id, target_content_type, target_object_id, target_type, link_type. Only links where the event is the source are exposed; the frontend can fetch the target object separately when it needs title/summary fields.

The retrieve queryset prefetches feature_links_source with the target content type so this is one extra query, not N+1.

test_phase6_feature_links covers the empty case, a mixed-target payload (geostory/event/geofeedback), and confirms incoming links where the event is the target stay hidden.

## Summary

- [ ] Description of changes
- [ ] Related issue link

## Testing

- [ ] `uv run pytest`
- [ ] Other (describe)
