### PR TITLE
Harden destructive admin ops and document the soft-delete decision

### DIFF
--- a/tosca_api/apps/campaigns/admin.py
+++ b/tosca_api/apps/campaigns/admin.py
@@ -1,4 +1,4 @@
-from django.contrib import admin
+from django.contrib import admin, messages
 
 from .models import Campaign
 
@@ -19,3 +19,37 @@ class CampaignAdmin(admin.ModelAdmin):
         ("Ownership", {"fields": ("created_by",)}),
         ("Timestamps", {"fields": ("created_at", "updated_at")}),
     )
+
+    # ------------------------------------------------------------------
+    # Delete safety: warn before the Event/EventSeries/GeoStory/GeoFeedback
+    # cascade. Matches the LayerAdmin.usage_summary() warning pattern —
+    # Django's default delete confirmation page already lists every
+    # cascaded object individually (which can be a very long raw list for
+    # an active campaign), this adds a concise count-based warning banner
+    # on top of that so the scope is obvious at a glance.
+    # ------------------------------------------------------------------
+    def delete_view(self, request, object_id, extra_context=None):
+        try:
+            campaign = self.get_object(request, object_id)
+        except Exception:
+            campaign = None
+
+        if campaign is not None:
+            usage = campaign.usage_summary()
+            if any(usage.values()):
+                self.message_user(
+                    request,
+                    (
+                        f"Campaign '{campaign.title}' has "
+                        f"{usage['events']} events, "
+                        f"{usage['event_series']} event series, "
+                        f"{usage['geostories']} geostories, and "
+                        f"{usage['feedbacks']} feedbacks. "
+                        "Confirming will permanently delete all of them — "
+                        "there is no soft-delete or recovery path."
+                    ),
+                    messages.WARNING,
+                )
+            extra_context = {**(extra_context or {}), "campaign_usage_summary": usage}
+
+        return super().delete_view(request, object_id, extra_context=extra_context)

--- a/tosca_api/apps/campaigns/models.py
+++ b/tosca_api/apps/campaigns/models.py
@@ -20,7 +20,7 @@ class Campaign(TimeStampedModel):
     """
     Campaign model for grouping features (stories, events, feedback) under a
     thematic initiative.
-    
+
     Attributes:
         id: UUID primary key
         title: Campaign name (required)
@@ -28,6 +28,17 @@ class Campaign(TimeStampedModel):
         status: Draft/Active/Archived lifecycle state
         visibility: Public/Private access control
         created_by: Owner/creator of the campaign
+
+    Soft-delete decision (deliberately no `deleted_at`/`is_deleted`): hard
+    delete is intentional here, matching every other cascading-delete model
+    in this codebase (Workspace/Store/Layer also hard-delete). Adding
+    soft-delete would mean filtering it out of every existing queryset
+    across campaigns/events/geostories/feedback, plus admin and API
+    changes, for a risk that `usage_summary()` + a warning on the delete
+    confirmation page already covers: the operator sees exactly what will
+    be cascade-deleted before confirming. Revisit only if a real recovery
+    requirement shows up (e.g. accidental-delete reports in practice) —
+    don't build it speculatively.
     """
 
     class Status(models.TextChoices):
@@ -73,3 +84,20 @@ class Campaign(TimeStampedModel):
         self.title = sanitize_simple(self.title)
         self.summary = sanitize_simple(self.summary)
         super().save(*args, **kwargs)
+
+    def usage_summary(self) -> dict[str, int]:
+        """
+        Return how many Event / EventSeries / GeoStory / GeoFeedback rows
+        belong to this campaign.
+
+        Unlike Layer.usage_summary() (which warns about references that
+        would be *orphaned*), deleting a Campaign CASCADE-deletes these
+        rows outright — the admin delete-confirmation page uses this to
+        warn an operator before that cascade runs.
+        """
+        return {
+            "events": self.events.count(),
+            "event_series": self.event_series.count(),
+            "geostories": self.geostories.count(),
+            "feedbacks": self.feedbacks.count(),
+        }

--- a/tosca_api/apps/campaigns/tests/test_admin.py
+++ b/tosca_api/apps/campaigns/tests/test_admin.py
@@ -1,0 +1,113 @@
+"""
+Tests for CampaignAdmin's delete-confirmation warning.
+
+Campaign deletion CASCADEs to Event/EventSeries/GeoStory/GeoFeedback with
+no soft-delete (see the deliberate decision documented on Campaign's
+docstring). These tests cover the warning banner added on top of Django's
+default cascade-delete confirmation page.
+"""
+from datetime import timedelta
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.contrib.gis.geos import Point
+from django.test import Client
+from django.urls import reverse
+from django.utils import timezone
+
+from tosca_api.apps.campaigns.models import Campaign
+from tosca_api.apps.events.models import Event
+from tosca_api.apps.feedback.models import GeoFeedback
+from tosca_api.apps.geostories.models import GeoStory
+
+User = get_user_model()
+
+
+@pytest.fixture
+def admin_client(db):
+    client = Client()
+    user = User.objects.create_user(
+        username="campaign-admin",
+        password="testpass123",
+        is_staff=True,
+        is_superuser=True,
+    )
+    client.force_login(user)
+    return client, user
+
+
+@pytest.mark.django_db
+def test_delete_confirmation_shows_no_warning_for_empty_campaign(admin_client):
+    client, user = admin_client
+    campaign = Campaign.objects.create(title="Empty Campaign", created_by=user)
+
+    response = client.get(
+        reverse("admin:campaigns_campaign_delete", args=[campaign.pk])
+    )
+
+    assert response.status_code == 200
+    messages = [str(m) for m in response.context["messages"]]
+    assert not any("Confirming will permanently delete" in m for m in messages)
+
+
+@pytest.mark.django_db
+def test_delete_confirmation_warns_with_dependent_counts(admin_client):
+    client, user = admin_client
+    campaign = Campaign.objects.create(title="Busy Campaign", created_by=user)
+    now = timezone.now()
+    Event.objects.create(
+        campaign=campaign,
+        title="Workshop",
+        start_datetime=now,
+        end_datetime=now + timedelta(hours=1),
+        location=Point(10.0, 53.5, srid=4326),
+        organizer=user,
+    )
+    GeoStory.objects.create(title="Story", campaign=campaign, author=user)
+    GeoFeedback.objects.create(
+        campaign=campaign,
+        title="Feedback",
+        rating_enabled=True,
+        created_by=user,
+    )
+
+    response = client.get(
+        reverse("admin:campaigns_campaign_delete", args=[campaign.pk])
+    )
+
+    assert response.status_code == 200
+    messages = [str(m) for m in response.context["messages"]]
+    warning = next(
+        (m for m in messages if "Confirming will permanently delete" in m), None
+    )
+    assert warning is not None
+    assert "1 events" in warning
+    assert "1 geostories" in warning
+    assert "1 feedbacks" in warning
+    assert "0 event series" in warning
+
+
+@pytest.mark.django_db
+def test_confirmed_delete_cascades_dependents(admin_client):
+    client, user = admin_client
+    campaign = Campaign.objects.create(title="To Delete", created_by=user)
+    now = timezone.now()
+    event = Event.objects.create(
+        campaign=campaign,
+        title="Workshop",
+        start_datetime=now,
+        end_datetime=now + timedelta(hours=1),
+        location=Point(10.0, 53.5, srid=4326),
+        organizer=user,
+    )
+    story = GeoStory.objects.create(title="Story", campaign=campaign, author=user)
+
+    response = client.post(
+        reverse("admin:campaigns_campaign_delete", args=[campaign.pk]),
+        {"post": "yes"},
+    )
+
+    assert response.status_code == 302
+    assert not Campaign.objects.filter(pk=campaign.pk).exists()
+    assert not Event.objects.filter(pk=event.pk).exists()
+    assert not GeoStory.objects.filter(pk=story.pk).exists()

--- a/tosca_api/apps/campaigns/tests/test_models.py
+++ b/tosca_api/apps/campaigns/tests/test_models.py
@@ -93,3 +93,51 @@ def test_campaign_sanitization(test_user):
     
     assert "<script>" not in campaign.summary
     assert campaign.summary == "A summary with  tags."
+
+
+@pytest.mark.django_db
+def test_usage_summary_zero_for_empty_campaign(test_user):
+    campaign = Campaign.objects.create(title="Empty Campaign", created_by=test_user)
+
+    assert campaign.usage_summary() == {
+        "events": 0,
+        "event_series": 0,
+        "geostories": 0,
+        "feedbacks": 0,
+    }
+
+
+@pytest.mark.django_db
+def test_usage_summary_counts_dependents(test_user):
+    from datetime import timedelta
+
+    from django.contrib.gis.geos import Point
+    from django.utils import timezone
+
+    from tosca_api.apps.events.models import Event
+    from tosca_api.apps.feedback.models import GeoFeedback
+    from tosca_api.apps.geostories.models import GeoStory
+
+    campaign = Campaign.objects.create(title="Busy Campaign", created_by=test_user)
+    now = timezone.now()
+    Event.objects.create(
+        campaign=campaign,
+        title="Workshop",
+        start_datetime=now,
+        end_datetime=now + timedelta(hours=1),
+        location=Point(10.0, 53.5, srid=4326),
+        organizer=test_user,
+    )
+    GeoStory.objects.create(title="Story", campaign=campaign, author=test_user)
+    GeoFeedback.objects.create(
+        campaign=campaign,
+        title="Feedback",
+        rating_enabled=True,
+        created_by=test_user,
+    )
+
+    usage = campaign.usage_summary()
+    assert usage["events"] == 1
+    assert usage["geostories"] == 1
+    assert usage["feedbacks"] == 1
+    assert usage["event_series"] == 0

--- a/tosca_api/apps/geodata_providers/admin.py
+++ b/tosca_api/apps/geodata_providers/admin.py
@@ -1421,14 +1421,18 @@ class LayerAdmin(RemoteDeleteAdminMixin, admin.ModelAdmin):
         _run_workspace_sync(self, request, obj.workspace)
 
     def save_formset(self, request, form, formset, change):
-        instances = formset.save(commit=False)
-        for obj in instances:
-            if isinstance(obj, LayerStyleAssignment) and not obj.pk:
-                obj.created_by = request.user
-            obj.save()
-        for obj in formset.deleted_objects:
-            obj.delete()
-        formset.save_m2m()
+        # Pure Django ORM work (no remote calls) — safe and necessary to
+        # wrap in one transaction so a failure partway through a batch of
+        # style-assignment saves/deletes can't leave the formset half-applied.
+        with transaction.atomic():
+            instances = formset.save(commit=False)
+            for obj in instances:
+                if isinstance(obj, LayerStyleAssignment) and not obj.pk:
+                    obj.created_by = request.user
+                obj.save()
+            for obj in formset.deleted_objects:
+                obj.delete()
+            formset.save_m2m()
 
     # ------------------------------------------------------------------
     # 4.5 — Delete safety: GeoServer-first for PUBLISHED layers

--- a/tosca_api/apps/geodata_providers/admin_actions/engine.py
+++ b/tosca_api/apps/geodata_providers/admin_actions/engine.py
@@ -11,7 +11,6 @@ from django.contrib import admin, messages
 
 from ..engine_factory import EngineClientFactory
 from ..exceptions import GeoServerConnectionError, GeodataEngineError
-from ..models import GeodataEngine
 from ..services.commands.geodata_engine_service import GeodataEngineService
 from ..sync_service import GeoServerSyncService
 
@@ -102,7 +101,8 @@ def set_as_default(modeladmin, request, queryset):
         return
 
     engine = queryset.first()
-    GeodataEngine.objects.filter(is_default=True).exclude(pk=engine.pk).update(is_default=False)
+    # GeodataEngine.save() already atomically unsets any other default
+    # engine when is_default=True — no need to duplicate that here.
     engine.is_default = True
     engine.save(update_fields=['is_default'])
     modeladmin.message_user(

--- a/tosca_api/apps/geodata_providers/models.py
+++ b/tosca_api/apps/geodata_providers/models.py
@@ -20,7 +20,7 @@ import uuid
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
-from django.db import models
+from django.db import models, transaction
 
 from tosca_api.apps.core.models import TimeStampedModel
 
@@ -158,12 +158,17 @@ class GeodataEngine(TimeStampedModel, EncryptedCharField):
     def save(self, *args, **kwargs) -> None:
         self.full_clean()
         # Keep a single default engine — exclude self so re-saving the existing
-        # default doesn't accidentally clear its own flag.
+        # default doesn't accidentally clear its own flag. Wrapped in atomic
+        # so a failure between unsetting the old default and saving the new
+        # one can't leave zero default engines.
         if self.is_default:
-            GeodataEngine.objects.exclude(pk=self.pk).filter(is_default=True).update(
-                is_default=False
-            )
-        super().save(*args, **kwargs)
+            with transaction.atomic():
+                GeodataEngine.objects.exclude(pk=self.pk).filter(is_default=True).update(
+                    is_default=False
+                )
+                super().save(*args, **kwargs)
+        else:
+            super().save(*args, **kwargs)
 
     @property
     def decrypted_admin_password(self) -> str:

--- a/tosca_api/apps/geodata_providers/tests/test_default_engine_atomicity.py
+++ b/tosca_api/apps/geodata_providers/tests/test_default_engine_atomicity.py
@@ -1,0 +1,72 @@
+"""
+GeodataEngine.save() atomically unsets any other default engine before
+saving itself as the new default. This covers the regression this fix
+targets: a failure between the unset and the save must not leave zero
+default engines.
+"""
+from unittest.mock import patch
+
+from django.contrib.auth.models import User
+from django.db import models as django_models
+from django.test import TestCase
+
+from tosca_api.apps.geodata_providers.models import GeodataEngine
+
+
+def _make_engine(name, user, is_default=False):
+    return GeodataEngine.objects.create(
+        name=name,
+        description="test",
+        engine_type="geoserver",
+        base_url="http://example.com/geoserver",
+        public_url="http://example.com/geoserver",
+        admin_username="admin",
+        admin_password="secret",
+        is_default=is_default,
+        created_by=user,
+    )
+
+
+class DefaultEngineAtomicityTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="atomic-user", password="testpass123")
+
+    def test_setting_a_new_default_unsets_the_old_one(self):
+        engine_a = _make_engine("Engine A", self.user, is_default=True)
+        engine_b = _make_engine("Engine B", self.user, is_default=False)
+
+        engine_b.is_default = True
+        engine_b.save(update_fields=["is_default"])
+
+        engine_a.refresh_from_db()
+        engine_b.refresh_from_db()
+        assert engine_a.is_default is False
+        assert engine_b.is_default is True
+
+    def test_failure_saving_new_default_leaves_old_default_untouched(self):
+        """Regression test: a failure between the unset-others update and
+        the final save() must roll back the unset too, not just skip the
+        final save. Before this fix, those two writes were not in the same
+        transaction, so a failure here could leave zero default engines.
+        """
+        engine_a = _make_engine("Engine A", self.user, is_default=True)
+        engine_b = _make_engine("Engine B", self.user, is_default=False)
+
+        real_save = django_models.Model.save
+
+        def failing_save(self, *args, **kwargs):
+            if isinstance(self, GeodataEngine) and self.pk == engine_b.pk:
+                raise RuntimeError("simulated failure mid-save")
+            return real_save(self, *args, **kwargs)
+
+        engine_b.is_default = True
+        with patch.object(django_models.Model, "save", failing_save):
+            with self.assertRaises(RuntimeError):
+                engine_b.save(update_fields=["is_default"])
+
+        engine_a.refresh_from_db()
+        engine_b.refresh_from_db()
+        # The unset-others update must have rolled back along with the
+        # failed save — engine_a is still the (only) default.
+        assert engine_a.is_default is True
+        assert engine_b.is_default is False


### PR DESCRIPTION

Campaign deletion CASCADE-deletes every Event/EventSeries/GeoStory/GeoFeedback with no prior warning specific to that scope. Adds Campaign.usage_summary() and a delete_view() warning banner, matching the review's Layer.usage_summary() precedent (not the Store/Workspace GeoServer-first pattern, which doesn't apply — Campaign has no remote twin). Documents the no-soft-delete decision directly on Campaign's docstring so it isn't re-litigated.

Audited every multi-step admin write across all apps for missing transaction.atomic() wrapping. The GeoServer sync helpers are correctly left non-atomic — they interleave network calls with writes, and wrapping those in one DB transaction would be a new bug, not a fix. Fixed the two genuine pure-ORM gaps: LayerAdmin.save_formset()'s batch save/delete loop, and GeodataEngine.save()'s unset-old-default- then-save-new-default sequence, which was unprotected at the model level (the admin action duplicated the same unprotected logic on top — simplified to rely on the now-atomic model method instead).

Adds a rollback-regression test that forces a failure mid-save and confirms the old default engine survives. Full suite: 737 passed (was 730).

## Summary

- [ ] Description of changes
- [ ] Related issue link

## Testing

- [ ] `uv run pytest`
- [ ] Other (describe)
