### PR TITLE
Collapse duplicated create/delete cycles in GeoServerClient

### DIFF
--- a/tosca_api/apps/geodata_providers/geoserver/client.py
+++ b/tosca_api/apps/geodata_providers/geoserver/client.py
@@ -4,7 +4,7 @@ Thin, controlled wrapper around geoserver-rest
 import sys
 import os
 import logging
-from typing import Dict, Optional
+from typing import Callable, Dict, Optional
 import requests
 
 # Add geoserver-rest to Python path
@@ -91,6 +91,104 @@ class GeoServerClient:
             return value.removeprefix("file:")
         return value
 
+    def _create_resource(
+        self,
+        *,
+        exists_check: Callable[[], bool],
+        already_exists_result: Callable[[], Dict],
+        perform_create: Callable[[], Dict],
+        validate_operation_label: str,
+        validation_failure_prefix: str,
+        perform_verify: Callable[[], Dict],
+        verify_failure_message: str,
+        success_result: Callable[[Dict, Dict], Dict],
+        error_result: Callable[[Exception], Dict],
+        error_log_message: Callable[[Exception], str],
+    ) -> Dict:
+        """
+        Shared GeoServer-first create cycle: pre-check -> operation ->
+        response validation -> post-verify -> final response.
+
+        Every create_* method (create_workspace, create_store, ...) used to
+        repeat this exact five-step control flow with its own copy of the
+        try/except and validation/verification checks. This centralizes the
+        control flow; callers supply only what's resource-specific (the
+        actual GeoServer call, and the shape of each returned dict) via the
+        callables above. See create_workspace/create_store for usage.
+        """
+        try:
+            if exists_check():
+                return already_exists_result()
+
+            raw_result = perform_create()
+            validated_result = self.validate_response(raw_result, validate_operation_label)
+
+            if not validated_result.get('success', False):
+                raise GeoServerPublishError(
+                    f"{validation_failure_prefix}: {validated_result.get('message')}"
+                )
+
+            verification = perform_verify()
+            if not verification.get('verified', False):
+                raise GeoServerPublishError(
+                    verification.get('message') or verify_failure_message
+                )
+
+            return success_result(validated_result, verification)
+
+        except Exception as e:
+            logger.error(error_log_message(e))
+            return error_result(e)
+
+    def _delete_resource(
+        self,
+        *,
+        exists_check: Callable[[], bool],
+        already_deleted_result: Callable[[], Dict],
+        perform_delete: Callable[[], Optional[Dict]],
+        validate_operation_label: Optional[str],
+        validation_failure_prefix: str,
+        perform_verify: Callable[[], Dict],
+        verify_failure_message: str,
+        success_result: Callable[[Optional[Dict], Dict], Dict],
+        error_result: Callable[[Exception], Dict],
+        error_log_message: Callable[[Exception], str],
+    ) -> Dict:
+        """
+        Shared GeoServer-first delete cycle: pre-check -> operation ->
+        optional response validation -> post-verify -> final response.
+
+        `perform_delete` may return None when the underlying call has
+        nothing to validate (e.g. geoserver-rest's delete_featurestore()
+        returns a plain string on success and raises on failure) — in that
+        case the validation step is skipped, matching the original
+        per-method behavior exactly.
+        """
+        try:
+            if not exists_check():
+                return already_deleted_result()
+
+            raw_result = perform_delete()
+            validated_result = None
+            if raw_result is not None:
+                validated_result = self.validate_response(raw_result, validate_operation_label)
+                if not validated_result.get('success', False):
+                    raise GeoServerPublishError(
+                        f"{validation_failure_prefix}: {validated_result.get('message')}"
+                    )
+
+            verification = perform_verify()
+            if not verification.get('verified', False):
+                raise GeoServerPublishError(
+                    verification.get('message') or verify_failure_message
+                )
+
+            return success_result(validated_result, verification)
+
+        except Exception as e:
+            logger.error(error_log_message(e))
+            return error_result(e)
+
     # Workspace operations
 
     def create_workspace(self, name: str) -> Dict:
@@ -106,19 +204,7 @@ class GeoServerClient:
         """
         logger.info(f"Starting workspace creation with GeoServer-first pattern: {name}")
 
-        try:
-            # 1) PRE-CHECK: Does the workspace already exist?
-            if self.workspace_exists(name):
-                logger.info(f"Workspace {name} already exists (pre-check)")
-                return {
-                    'success': True,
-                    'workspace': name,
-                    'message': f"Workspace '{name}' already exists",
-                    'created': False,
-                    'pre_existed': True,
-                }
-
-            # 2) OPERATION: Create workspace in GeoServer.
+        def _perform_create() -> Dict:
             logger.info(f"Creating workspace in GeoServer: {name}")
             payload = f"<workspace><name>{name}</name></workspace>"
             logger.info("GeoServer create_workspace payload for '%s': %s", name, payload)
@@ -134,57 +220,61 @@ class GeoServerClient:
                 response.status_code,
                 response.text[:500],
             )
-            raw_result = {
+            return {
                 'success': response.status_code == 201,
                 'validated': response.status_code == 201,
                 'status_code': response.status_code,
                 'message': response.text.strip() or f"HTTP {response.status_code}",
             }
 
-            # 3) RESPONSE VALIDATION: Validate GeoServer response.
-            validated_result = self.validate_response(raw_result, f"create_workspace({name})")
-
-            if not validated_result.get('success', False):
-                raise GeoServerPublishError(
-                    f"Workspace creation failed validation: {validated_result.get('message')}"
-                )
-
-            # 4) POST-CHECK: Verify workspace creation.
+        def _perform_verify() -> Dict:
             verification = self.post_verify_workspace(name, expected_exists=True)
-
             if not verification.get('verified', False):
                 logger.error(f"Post-verification failed for workspace {name}: {verification['message']}")
-                raise GeoServerPublishError(
-                    verification.get('message')
-                    or f"Workspace '{name}' could not be verified in GeoServer after create."
-                )
+            return verification
 
-            # 5) FINAL RESPONSE: Return aggregated result details.
-            final_result = {
+        def _already_exists_result() -> Dict:
+            logger.info(f"Workspace {name} already exists (pre-check)")
+            return {
+                'success': True,
+                'workspace': name,
+                'message': f"Workspace '{name}' already exists",
+                'created': False,
+                'pre_existed': True,
+            }
+
+        result = self._create_resource(
+            exists_check=lambda: self.workspace_exists(name),
+            already_exists_result=_already_exists_result,
+            perform_create=_perform_create,
+            validate_operation_label=f"create_workspace({name})",
+            validation_failure_prefix="Workspace creation failed validation",
+            perform_verify=_perform_verify,
+            verify_failure_message=f"Workspace '{name}' could not be verified in GeoServer after create.",
+            success_result=lambda validated, verification: {
                 'success': True,
                 'workspace': name,
                 'message': f"Workspace '{name}' created successfully",
                 'created': True,
                 'pre_existed': False,
-                'validated': validated_result.get('validated', False),
+                'validated': validated.get('validated', False),
                 'verified': True,
-                'geoserver_response': validated_result,
-            }
-
-            logger.info(f"Workspace creation completed: {name} (verified: {verification.get('verified')})")
-            return final_result
-
-        except Exception as e:
-            logger.error(f"Failed to create workspace {name}: {e}")
-            # ERROR RECOVERY: Return recovery-needed signal.
-            return {
+                'geoserver_response': validated,
+            },
+            error_result=lambda e: {
                 'success': False,
                 'workspace': name,
                 'error': str(e),
                 'message': f"Failed to create workspace '{name}': {e}",
                 'created': False,
                 'recovery_needed': True,
-            }
+            },
+            error_log_message=lambda e: f"Failed to create workspace {name}: {e}",
+        )
+
+        if result.get('created'):
+            logger.info(f"Workspace creation completed: {name} (verified: {result.get('verified')})")
+        return result
 
     def delete_workspace(self, name: str) -> Dict:
         """
@@ -198,59 +288,60 @@ class GeoServerClient:
         """
         logger.info(f"Deleting workspace from GeoServer: {name}")
 
-        try:
-            # Check if workspace exists before deletion.
-            if not self.workspace_exists(name):
-                logger.info(f"Workspace {name} does not exist, nothing to delete")
-                return {
-                    'success': True,
-                    'workspace': name,
-                    'message': f"Workspace '{name}' does not exist",
-                    'deleted': False,
-                    'already_deleted': True,
-                }
+        def _already_deleted_result() -> Dict:
+            logger.info(f"Workspace {name} does not exist, nothing to delete")
+            return {
+                'success': True,
+                'workspace': name,
+                'message': f"Workspace '{name}' does not exist",
+                'deleted': False,
+                'already_deleted': True,
+            }
 
-            # Delete workspace from GeoServer.
+        def _perform_delete() -> Dict:
             response = self._request("delete", f"/rest/workspaces/{name}", params={"recurse": "true"})
+            return {
+                'success': response.status_code == 200,
+                'validated': response.status_code == 200,
+                'status_code': response.status_code,
+                'message': response.text.strip() or f"HTTP {response.status_code}",
+            }
 
-            # Validate response.
-            validated_result = self.validate_response(
-                {
-                    'success': response.status_code == 200,
-                    'validated': response.status_code == 200,
-                    'status_code': response.status_code,
-                    'message': response.text.strip() or f"HTTP {response.status_code}",
-                },
-                f"delete_workspace({name})",
-            )
-
-            if not validated_result.get('success', False):
-                raise GeoServerPublishError(
-                    f"Workspace deletion failed validation: {validated_result.get('message')}"
-                )
-
-            # Post-check: verify deletion.
+        def _perform_verify() -> Dict:
+            # Soft post-check: log a warning but never fail the deletion on
+            # this — matches the original behavior exactly.
             if self.workspace_exists(name):
                 logger.warning(f"Workspace {name} still exists after deletion attempt")
+            return {'verified': True}
 
+        def _success_result(validated: Dict, verification: Dict) -> Dict:
             logger.info(f"Workspace deleted successfully: {name}")
             return {
                 'success': True,
                 'workspace': name,
                 'message': f"Workspace '{name}' deleted successfully",
                 'deleted': True,
-                'geoserver_response': validated_result,
+                'geoserver_response': validated,
             }
 
-        except Exception as e:
-            logger.error(f"Failed to delete workspace {name}: {e}")
-            return {
+        return self._delete_resource(
+            exists_check=lambda: self.workspace_exists(name),
+            already_deleted_result=_already_deleted_result,
+            perform_delete=_perform_delete,
+            validate_operation_label=f"delete_workspace({name})",
+            validation_failure_prefix="Workspace deletion failed validation",
+            perform_verify=_perform_verify,
+            verify_failure_message=f"Workspace '{name}' could not be verified as deleted.",
+            success_result=_success_result,
+            error_result=lambda e: {
                 'success': False,
                 'workspace': name,
                 'error': str(e),
                 'message': f"Failed to delete workspace '{name}': {e}",
                 'deleted': False,
-            }
+            },
+            error_log_message=lambda e: f"Failed to delete workspace {name}: {e}",
+        )
 
     def workspace_exists(self, workspace: str) -> bool:
         """
@@ -863,22 +954,9 @@ class GeoServerClient:
         store_name = store_data.get('name')
         logger.info(f"Creating store '{store_name}' in workspace '{workspace}'")
 
-        try:
-            # 1) PRE-CHECK: Does the store already exist?
-            pre_check = self.pre_check_store(workspace, store_name)
-            if pre_check.get('exists', False):
-                return {
-                    'success': True,
-                    'store': store_name,
-                    'workspace': workspace,
-                    'message': f"Store '{store_name}' already exists",
-                    'created': False,
-                    'pre_existed': True,
-                }
-
-            # 2) OPERATION: Create datastore in GeoServer.
+        def _perform_create() -> Dict:
             logger.info(f"Creating PostGIS store in GeoServer: {store_name}")
-            raw_result = self._client.create_featurestore(
+            return self._client.create_featurestore(
                 store_name=store_name,
                 workspace=workspace,
                 db=store_data['database'],
@@ -889,16 +967,8 @@ class GeoServerClient:
                 pg_password=store_data['passwd'],
             )
 
-            # 3) RESPONSE VALIDATION.
-            validated_result = self.validate_response(raw_result, f"create_featurestore({store_name})")
-
-            if not validated_result.get('success', False):
-                raise GeoServerPublishError(
-                    f"Store creation failed validation: {validated_result.get('message')}"
-                )
-
-            # 4) POST-CHECK: Verify datastore creation.
-            verification = self.post_verify_store(
+        def _perform_verify() -> Dict:
+            return self.post_verify_store(
                 workspace,
                 store_name,
                 expected_exists=True,
@@ -910,37 +980,46 @@ class GeoServerClient:
                     'schema': store_data.get('schema', 'public'),
                 },
             )
-            if not verification.get('verified', False):
-                raise GeoServerPublishError(
-                    verification.get('message')
-                    or f"Store '{store_name}' could not be verified in GeoServer after create."
-                )
 
-            # 5) FINAL RESPONSE.
-            final_result = {
+        def _success_result(validated: Dict, verification: Dict) -> Dict:
+            logger.info(f"Store creation completed: {store_name} (verified: {verification.get('verified')})")
+            return {
                 'success': True,
                 'store': store_name,
                 'workspace': workspace,
                 'message': f"Store '{store_name}' created successfully",
                 'created': True,
                 'pre_existed': False,
-                'validated': validated_result.get('validated', False),
+                'validated': validated.get('validated', False),
                 'verified': verification.get('verified', False),
-                'geoserver_response': validated_result,
+                'geoserver_response': validated,
             }
 
-            logger.info(f"Store creation completed: {store_name} (verified: {verification.get('verified')})")
-            return final_result
-
-        except Exception as e:
-            logger.error(f"Failed to create store '{store_name}': {e}")
-            return {
+        return self._create_resource(
+            exists_check=lambda: self.pre_check_store(workspace, store_name).get('exists', False),
+            already_exists_result=lambda: {
+                'success': True,
+                'store': store_name,
+                'workspace': workspace,
+                'message': f"Store '{store_name}' already exists",
+                'created': False,
+                'pre_existed': True,
+            },
+            perform_create=_perform_create,
+            validate_operation_label=f"create_featurestore({store_name})",
+            validation_failure_prefix="Store creation failed validation",
+            perform_verify=_perform_verify,
+            verify_failure_message=f"Store '{store_name}' could not be verified in GeoServer after create.",
+            success_result=_success_result,
+            error_result=lambda e: {
                 'success': False,
                 'store': store_name,
                 'workspace': workspace,
                 'error': str(e),
                 'message': f"Store creation failed: {e}",
-            }
+            },
+            error_log_message=lambda e: f"Failed to create store '{store_name}': {e}",
+        )
 
     def delete_store(self, workspace: str, store: str) -> Dict:
         """
@@ -955,35 +1034,24 @@ class GeoServerClient:
         """
         logger.info(f"Deleting store '{store}' from workspace '{workspace}'")
 
-        try:
-            # Check if store exists before deletion.
-            pre_check = self.pre_check_store(workspace, store)
-            if not pre_check.get('exists', False):
-                logger.info(f"Store {store} does not exist in workspace {workspace}, nothing to delete")
-                return {
-                    'success': True,
-                    'store': store,
-                    'workspace': workspace,
-                    'message': f"Store '{store}' does not exist",
-                    'deleted': False,
-                    'already_deleted': True,
-                }
+        def _already_deleted_result() -> Dict:
+            logger.info(f"Store {store} does not exist in workspace {workspace}, nothing to delete")
+            return {
+                'success': True,
+                'store': store,
+                'workspace': workspace,
+                'message': f"Store '{store}' does not exist",
+                'deleted': False,
+                'already_deleted': True,
+            }
 
-            # Delete datastore from GeoServer.
-            # delete_featurestore() returns a plain string on success and raises
-            # GeoserverException on failure — no dict to validate.
-            self._client.delete_featurestore(
-                featurestore_name=store, workspace=workspace
-            )
+        def _perform_delete() -> Optional[Dict]:
+            # delete_featurestore() returns a plain string on success and
+            # raises GeoserverException on failure — no dict to validate.
+            self._client.delete_featurestore(featurestore_name=store, workspace=workspace)
+            return None
 
-            # Post-check: verify deletion.
-            verification = self.post_verify_store(workspace, store, expected_exists=False)
-            if not verification.get('verified', False):
-                raise GeoServerPublishError(
-                    verification.get('message')
-                    or f"Store '{store}' could not be verified as deleted in GeoServer."
-                )
-
+        def _success_result(validated: Optional[Dict], verification: Dict) -> Dict:
             logger.info(f"Store deleted successfully: {store} from workspace {workspace}")
             return {
                 'success': True,
@@ -994,16 +1062,25 @@ class GeoServerClient:
                 'verified': verification.get('verified', False),
             }
 
-        except Exception as e:
-            logger.error(f"Failed to delete store '{store}' from workspace '{workspace}': {e}")
-            return {
+        return self._delete_resource(
+            exists_check=lambda: self.pre_check_store(workspace, store).get('exists', False),
+            already_deleted_result=_already_deleted_result,
+            perform_delete=_perform_delete,
+            validate_operation_label=None,
+            validation_failure_prefix="Store deletion failed validation",
+            perform_verify=lambda: self.post_verify_store(workspace, store, expected_exists=False),
+            verify_failure_message=f"Store '{store}' could not be verified as deleted in GeoServer.",
+            success_result=_success_result,
+            error_result=lambda e: {
                 'success': False,
                 'store': store,
                 'workspace': workspace,
                 'error': str(e),
                 'message': f"Failed to delete store '{store}': {e}",
                 'deleted': False,
-            }
+            },
+            error_log_message=lambda e: f"Failed to delete store '{store}' from workspace '{workspace}': {e}",
+        )
 
     def pre_check_store(self, workspace: str, store_name: str) -> Dict:
         """Check if store already exists."""

--- a/tosca_api/apps/geodata_providers/tests/test_geoserver_client.py
+++ b/tosca_api/apps/geodata_providers/tests/test_geoserver_client.py
@@ -1,0 +1,379 @@
+"""
+Tests for GeoServerClient's shared create/delete resource helpers, plus the
+four methods that use them (create_workspace, delete_workspace,
+create_store, delete_store).
+
+Before this refactor, each of these four methods repeated the same
+five-step pre-check -> operate -> validate -> post-verify -> respond cycle
+independently, with no direct unit test coverage (existing tests mock
+GeoServerClient entirely at the service-layer boundary). These tests cover
+the shared control flow once via the helpers, then confirm each of the four
+methods still produces the exact same response shape as before.
+"""
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from tosca_api.apps.geodata_providers.geoserver.client import GeoServerClient
+
+
+def make_client():
+    """A GeoServerClient with the network-touching pieces mocked out."""
+    with patch(
+        "tosca_api.apps.geodata_providers.geoserver.client.GeoServerRestClient"
+    ) as mock_rest_client_cls:
+        client = GeoServerClient("http://geoserver.example.com/geoserver", "admin", "secret")
+        client._client = mock_rest_client_cls.return_value
+    return client
+
+
+class CreateResourceHelperTests(TestCase):
+    """Direct tests of _create_resource — the five-step cycle, tested once."""
+
+    def setUp(self):
+        self.client = make_client()
+
+    def test_short_circuits_when_resource_already_exists(self):
+        perform_create = MagicMock()
+
+        result = self.client._create_resource(
+            exists_check=lambda: True,
+            already_exists_result=lambda: {"success": True, "pre_existed": True},
+            perform_create=perform_create,
+            validate_operation_label="op",
+            validation_failure_prefix="failed",
+            perform_verify=MagicMock(),
+            verify_failure_message="not verified",
+            success_result=MagicMock(),
+            error_result=MagicMock(),
+            error_log_message=lambda e: str(e),
+        )
+
+        self.assertEqual(result, {"success": True, "pre_existed": True})
+        perform_create.assert_not_called()
+
+    def test_full_success_cycle_calls_every_step_in_order(self):
+        calls = []
+
+        def _create():
+            calls.append("create")
+            return {"success": True}
+
+        def _verify():
+            calls.append("verify")
+            return {"verified": True}
+
+        with patch.object(
+            self.client, "validate_response", return_value={"success": True, "validated": True}
+        ) as mock_validate:
+            result = self.client._create_resource(
+                exists_check=lambda: calls.append("exists_check") or False,
+                already_exists_result=MagicMock(),
+                perform_create=_create,
+                validate_operation_label="op",
+                validation_failure_prefix="failed",
+                perform_verify=_verify,
+                verify_failure_message="not verified",
+                success_result=lambda validated, verification: {
+                    "success": True,
+                    "validated": validated["validated"],
+                    "verified": verification["verified"],
+                },
+                error_result=MagicMock(),
+                error_log_message=lambda e: str(e),
+            )
+
+        self.assertEqual(calls, ["exists_check", "create", "verify"])
+        mock_validate.assert_called_once_with({"success": True}, "op")
+        self.assertEqual(result, {"success": True, "validated": True, "verified": True})
+
+    def test_validation_failure_routes_to_error_result(self):
+        with patch.object(
+            self.client, "validate_response", return_value={"success": False, "message": "bad"}
+        ):
+            result = self.client._create_resource(
+                exists_check=lambda: False,
+                already_exists_result=MagicMock(),
+                perform_create=lambda: {"success": False},
+                validate_operation_label="op",
+                validation_failure_prefix="Creation failed",
+                perform_verify=MagicMock(),
+                verify_failure_message="not verified",
+                success_result=MagicMock(),
+                error_result=lambda e: {"success": False, "error": str(e)},
+                error_log_message=lambda e: str(e),
+            )
+
+        self.assertFalse(result["success"])
+        self.assertIn("Creation failed", result["error"])
+
+    def test_verify_failure_routes_to_error_result(self):
+        with patch.object(
+            self.client, "validate_response", return_value={"success": True, "validated": True}
+        ):
+            result = self.client._create_resource(
+                exists_check=lambda: False,
+                already_exists_result=MagicMock(),
+                perform_create=lambda: {"success": True},
+                validate_operation_label="op",
+                validation_failure_prefix="failed",
+                perform_verify=lambda: {"verified": False, "message": "still missing"},
+                verify_failure_message="fallback message",
+                success_result=MagicMock(),
+                error_result=lambda e: {"success": False, "error": str(e)},
+                error_log_message=lambda e: str(e),
+            )
+
+        self.assertFalse(result["success"])
+        self.assertIn("still missing", result["error"])
+
+    def test_exception_in_exists_check_is_caught_by_the_same_handler(self):
+        """A pre-check exception must be caught the same way an operation
+        or verification exception is — regression guard for the refactor
+        moving exists_check inside the try block, not evaluated eagerly
+        before it.
+        """
+
+        def _boom():
+            raise ValueError("pre-check exploded")
+
+        result = self.client._create_resource(
+            exists_check=_boom,
+            already_exists_result=MagicMock(),
+            perform_create=MagicMock(),
+            validate_operation_label="op",
+            validation_failure_prefix="failed",
+            perform_verify=MagicMock(),
+            verify_failure_message="not verified",
+            success_result=MagicMock(),
+            error_result=lambda e: {"success": False, "error": str(e)},
+            error_log_message=lambda e: str(e),
+        )
+
+        self.assertFalse(result["success"])
+        self.assertIn("pre-check exploded", result["error"])
+
+
+class DeleteResourceHelperTests(TestCase):
+    """Direct tests of _delete_resource — the delete cycle, tested once."""
+
+    def setUp(self):
+        self.client = make_client()
+
+    def test_short_circuits_when_resource_already_absent(self):
+        perform_delete = MagicMock()
+
+        result = self.client._delete_resource(
+            exists_check=lambda: False,
+            already_deleted_result=lambda: {"success": True, "already_deleted": True},
+            perform_delete=perform_delete,
+            validate_operation_label="op",
+            validation_failure_prefix="failed",
+            perform_verify=MagicMock(),
+            verify_failure_message="not verified",
+            success_result=MagicMock(),
+            error_result=MagicMock(),
+            error_log_message=lambda e: str(e),
+        )
+
+        self.assertEqual(result, {"success": True, "already_deleted": True})
+        perform_delete.assert_not_called()
+
+    def test_perform_delete_returning_none_skips_validation(self):
+        """Matches delete_store: the vendored client call returns nothing
+        useful to validate — the validation step must be skipped entirely,
+        not called with None.
+        """
+        with patch.object(self.client, "validate_response") as mock_validate:
+            result = self.client._delete_resource(
+                exists_check=lambda: True,
+                already_deleted_result=MagicMock(),
+                perform_delete=lambda: None,
+                validate_operation_label=None,
+                validation_failure_prefix="failed",
+                perform_verify=lambda: {"verified": True},
+                verify_failure_message="not verified",
+                success_result=lambda validated, verification: {
+                    "success": True,
+                    "validated_was": validated,
+                },
+                error_result=MagicMock(),
+                error_log_message=lambda e: str(e),
+            )
+
+        mock_validate.assert_not_called()
+        self.assertEqual(result, {"success": True, "validated_was": None})
+
+    def test_perform_delete_returning_dict_is_validated(self):
+        with patch.object(
+            self.client, "validate_response", return_value={"success": True, "validated": True}
+        ) as mock_validate:
+            self.client._delete_resource(
+                exists_check=lambda: True,
+                already_deleted_result=MagicMock(),
+                perform_delete=lambda: {"success": True},
+                validate_operation_label="op",
+                validation_failure_prefix="failed",
+                perform_verify=lambda: {"verified": True},
+                verify_failure_message="not verified",
+                success_result=lambda validated, verification: {"success": True},
+                error_result=MagicMock(),
+                error_log_message=lambda e: str(e),
+            )
+
+        mock_validate.assert_called_once_with({"success": True}, "op")
+
+
+class CreateWorkspaceTests(TestCase):
+    def setUp(self):
+        self.client = make_client()
+
+    def test_already_exists_short_circuits(self):
+        with patch.object(self.client, "workspace_exists", return_value=True):
+            result = self.client.create_workspace("mobility")
+
+        self.assertEqual(
+            result,
+            {
+                "success": True,
+                "workspace": "mobility",
+                "message": "Workspace 'mobility' already exists",
+                "created": False,
+                "pre_existed": True,
+            },
+        )
+
+    def test_success_cycle(self):
+        response = MagicMock(status_code=201, text="")
+        with patch.object(self.client, "workspace_exists", return_value=False), \
+                patch.object(self.client, "_request", return_value=response), \
+                patch.object(
+                    self.client, "post_verify_workspace", return_value={"verified": True}
+                ):
+            result = self.client.create_workspace("mobility")
+
+        self.assertTrue(result["success"])
+        self.assertTrue(result["created"])
+        self.assertFalse(result["pre_existed"])
+        self.assertEqual(result["workspace"], "mobility")
+
+    def test_verify_failure_returns_recovery_needed(self):
+        response = MagicMock(status_code=201, text="")
+        with patch.object(self.client, "workspace_exists", return_value=False), \
+                patch.object(self.client, "_request", return_value=response), \
+                patch.object(
+                    self.client,
+                    "post_verify_workspace",
+                    return_value={"verified": False, "message": "gone"},
+                ):
+            result = self.client.create_workspace("mobility")
+
+        self.assertFalse(result["success"])
+        self.assertFalse(result["created"])
+        self.assertTrue(result["recovery_needed"])
+
+
+class DeleteWorkspaceTests(TestCase):
+    def setUp(self):
+        self.client = make_client()
+
+    def test_already_deleted_short_circuits(self):
+        with patch.object(self.client, "workspace_exists", return_value=False):
+            result = self.client.delete_workspace("mobility")
+
+        self.assertEqual(
+            result,
+            {
+                "success": True,
+                "workspace": "mobility",
+                "message": "Workspace 'mobility' does not exist",
+                "deleted": False,
+                "already_deleted": True,
+            },
+        )
+
+    def test_success_ignores_lingering_post_check(self):
+        """delete_workspace's post-check is soft: even if the workspace
+        still appears to exist afterwards, it only logs a warning and still
+        reports success — matches the pre-refactor behavior exactly.
+        """
+        response = MagicMock(status_code=200, text="")
+        with patch.object(self.client, "workspace_exists", side_effect=[True, True]), \
+                patch.object(self.client, "_request", return_value=response):
+            result = self.client.delete_workspace("mobility")
+
+        self.assertTrue(result["success"])
+        self.assertTrue(result["deleted"])
+
+
+class CreateStoreTests(TestCase):
+    def setUp(self):
+        self.client = make_client()
+        self.store_data = {
+            "name": "gis_store",
+            "database": "gis",
+            "host": "db",
+            "port": 5432,
+            "user": "postgres",
+            "passwd": "secret",
+            "schema": "public",
+        }
+
+    def test_already_exists_short_circuits(self):
+        with patch.object(self.client, "pre_check_store", return_value={"exists": True}):
+            result = self.client.create_store("mobility", self.store_data)
+
+        self.assertTrue(result["pre_existed"])
+        self.assertFalse(result["created"])
+        self.client._client.create_featurestore.assert_not_called()
+
+    def test_success_cycle(self):
+        with patch.object(self.client, "pre_check_store", return_value={"exists": False}), \
+                patch.object(
+                    self.client, "post_verify_store", return_value={"verified": True}
+                ):
+            self.client._client.create_featurestore.return_value = {"success": True}
+            result = self.client.create_store("mobility", self.store_data)
+
+        self.assertTrue(result["success"])
+        self.assertTrue(result["created"])
+        self.assertEqual(result["store"], "gis_store")
+        self.assertEqual(result["workspace"], "mobility")
+
+
+class DeleteStoreTests(TestCase):
+    def setUp(self):
+        self.client = make_client()
+
+    def test_already_deleted_short_circuits(self):
+        with patch.object(self.client, "pre_check_store", return_value={"exists": False}):
+            result = self.client.delete_store("mobility", "gis_store")
+
+        self.assertTrue(result["already_deleted"])
+        self.client._client.delete_featurestore.assert_not_called()
+
+    def test_success_cycle_skips_response_validation(self):
+        """delete_featurestore() has nothing to validate — regression guard
+        that this path doesn't call validate_response at all.
+        """
+        with patch.object(self.client, "pre_check_store", return_value={"exists": True}), \
+                patch.object(
+                    self.client, "post_verify_store", return_value={"verified": True}
+                ), \
+                patch.object(self.client, "validate_response") as mock_validate:
+            result = self.client.delete_store("mobility", "gis_store")
+
+        mock_validate.assert_not_called()
+        self.assertTrue(result["success"])
+        self.assertTrue(result["deleted"])
+
+    def test_verify_failure_returns_error(self):
+        with patch.object(self.client, "pre_check_store", return_value={"exists": True}), \
+                patch.object(
+                    self.client,
+                    "post_verify_store",
+                    return_value={"verified": False, "message": "still there"},
+                ):
+            result = self.client.delete_store("mobility", "gis_store")
+
+        self.assertFalse(result["success"])
+        self.assertIn("still there", result["error"])


### PR DESCRIPTION
Only create/delete_workspace and create/delete_store actually share the five-step pre-check/operate/validate/verify cycle (layer/style methods have different semantics and are left alone). Extracts _create_resource() and _delete_resource() to hold that flow once; per-resource details stay as small closures so response shapes are unchanged.

Adds 18 direct unit tests for GeoServerClient, which had none before (existing coverage mocks it at the service layer). Full suite: 755 passed (was 737).

## Summary

- [ ] Description of changes
- [ ] Related issue link

## Testing

- [ ] `uv run pytest`
- [ ] Other (describe)
