### PR TITLE
seed public health taxonomy dimensions and terms

### DIFF
--- a/tosca_api/apps/events/migrations/0018_seed_ph_taxonomy.py
+++ b/tosca_api/apps/events/migrations/0018_seed_ph_taxonomy.py
@@ -1,0 +1,284 @@
+from django.db import migrations
+
+
+PH = "public_health"
+
+SEED = [
+    {
+        "code": "field_of_action",
+        "label": "Field of Action",
+        "selection_mode": "multiple",
+        "terms": [
+            ("begegnung_austausch", "Meeting and Exchange"),
+            ("beratung_familienhilfe", "Counseling and Family Support"),
+            ("erholung_entspannung", "Recreation, Relaxation, and Stress Management"),
+            ("ernaehrung_kochen", "Nutrition and Cooking"),
+            ("kultur_freizeit", "Culture and Leisure"),
+            ("nachbarschaftshilfe_ehrenamt", "Neighborhood Support and Volunteering"),
+            ("selbsthilfegruppen", "Self-Help Groups"),
+            ("sport_bewegung", "Sports and Physical Activity"),
+            ("digital_kompetenz", "Using Computers, Tablets, and Smartphones"),
+            ("spielen", "Play"),
+            ("gewalt_mobbing_extremismus", "Sexualized Violence, Bullying, and Extremism"),
+            ("sexualitaet", "Sexuality"),
+            ("sucht", "Addiction"),
+            ("mentale_gesundheit", "Mental Health"),
+        ],
+    },
+    {
+        "code": "format_ph",
+        "label": "Offer Type",
+        "selection_mode": "single",
+        "terms": [
+            ("sprechstunde", "Consultation Hours"),
+            ("kurs", "Course"),
+            ("workshop", "Workshop"),
+            ("infoveranstaltung", "Information Event"),
+            ("seminar", "Seminar"),
+            ("fortbildung", "Training"),
+            ("beratung", "Counseling"),
+            ("pflege", "Care"),
+            ("vortrag", "Lecture"),
+            ("treff", "Meetup"),
+            ("vorsorgetermin", "Preventive Care Appointment"),
+            ("tagesstrukturierend", "Day-Structuring Offer"),
+            ("unterstuetztes_wohnen", "Supported Living"),
+            ("besondere_wohnform", "Special Housing Form"),
+            ("selbsthilfegruppe", "Self-Help Group"),
+        ],
+    },
+    {
+        "code": "organization_type",
+        "label": "Organization Type",
+        "selection_mode": "single",
+        "terms": [
+            {
+                "code": "bildungseinrichtung",
+                "label": "Educational Institution",
+                "children": [
+                    ("kindergarten_hort", "Kindergarten or After-School Care"),
+                    ("grundschule", "Primary School"),
+                    ("weiterfuehrende_schule", "Secondary School"),
+                    ("hochschule", "University"),
+                    ("volkshochschule", "Adult Education Center"),
+                ],
+            },
+            {
+                "code": "gesundheitsdienstleister",
+                "label": "Health Service Provider",
+                "children": [
+                    ("krankenhaus", "Hospital"),
+                    ("gesundheitszentrum", "Health Center"),
+                    ("arztpraxis", "Medical Practice"),
+                    ("fachklinik", "Specialist Clinic"),
+                    ("rehaklinik", "Rehabilitation Clinic"),
+                    ("apotheke", "Pharmacy"),
+                    ("psychotherapeutische_praxis", "Psychotherapy Practice"),
+                    ("ergotherapie", "Occupational Therapy"),
+                    ("logotherapie", "Speech Therapy"),
+                    ("physiotherapie", "Physiotherapy"),
+                ],
+            },
+            {
+                "code": "privater_leistungserbringer",
+                "label": "Private Service Provider",
+                "children": [
+                    ("sportstudio", "Fitness Studio"),
+                    ("heilpraktiker", "Alternative Practitioner"),
+                ],
+            },
+            {
+                "code": "zivilgesellschaft",
+                "label": "Civil Society Organization or Association",
+                "children": [
+                    ("selbsthilfegruppe_zivil", "Self-Help Group"),
+                    ("verein", "Association"),
+                    ("nachbarschaftstreff", "Neighborhood Meeting Place"),
+                ],
+            },
+            {"code": "krankenkasse", "label": "Health Insurance Fund"},
+            {"code": "gemeinschaftsstaette", "label": "Community or Meeting Center"},
+            {"code": "kultureinrichtung", "label": "Cultural Institution"},
+            {"code": "kommune", "label": "Municipality"},
+            {"code": "quartiersmanagement", "label": "Neighborhood Management"},
+            {"code": "gesundheitsamt", "label": "Public Health Department"},
+            {"code": "sozialpsych_dienst", "label": "Social Psychiatric Service"},
+            {"code": "beratungseinrichtung", "label": "Counseling Center"},
+            {"code": "religionsgemeinschaft", "label": "Religious or Faith Community"},
+            {"code": "kinder_jugendarbeit", "label": "Child and Youth Work"},
+            {"code": "inklusionsbetrieb", "label": "Inclusive Enterprise"},
+            {"code": "werkstatt_behinderung", "label": "Workshop for People with Disabilities"},
+            {"code": "gesundheitstreff", "label": "Health Meeting Place"},
+            {"code": "servicezentrum", "label": "Service Center"},
+            {"code": "freizeiteinrichtung", "label": "Leisure Facility"},
+            {
+                "code": "wohlfahrtsverband",
+                "label": "Welfare Association",
+                "children": [
+                    ("awo", "AWO"),
+                    ("caritas", "Caritas"),
+                    ("diakonie", "Diakonie"),
+                    ("drk", "DRK"),
+                    ("paritaetisch", "Der Paritaetische"),
+                ],
+            },
+            {"code": "stiftung", "label": "Foundation"},
+            {
+                "code": "stadtentwicklung_wohnungsbau",
+                "label": "Urban Development or Housing Association",
+            },
+        ],
+    },
+    {
+        "code": "age_group",
+        "label": "Age Group",
+        "selection_mode": "multiple",
+        "terms": [
+            ("early_childhood_0_6", "Early Childhood (0-6)"),
+            ("early_childhood_0_3", "Early Childhood (0-3)"),
+            ("kita_3_6", "Daycare Age or Phase (3-6)"),
+            ("youth_10_18", "Youth (10-18)"),
+            ("young_adult_18_25", "Young Adults (18-25)"),
+            ("adult", "Adults"),
+            ("senior", "Seniors"),
+        ],
+    },
+    {
+        "code": "audience_spec",
+        "label": "Audience Specification",
+        "selection_mode": "multiple",
+        "terms": [
+            ("fachpersonen", "Interested Professionals from the Field or Target Group"),
+            ("kognitive_behinderung", "People with Cognitive Disabilities"),
+            ("koerperliche_behinderung", "People with Physical Disabilities"),
+            ("psychische_erkrankung", "People with Mental Illness or Psychological Disabilities"),
+            ("riskanter_konsum", "People with Risky Consumption Behavior"),
+            ("sinnesbehinderung", "People with Sensory Disabilities"),
+            ("suchterkrankung", "People with Addiction Disorders"),
+            ("demenz_kognitiv", "People with Dementia or Cognitive Impairments"),
+            ("koerperliche_beeintraechtigung", "People with Physical Impairments"),
+            ("psychische_beeintraechtigung", "People with Psychological or Emotional Impairments"),
+            ("pflegende_angehoerige", "Family Caregivers or Comparable Close Contacts"),
+            ("behinderung_allgemein", "People with Disabilities"),
+            ("familien", "Families"),
+            ("schwangere", "Pregnant People"),
+            ("eltern", "Parents"),
+            ("muetter", "Mothers"),
+            ("vaeter", "Fathers"),
+            ("migrationsgeschichte", "People with a Migration History"),
+            ("lgbtqia", "LGBTQIA+"),
+            ("maennlich", "Male"),
+            ("weiblich", "Female"),
+            ("divers", "Diverse"),
+            ("ohne_krankenversicherung", "People without Health Insurance"),
+        ],
+    },
+    {
+        "code": "cost_category",
+        "label": "Cost and Funding",
+        "selection_mode": "multiple",
+        "terms": [
+            ("praeventionskurs_foerderfaehig", "Health-Insurance-Funded Prevention Course"),
+            ("zuschuss_krankenkasse", "Health Insurance Subsidy"),
+            ("krankenkassenleistung", "Health Insurance Benefit"),
+            ("kostenpflichtig", "Fee-Based"),
+            ("ermaessigung", "Discount Available"),
+            ("spende", "Donation-Based"),
+            ("but_verguenstigung", "Discount for Children Eligible for Education Benefits"),
+            ("kostenlos", "Free of Charge"),
+            ("sonstiger_zuschuss", "Other Subsidy Available"),
+        ],
+    },
+    {
+        "code": "accessibility",
+        "label": "Accessibility",
+        "selection_mode": "multiple",
+        "terms": [
+            ("wc_barrierefrei", "Accessible Toilet"),
+            ("sprachunterstuetzung", "Language Support"),
+            ("aufzuege", "Elevators Available"),
+            ("aufzuege_elektrorollstuhl", "Elevators Suitable for Electric Wheelchairs"),
+            ("behindertenparkplaetze", "Accessible Parking Spaces"),
+            ("rollstuhlgerecht", "Wheelchair Accessible"),
+            ("leichte_sprache", "Plain Language"),
+            ("zugang_schwellenfrei", "Step-Free Access or Ramp"),
+            ("gebaerdendolmetscher", "Sign Language Interpreter"),
+            ("induktionsschleife", "Induction Loop or FM System for Hard-of-Hearing People"),
+            ("reizarm_ruheraum", "Low-Stimulus Environment, Quiet Room, or Ample Space"),
+            ("taktiles_leitsystem", "Tactile Guidance System for Blind People"),
+            ("assistenz_erlaubt", "Assistance or Companion Allowed"),
+        ],
+    },
+    {
+        "code": "further_info",
+        "label": "Further Information",
+        "selection_mode": "multiple",
+        "terms": [
+            ("oepnv_erreichbar", "Easy to Reach by Public Transport"),
+            ("kinderbetreuung_vor_ort", "Childcare Available On Site"),
+            ("parkplaetze", "Parking Spaces Available"),
+            ("bring_abholservice", "Drop-Off and Pick-Up Service"),
+            ("fahrradabstellanlage", "Bicycle Parking Available"),
+            ("dusch_waschraum", "Shower and Washing Room Available"),
+            ("umkleideraeume", "Changing Rooms Available"),
+            ("raeume_klimatisiert", "Air-Conditioned Rooms"),
+            ("anonym", "Anonymous"),
+        ],
+    },
+]
+
+
+def _seed_term(TaxonomyTerm, dimension, term_data, sort_order, parent=None):
+    if isinstance(term_data, tuple):
+        code, label = term_data
+        children = []
+    else:
+        code = term_data["code"]
+        label = term_data["label"]
+        children = term_data.get("children", [])
+
+    term, _ = TaxonomyTerm.objects.update_or_create(
+        dimension=dimension,
+        code=code,
+        defaults={
+            "parent": parent,
+            "label": label,
+            "sort_order": sort_order,
+            "is_active": True,
+        },
+    )
+
+    for child_sort_order, child_data in enumerate(children, start=1):
+        _seed_term(TaxonomyTerm, dimension, child_data, child_sort_order, parent=term)
+
+    return term
+
+
+def seed_ph_taxonomy(apps, schema_editor):
+    TaxonomyDimension = apps.get_model("events", "TaxonomyDimension")
+    TaxonomyTerm = apps.get_model("events", "TaxonomyTerm")
+
+    for sort_order, entry in enumerate(SEED, start=1):
+        dimension, _ = TaxonomyDimension.objects.update_or_create(
+            code=entry["code"],
+            defaults={
+                "label": entry["label"],
+                "selection_mode": entry["selection_mode"],
+                "profile_key": PH,
+                "sort_order": sort_order,
+                "is_active": True,
+            },
+        )
+        for term_sort_order, term_data in enumerate(entry["terms"], start=1):
+            _seed_term(TaxonomyTerm, dimension, term_data, term_sort_order)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("events", "0017_publichealtheventprofile_cost_amount_eur_and_more"),
+    ]
+
+    operations = [
+        migrations.RunPython(seed_ph_taxonomy, migrations.RunPython.noop),
+    ]

--- a/tosca_api/apps/events/models.py
+++ b/tosca_api/apps/events/models.py
@@ -1,3 +1,4 @@
+# pyright: reportIncompatibleVariableOverride=false
 """
 Event model - Time-bound spatial events.
 
@@ -8,6 +9,7 @@ to a Campaign and can have associated map layers and rich content (GeoContext).
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, cast
 import uuid
 
 from django.conf import settings
@@ -135,6 +137,10 @@ class TaxonomyDimension(TimeStampedModel):
 class TaxonomyTerm(TimeStampedModel):
     """Term within a taxonomy dimension, with optional parent nesting."""
 
+    if TYPE_CHECKING:
+        dimension_id: uuid.UUID
+        parent_id: uuid.UUID | None
+
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     dimension = models.ForeignKey(
         TaxonomyDimension,
@@ -172,9 +178,14 @@ class TaxonomyTerm(TimeStampedModel):
         errors = {}
 
         if self.parent_id:
+            parent = self.parent
             if self.parent_id == self.id:
                 errors["parent"] = "A taxonomy term cannot be its own parent."
-            elif self.dimension_id and self.parent.dimension_id != self.dimension_id:
+            elif (
+                self.dimension_id
+                and parent is not None
+                and parent.dimension_id != self.dimension_id
+            ):
                 errors["parent"] = "Parent term must belong to the same dimension."
 
         if errors:
@@ -195,6 +206,12 @@ class TaxonomyTerm(TimeStampedModel):
 
 class EventSeries(TimeStampedModel):
     """Grouping and recurrence definition model for batch and recurring events."""
+
+    if TYPE_CHECKING:
+        campaign_id: uuid.UUID | None
+        created_by_id: int | None
+        default_context_id: uuid.UUID | None
+        event_type_id: uuid.UUID | None
 
     class SeriesMode(models.TextChoices):
         MANUAL_BATCH = "manual_batch", "Manual Batch"
@@ -452,6 +469,12 @@ class Event(TimeStampedModel):
         visibility: Public/Private
     """
 
+    if TYPE_CHECKING:
+        campaign_id: uuid.UUID
+        context_id: uuid.UUID | None
+        event_type_id: uuid.UUID | None
+        series_id: uuid.UUID | None
+
     class Status(models.TextChoices):
         DRAFT = "draft", "Draft"
         PUBLISHED = "published", "Published"
@@ -626,10 +649,12 @@ class Event(TimeStampedModel):
         2. EventSeries.default_context
         3. None
         """
-        if self.context_id:
+        if self.context_id is not None:
             return self.context
-        if self.series_id and self.series and self.series.default_context_id:
-            return self.series.default_context
+        if self.series_id is not None:
+            series = self.series
+            if series is not None and series.default_context_id is not None:
+                return series.default_context
         return None
 
     def clean(self) -> None:
@@ -684,17 +709,22 @@ class Event(TimeStampedModel):
         if self.series_id and self.occurrence_index is None:
             errors["occurrence_index"] = "Series events require an occurrence index."
 
-        if self.series_id:
-            if self.series.campaign_id is None:
+        if self.series_id is not None:
+            series = self.series
+            if series is None:
+                errors["series"] = "Series-linked events require a series."
+            elif series.campaign_id is None:
                 errors["series"] = "Series-linked events require a series campaign."
-            elif self.series.campaign_id != self.campaign_id:
+            elif series.campaign_id != self.campaign_id:
                 errors["campaign"] = "Series-linked events must match the series campaign."
 
-            if self.series.event_type_id is None:
+            if series is None:
+                pass
+            elif series.event_type_id is None:
                 errors["series"] = "Series-linked events require a series event type."
             elif self.event_type_id is None:
                 errors["event_type"] = "Series-linked events require an event type."
-            elif self.series.event_type_id != self.event_type_id:
+            elif series.event_type_id != self.event_type_id:
                 errors["event_type"] = "Series-linked events must match the series event type."
 
         if errors:
@@ -717,6 +747,10 @@ class EventLayer(models.Model):
     Allows ordering of layers within an event. Layers must be public and
     published — see ``clean()``.
     """
+
+    if TYPE_CHECKING:
+        event_id: uuid.UUID
+        layer_id: uuid.UUID | None
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     event = models.ForeignKey(Event, on_delete=models.CASCADE)
@@ -769,6 +803,10 @@ class EventLayer(models.Model):
 class EventTerm(TimeStampedModel):
     """Assignment table linking events to taxonomy terms."""
 
+    if TYPE_CHECKING:
+        event_id: uuid.UUID | None
+        term_id: uuid.UUID | None
+
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     event = models.ForeignKey(
         Event,
@@ -814,9 +852,10 @@ class EventTerm(TimeStampedModel):
                     )
 
             if dimension.profile_key:
+                event_type = self.event.event_type if self.event.event_type_id else None
                 event_profile_key = (
-                    (self.event.event_type.profile_key or "")
-                    if self.event.event_type_id
+                    (event_type.profile_key or "")
+                    if event_type is not None
                     else ""
                 )
                 if event_profile_key != dimension.profile_key:
@@ -840,6 +879,9 @@ class BaseEventProfile(TimeStampedModel):
 
     expected_profile_key: str | None = None
 
+    if TYPE_CHECKING:
+        event_id: uuid.UUID | None
+
     class Meta:
         abstract = True
 
@@ -849,7 +891,8 @@ class BaseEventProfile(TimeStampedModel):
         if not self.event_id:
             errors["event"] = "Extension profiles require an event."
         else:
-            event_type = self.event.event_type
+            event = cast("Event", getattr(self, "event", None))
+            event_type = event.event_type
             if event_type is None:
                 errors["event"] = "Extension profiles require an event type."
             elif event_type.profile_mode != EventType.ProfileMode.EXTENSION:

--- a/tosca_api/apps/events/tests/test_phase9_ph_taxonomy_seed.py
+++ b/tosca_api/apps/events/tests/test_phase9_ph_taxonomy_seed.py
@@ -1,0 +1,137 @@
+import importlib
+from datetime import timedelta
+
+import pytest
+from django.apps import apps
+from django.contrib.auth import get_user_model
+from django.contrib.gis.geos import Point
+from django.core.exceptions import ValidationError
+from django.utils import timezone
+
+from tosca_api.apps.campaigns.models import Campaign
+from tosca_api.apps.events.models import (
+    Event,
+    EventTerm,
+    EventType,
+    TaxonomyDimension,
+    TaxonomyTerm,
+)
+
+User = get_user_model()
+
+PH_DIMENSION_CODES = {
+    "field_of_action",
+    "format_ph",
+    "organization_type",
+    "age_group",
+    "audience_spec",
+    "cost_category",
+    "accessibility",
+    "further_info",
+}
+
+EXPECTED_TERM_COUNTS = {
+    "field_of_action": 14,
+    "format_ph": 15,
+    "organization_type": 47,
+    "age_group": 7,
+    "audience_spec": 23,
+    "cost_category": 9,
+    "accessibility": 13,
+    "further_info": 9,
+}
+
+
+@pytest.fixture
+def user():
+    return User.objects.create_user(username="phase9", password="pw")
+
+
+@pytest.fixture
+def campaign(user):
+    return Campaign.objects.create(title="Phase 9", created_by=user)
+
+
+def _make_event(user, campaign, event_type):
+    return Event.objects.create(
+        campaign=campaign,
+        event_type=event_type,
+        title="Phase 9 event",
+        summary="Phase 9 summary",
+        start_datetime=timezone.now() + timedelta(days=1),
+        end_datetime=timezone.now() + timedelta(days=1, hours=1),
+        location=Point(10.0, 53.5, srid=4326),
+        organizer=user,
+        status=Event.Status.PUBLISHED,
+        visibility=Event.Visibility.PUBLIC,
+        provider_phone="+49 89 12345",
+    )
+
+
+@pytest.mark.django_db
+def test_ph_taxonomy_dimensions_are_seeded_with_english_labels():
+    dimensions = {
+        dimension.code: dimension
+        for dimension in TaxonomyDimension.objects.filter(code__in=PH_DIMENSION_CODES)
+    }
+
+    assert set(dimensions) == PH_DIMENSION_CODES
+    assert dimensions["field_of_action"].label == "Field of Action"
+    assert dimensions["format_ph"].label == "Offer Type"
+    assert dimensions["organization_type"].label == "Organization Type"
+    assert dimensions["cost_category"].label == "Cost and Funding"
+
+    for dimension in dimensions.values():
+        assert dimension.profile_key == "public_health"
+        assert dimension.is_active is True
+
+    assert dimensions["format_ph"].selection_mode == TaxonomyDimension.SelectionMode.SINGLE
+    assert dimensions["organization_type"].selection_mode == TaxonomyDimension.SelectionMode.SINGLE
+    assert dimensions["field_of_action"].selection_mode == TaxonomyDimension.SelectionMode.MULTIPLE
+
+
+@pytest.mark.django_db
+def test_ph_taxonomy_terms_are_seeded_with_expected_counts_and_hierarchy():
+    for code, expected_count in EXPECTED_TERM_COUNTS.items():
+        assert TaxonomyTerm.objects.filter(dimension__code=code).count() == expected_count
+
+    organization_type = TaxonomyDimension.objects.get(code="organization_type")
+    school = TaxonomyTerm.objects.get(dimension=organization_type, code="grundschule")
+    health_center = TaxonomyTerm.objects.get(dimension=organization_type, code="gesundheitszentrum")
+    welfare = TaxonomyTerm.objects.get(dimension=organization_type, code="wohlfahrtsverband")
+
+    assert school.label == "Primary School"
+    assert school.parent.code == "bildungseinrichtung"
+    assert health_center.label == "Health Center"
+    assert health_center.parent.code == "gesundheitsdienstleister"
+    assert welfare.parent is None
+
+
+@pytest.mark.django_db
+def test_ph_taxonomy_seed_can_be_re_run_without_duplicates():
+    before_dimensions = TaxonomyDimension.objects.filter(code__in=PH_DIMENSION_CODES).count()
+    before_terms = TaxonomyTerm.objects.filter(dimension__code__in=PH_DIMENSION_CODES).count()
+
+    migration = importlib.import_module("tosca_api.apps.events.migrations.0018_seed_ph_taxonomy")
+    migration.seed_ph_taxonomy(apps, None)
+    migration.seed_ph_taxonomy(apps, None)
+
+    assert TaxonomyDimension.objects.filter(code__in=PH_DIMENSION_CODES).count() == before_dimensions
+    assert TaxonomyTerm.objects.filter(dimension__code__in=PH_DIMENSION_CODES).count() == before_terms
+    assert TaxonomyTerm.objects.filter(
+        dimension__code="organization_type",
+        code="grundschule",
+    ).count() == 1
+
+
+@pytest.mark.django_db
+def test_seeded_ph_dimension_rejects_assignment_to_general_event(user, campaign):
+    general_type = EventType.objects.get(code="general")
+    event = _make_event(user, campaign, general_type)
+    term = TaxonomyTerm.objects.get(dimension__code="field_of_action", code="sport_bewegung")
+
+    candidate = EventTerm(event=event, term=term)
+    with pytest.raises(ValidationError) as exc:
+        candidate.clean()
+
+    assert "term" in exc.value.message_dict


### PR DESCRIPTION
Add the phase 9 data migration for public-health scoped taxonomy dimensions and terms. Seeded labels are English while preserving the stable ASCII term codes and organization hierarchy.

Cover the seed with tests for expected dimensions, term counts, parent-child relationships, idempotent re-runs, and profile scoping against general events.

## Summary

- [ ] Description of changes
- [ ] Related issue link

## Testing

- [ ] `uv run pytest`
- [ ] Other (describe)
