### PR TITLE
enforce the service layer as the only boundary

### DIFF
--- a/tosca_api/apps/geodata_providers/admin.py
+++ b/tosca_api/apps/geodata_providers/admin.py
@@ -186,9 +186,10 @@ def _run_workspace_sync(modeladmin, request, workspace):
 
     try:
         service = EngineClientFactory.create_sync_service(engine)
-        store_result = service.sync_stores_for_workspace(workspace, created_by=request.user)
-        style_result = service.sync_styles_for_scope(workspace, created_by=request.user)
-        layer_result = service.sync_layers_for_workspace(workspace, created_by=request.user)
+        results = service.sync_workspace_resources(workspace, created_by=request.user)
+        store_result = results['stores']
+        style_result = results['styles']
+        layer_result = results['layers']
     except (GeoServerConnectionError, GeodataEngineError) as exc:
         modeladmin.message_user(
             request,

--- a/tosca_api/apps/geodata_providers/admin_actions/engine.py
+++ b/tosca_api/apps/geodata_providers/admin_actions/engine.py
@@ -12,7 +12,6 @@ from django.contrib import admin, messages
 from ..engine_factory import EngineClientFactory
 from ..exceptions import GeoServerConnectionError, GeodataEngineError
 from ..services.commands.geodata_engine_service import GeodataEngineService
-from ..sync_service import GeoServerSyncService
 
 
 @admin.action(description="Sync selected providers into the local catalog")
@@ -20,7 +19,7 @@ def sync_engines(modeladmin, request, queryset):
     """Pull provider state into the local catalog for every selected engine."""
     for engine in queryset:
         try:
-            service = GeoServerSyncService(engine)
+            service = EngineClientFactory.create_sync_service(engine)
             result = service.sync_all_resources(created_by=request.user)
         except GeoServerConnectionError as e:
             modeladmin.message_user(

--- a/tosca_api/apps/geodata_providers/admin_actions/workspace.py
+++ b/tosca_api/apps/geodata_providers/admin_actions/workspace.py
@@ -4,8 +4,8 @@ Admin actions for Workspace.
 """
 from django.contrib import admin, messages
 
+from ..engine_factory import EngineClientFactory
 from ..exceptions import GeoServerConnectionError, GeodataEngineError
-from ..sync_service import GeoServerSyncService
 
 
 @admin.action(description="Sync selected workspaces into the local catalog")
@@ -32,16 +32,11 @@ def sync_workspaces(modeladmin, request, queryset):
         processed_engines.add(engine.pk)
 
         try:
-            service = GeoServerSyncService(engine)
-            store_result = service.sync_stores_for_workspace(
-                workspace, created_by=request.user
-            )
-            style_result = service.sync_styles_for_scope(
-                workspace, created_by=request.user
-            )
-            layer_result = service.sync_layers_for_workspace(
-                workspace, created_by=request.user
-            )
+            service = EngineClientFactory.create_sync_service(engine)
+            results = service.sync_workspace_resources(workspace, created_by=request.user)
+            store_result = results['stores']
+            style_result = results['styles']
+            layer_result = results['layers']
         except GeoServerConnectionError as e:
             modeladmin.message_user(
                 request,

--- a/tosca_api/apps/geodata_providers/admin_views/engine.py
+++ b/tosca_api/apps/geodata_providers/admin_views/engine.py
@@ -19,7 +19,6 @@ from ..engine_factory import EngineClientFactory
 from ..exceptions import GeoServerConnectionError, GeodataEngineError
 from ..models import GeodataEngine
 from ..services.commands.geodata_engine_service import GeodataEngineService
-from ..sync_service import GeoServerSyncService
 
 
 @require_POST
@@ -69,7 +68,7 @@ def engine_sync_view(request, engine_id):
         return JsonResponse({'error': 'Engine not found.'}, status=404)
 
     try:
-        service = GeoServerSyncService(engine)
+        service = EngineClientFactory.create_sync_service(engine)
         result = service.sync_all_resources(created_by=request.user)
     except GeoServerConnectionError as e:
         return JsonResponse({'success': False, 'error': f'Provider unreachable: {e}'}, status=502)

--- a/tosca_api/apps/geodata_providers/admin_views/layer.py
+++ b/tosca_api/apps/geodata_providers/admin_views/layer.py
@@ -18,7 +18,6 @@ from ..exceptions import GeoServerConnectionError, GeoServerPublishError
 from ..models import Layer, Store, Workspace
 from ..postgis_inspector import PostGISInspectorError, get_geometry_tables, get_table_bbox
 from ..services.commands.layer_service import LayerService
-from ..sync_service import GeoServerSyncService
 
 logger = logging.getLogger(__name__)
 
@@ -81,7 +80,7 @@ def publish_postgis_view(request):
                         f"in workspace '{workspace.name}'.",
                     )
                     try:
-                        service = GeoServerSyncService(workspace.geodata_engine)
+                        service = EngineClientFactory.create_sync_service(workspace.geodata_engine)
                         service.sync_styles_for_scope(workspace, created_by=request.user)
                         sync_result = service.sync_layers_for_workspace(workspace, created_by=request.user)
                         if sync_result.get('errors'):

--- a/tosca_api/apps/geodata_providers/admin_views/workspace.py
+++ b/tosca_api/apps/geodata_providers/admin_views/workspace.py
@@ -5,9 +5,9 @@ Admin views for Workspace.
 from django.http import JsonResponse
 from django.views.decorators.http import require_POST
 
+from ..engine_factory import EngineClientFactory
 from ..exceptions import GeoServerConnectionError, GeodataEngineError
 from ..models import Workspace
-from ..sync_service import GeoServerSyncService
 
 
 @require_POST
@@ -35,10 +35,11 @@ def workspace_sync_view(request, workspace_id):
         return JsonResponse({'error': 'Workspace has no engine attached.'}, status=400)
 
     try:
-        service = GeoServerSyncService(engine)
-        store_result = service.sync_stores_for_workspace(workspace, created_by=request.user)
-        style_result = service.sync_styles_for_scope(workspace, created_by=request.user)
-        layer_result = service.sync_layers_for_workspace(workspace, created_by=request.user)
+        service = EngineClientFactory.create_sync_service(engine)
+        results = service.sync_workspace_resources(workspace, created_by=request.user)
+        store_result = results['stores']
+        style_result = results['styles']
+        layer_result = results['layers']
     except GeoServerConnectionError as e:
         return JsonResponse({'success': False, 'error': f'Provider unreachable: {e}'}, status=502)
     except GeodataEngineError as e:

--- a/tosca_api/apps/geodata_providers/api/views.py
+++ b/tosca_api/apps/geodata_providers/api/views.py
@@ -24,7 +24,6 @@ from rest_framework.response import Response
 
 from ..engine_factory import EngineClientFactory
 from ..exceptions import GeoServerConnectionError, GeodataEngineError
-from ..geoserver.client import GeoServerClient
 from ..models import GeodataEngine, Layer, Store, Workspace
 from ..postgis_inspector import PostGISInspectorError, get_geometry_tables, get_table_bbox
 from ..services.commands.geodata_engine_service import GeodataEngineService
@@ -191,9 +190,7 @@ class GeodataEngineViewSet(viewsets.ModelViewSet):
         Does NOT modify Django state.
         """
         engine = get_object_or_404(GeodataEngine, pk=pk)
-        from ..sync_service import GeoServerSyncService
-
-        sync_service = GeoServerSyncService(engine)
+        sync_service = EngineClientFactory.create_sync_service(engine)
         result = sync_service.push_all_workspaces(created_by=request.user)
         code = status.HTTP_200_OK if result.get('success', False) else status.HTTP_400_BAD_REQUEST
         return Response(result, status=code)

--- a/tosca_api/apps/geodata_providers/management/commands/sync_geoserver.py
+++ b/tosca_api/apps/geodata_providers/management/commands/sync_geoserver.py
@@ -4,8 +4,8 @@ Ensures Django DB stays synchronized with GeoServer resources
 """
 from django.core.management.base import BaseCommand
 from django.contrib.auth.models import User
+from tosca_api.apps.geodata_providers.engine_factory import EngineClientFactory
 from tosca_api.apps.geodata_providers.models import GeodataEngine
-from tosca_api.apps.geodata_providers.sync_service import GeoServerSyncService
 
 
 class Command(BaseCommand):
@@ -81,7 +81,7 @@ class Command(BaseCommand):
                 continue
             
             try:
-                sync_service = GeoServerSyncService(engine)
+                sync_service = EngineClientFactory.create_sync_service(engine)
                 results = sync_service.sync_all_resources(created_by=sync_user)
                 
                 if results.get('success'):

--- a/tosca_api/apps/geodata_providers/sync_service.py
+++ b/tosca_api/apps/geodata_providers/sync_service.py
@@ -158,6 +158,23 @@ class GeoServerSyncService:
     def sync_layers_for_workspace(self, workspace: Workspace, created_by: User) -> Dict:
         return self._layer_syncer.sync_layers_for_workspace(workspace, created_by)
 
+    def sync_workspace_resources(self, workspace: Workspace, created_by: User) -> Dict:
+        """
+        Sync stores, styles, and layers for a single workspace (in that
+        order, matching sync_all_resources' resource ordering).
+
+        This is "sync a workspace" as a single call — previously the admin
+        action, the admin sync view, and the post-save sync hook each
+        repeated this same three-call sequence independently. Callers that
+        need individual error/count breakdowns can read result['stores'],
+        result['styles'], result['layers'].
+        """
+        return {
+            'stores': self.sync_stores_for_workspace(workspace, created_by),
+            'styles': self.sync_styles_for_scope(workspace, created_by),
+            'layers': self.sync_layers_for_workspace(workspace, created_by),
+        }
+
     def push_workspace(self, workspace: Workspace) -> Dict:
         return self._workspace_syncer.push_workspace(workspace)
 

--- a/tosca_api/apps/geodata_providers/tests/test_admin_forms.py
+++ b/tosca_api/apps/geodata_providers/tests/test_admin_forms.py
@@ -1104,16 +1104,16 @@ class LayerSurfaceRefactorTests(TestCase):
 
     @patch('tosca_api.apps.geodata_providers.admin_views.layer.messages.warning')
     @patch('tosca_api.apps.geodata_providers.admin_views.layer.messages.success')
-    @patch('tosca_api.apps.geodata_providers.admin_views.layer.GeoServerSyncService')
+    @patch('tosca_api.apps.geodata_providers.admin_views.layer.EngineClientFactory.create_sync_service')
     @patch('tosca_api.apps.geodata_providers.admin_views.layer.LayerService.publish_postgis')
-    def test_publish_postgis_view_uses_layer_service(self, mock_publish_postgis, mock_sync_service, mock_success, mock_warning):
+    def test_publish_postgis_view_uses_layer_service(self, mock_publish_postgis, mock_create_sync_service, mock_success, mock_warning):
         mock_publish_postgis.return_value = {
             'success': True,
             'created': True,
             'message': 'published',
             'resource': self.layer,
         }
-        mock_sync_service.return_value.sync_layers_for_workspace.return_value = {'errors': []}
+        mock_create_sync_service.return_value.sync_layers_for_workspace.return_value = {'errors': []}
         request = self.request_factory.post(
             '/admin/geodata_providers/layer/publish-postgis/',
             data={

--- a/tosca_api/apps/geodata_providers/tests/test_service_layer_boundary.py
+++ b/tosca_api/apps/geodata_providers/tests/test_service_layer_boundary.py
@@ -1,0 +1,74 @@
+"""
+Architectural regression guard: geoserver.client / sync_service must only
+be imported through engine_factory.EngineClientFactory. Every admin, admin
+action/view, DRF view, and management command should go through the
+factory so engine-type dispatch (GeoServer vs. the Martin placeholder)
+stays centralized in one place.
+
+This is a static/grep-style check rather than a runtime test, per the
+issue's own suggested test approach — the thing being guarded against is
+an import statement reappearing, not a behavior.
+"""
+import ast
+from pathlib import Path
+
+from django.test import SimpleTestCase
+
+APP_ROOT = Path(__file__).resolve().parent.parent
+
+# Files that ARE the service layer (or the factory that fronts it) — these
+# are allowed to import geoserver.client / sync_service directly.
+ALLOWED_FILES = {
+    APP_ROOT / "engine_factory.py",
+    APP_ROOT / "sync_service.py",
+}
+
+# Directories that are the sync layer itself, or test code (unit tests
+# legitimately construct the class under test directly). Note services/
+# is NOT excluded — services/commands/* should also go through the
+# factory, and currently does.
+ALLOWED_DIRS = {
+    APP_ROOT / "sync",
+    APP_ROOT / "tests",
+    APP_ROOT / "geoserver",
+}
+
+
+def _iter_app_python_files():
+    for path in APP_ROOT.rglob("*.py"):
+        if "__pycache__" in path.parts:
+            continue
+        if path in ALLOWED_FILES:
+            continue
+        if any(allowed_dir in path.parents for allowed_dir in ALLOWED_DIRS):
+            continue
+        yield path
+
+
+def _forbidden_imports_in(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(), filename=str(path))
+    hits = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ImportFrom):
+            continue
+        module = node.module or ""
+        if module.endswith("sync_service") or module.endswith("geoserver.client"):
+            hits.append(f"line {node.lineno}: from {'.' * node.level}{module} import ...")
+    return hits
+
+
+class ServiceLayerBoundaryTests(SimpleTestCase):
+    def test_no_view_or_admin_module_imports_sync_service_or_geoserver_client_directly(self):
+        violations = {}
+        for path in _iter_app_python_files():
+            hits = _forbidden_imports_in(path)
+            if hits:
+                violations[str(path.relative_to(APP_ROOT))] = hits
+
+        self.assertEqual(
+            violations,
+            {},
+            "The following files import sync_service/geoserver.client directly "
+            "instead of going through engine_factory.EngineClientFactory: "
+            f"{violations}",
+        )


### PR DESCRIPTION
api/views.py and admin.py bypassed the service layer in places — an unused GeoServerClient import, an inline sync_service import inside a method body, and a hand-rolled _run_workspace_sync that reimplemented sync orchestration. Grepping the app turned up six more spots doing the same thing, several of which instantiated GeoServerSyncService directly and so skipped EngineClientFactory's engine-type dispatch entirely (a Martin engine would get a real GeoServerClient instead of the placeholder).

Routed every admin action/view, DRF view, and management command through EngineClientFactory, and added a new GeoServerSyncService.sync_workspace_resources() to collapse the duplicated stores+styles+layers sync sequence into one call. Added an AST-based static test (test_service_layer_boundary.py) that fails if geoserver.client or sync_service is ever imported outside the factory again.

## Summary

- [ ] Description of changes
- [ ] Related issue link

## Testing

- [ ] `uv run pytest`
- [ ] Other (describe)
