### PR TITLE
typed results and a real exception hierarchy

### DIFF
--- a/tosca_api/apps/geodata_providers/geoserver/client.py
+++ b/tosca_api/apps/geodata_providers/geoserver/client.py
@@ -14,6 +14,7 @@ if geoserver_rest_path not in sys.path:
 
 from geo.Geoserver import Geoserver as GeoServerRestClient
 from ..exceptions import GeoServerConnectionError, GeoServerPublishError
+from ..results import OperationResult
 
 logger = logging.getLogger(__name__)
 
@@ -95,16 +96,16 @@ class GeoServerClient:
         self,
         *,
         exists_check: Callable[[], bool],
-        already_exists_result: Callable[[], Dict],
+        already_exists_result: Callable[[], OperationResult],
         perform_create: Callable[[], Dict],
         validate_operation_label: str,
         validation_failure_prefix: str,
         perform_verify: Callable[[], Dict],
         verify_failure_message: str,
-        success_result: Callable[[Dict, Dict], Dict],
-        error_result: Callable[[Exception], Dict],
+        success_result: Callable[[Dict, Dict], OperationResult],
+        error_result: Callable[[Exception], OperationResult],
         error_log_message: Callable[[Exception], str],
-    ) -> Dict:
+    ) -> OperationResult:
         """
         Shared GeoServer-first create cycle: pre-check -> operation ->
         response validation -> post-verify -> final response.
@@ -144,16 +145,16 @@ class GeoServerClient:
         self,
         *,
         exists_check: Callable[[], bool],
-        already_deleted_result: Callable[[], Dict],
+        already_deleted_result: Callable[[], OperationResult],
         perform_delete: Callable[[], Optional[Dict]],
         validate_operation_label: Optional[str],
         validation_failure_prefix: str,
         perform_verify: Callable[[], Dict],
         verify_failure_message: str,
-        success_result: Callable[[Optional[Dict], Dict], Dict],
-        error_result: Callable[[Exception], Dict],
+        success_result: Callable[[Optional[Dict], Dict], OperationResult],
+        error_result: Callable[[Exception], OperationResult],
         error_log_message: Callable[[Exception], str],
-    ) -> Dict:
+    ) -> OperationResult:
         """
         Shared GeoServer-first delete cycle: pre-check -> operation ->
         optional response validation -> post-verify -> final response.
@@ -191,7 +192,7 @@ class GeoServerClient:
 
     # Workspace operations
 
-    def create_workspace(self, name: str) -> Dict:
+    def create_workspace(self, name: str) -> OperationResult:
         """
         Create workspace in GeoServer using GeoServer-first pattern.
         Implements: Pre-Check -> Operation + Validation -> Post-Check
@@ -200,7 +201,7 @@ class GeoServerClient:
             name: Workspace name
 
         Returns:
-            Dict with success status and details
+            OperationResult with success status and details
         """
         logger.info(f"Starting workspace creation with GeoServer-first pattern: {name}")
 
@@ -233,15 +234,13 @@ class GeoServerClient:
                 logger.error(f"Post-verification failed for workspace {name}: {verification['message']}")
             return verification
 
-        def _already_exists_result() -> Dict:
+        def _already_exists_result() -> OperationResult:
             logger.info(f"Workspace {name} already exists (pre-check)")
-            return {
-                'success': True,
-                'workspace': name,
-                'message': f"Workspace '{name}' already exists",
-                'created': False,
-                'pre_existed': True,
-            }
+            return OperationResult(
+                success=True,
+                message=f"Workspace '{name}' already exists",
+                data={'workspace': name, 'created': False, 'pre_existed': True},
+            )
 
         result = self._create_resource(
             exists_check=lambda: self.workspace_exists(name),
@@ -251,24 +250,24 @@ class GeoServerClient:
             validation_failure_prefix="Workspace creation failed validation",
             perform_verify=_perform_verify,
             verify_failure_message=f"Workspace '{name}' could not be verified in GeoServer after create.",
-            success_result=lambda validated, verification: {
-                'success': True,
-                'workspace': name,
-                'message': f"Workspace '{name}' created successfully",
-                'created': True,
-                'pre_existed': False,
-                'validated': validated.get('validated', False),
-                'verified': True,
-                'geoserver_response': validated,
-            },
-            error_result=lambda e: {
-                'success': False,
-                'workspace': name,
-                'error': str(e),
-                'message': f"Failed to create workspace '{name}': {e}",
-                'created': False,
-                'recovery_needed': True,
-            },
+            success_result=lambda validated, verification: OperationResult(
+                success=True,
+                message=f"Workspace '{name}' created successfully",
+                data={
+                    'workspace': name,
+                    'created': True,
+                    'pre_existed': False,
+                    'validated': validated.get('validated', False),
+                    'verified': True,
+                    'geoserver_response': validated,
+                },
+            ),
+            error_result=lambda e: OperationResult(
+                success=False,
+                error=str(e),
+                message=f"Failed to create workspace '{name}': {e}",
+                data={'workspace': name, 'created': False, 'recovery_needed': True},
+            ),
             error_log_message=lambda e: f"Failed to create workspace {name}: {e}",
         )
 
@@ -276,7 +275,7 @@ class GeoServerClient:
             logger.info(f"Workspace creation completed: {name} (verified: {result.get('verified')})")
         return result
 
-    def delete_workspace(self, name: str) -> Dict:
+    def delete_workspace(self, name: str) -> OperationResult:
         """
         Delete workspace from GeoServer
 
@@ -284,19 +283,17 @@ class GeoServerClient:
             name: Workspace name
 
         Returns:
-            Dict with success status and details
+            OperationResult with success status and details
         """
         logger.info(f"Deleting workspace from GeoServer: {name}")
 
-        def _already_deleted_result() -> Dict:
+        def _already_deleted_result() -> OperationResult:
             logger.info(f"Workspace {name} does not exist, nothing to delete")
-            return {
-                'success': True,
-                'workspace': name,
-                'message': f"Workspace '{name}' does not exist",
-                'deleted': False,
-                'already_deleted': True,
-            }
+            return OperationResult(
+                success=True,
+                message=f"Workspace '{name}' does not exist",
+                data={'workspace': name, 'deleted': False, 'already_deleted': True},
+            )
 
         def _perform_delete() -> Dict:
             response = self._request("delete", f"/rest/workspaces/{name}", params={"recurse": "true"})
@@ -314,15 +311,13 @@ class GeoServerClient:
                 logger.warning(f"Workspace {name} still exists after deletion attempt")
             return {'verified': True}
 
-        def _success_result(validated: Dict, verification: Dict) -> Dict:
+        def _success_result(validated: Dict, verification: Dict) -> OperationResult:
             logger.info(f"Workspace deleted successfully: {name}")
-            return {
-                'success': True,
-                'workspace': name,
-                'message': f"Workspace '{name}' deleted successfully",
-                'deleted': True,
-                'geoserver_response': validated,
-            }
+            return OperationResult(
+                success=True,
+                message=f"Workspace '{name}' deleted successfully",
+                data={'workspace': name, 'deleted': True, 'geoserver_response': validated},
+            )
 
         return self._delete_resource(
             exists_check=lambda: self.workspace_exists(name),
@@ -333,13 +328,12 @@ class GeoServerClient:
             perform_verify=_perform_verify,
             verify_failure_message=f"Workspace '{name}' could not be verified as deleted.",
             success_result=_success_result,
-            error_result=lambda e: {
-                'success': False,
-                'workspace': name,
-                'error': str(e),
-                'message': f"Failed to delete workspace '{name}': {e}",
-                'deleted': False,
-            },
+            error_result=lambda e: OperationResult(
+                success=False,
+                error=str(e),
+                message=f"Failed to delete workspace '{name}': {e}",
+                data={'workspace': name, 'deleted': False},
+            ),
             error_log_message=lambda e: f"Failed to delete workspace {name}: {e}",
         )
 
@@ -940,7 +934,7 @@ class GeoServerClient:
 
         return []
 
-    def create_store(self, workspace: str, store_data: dict) -> Dict:
+    def create_store(self, workspace: str, store_data: dict) -> OperationResult:
         """
         Create PostGIS datastore in GeoServer using GeoServer-first pattern.
 
@@ -949,7 +943,7 @@ class GeoServerClient:
             store_data: Store connection details
 
         Returns:
-            Dict with creation results and verification status
+            OperationResult with creation results and verification status
         """
         store_name = store_data.get('name')
         logger.info(f"Creating store '{store_name}' in workspace '{workspace}'")
@@ -981,47 +975,45 @@ class GeoServerClient:
                 },
             )
 
-        def _success_result(validated: Dict, verification: Dict) -> Dict:
+        def _success_result(validated: Dict, verification: Dict) -> OperationResult:
             logger.info(f"Store creation completed: {store_name} (verified: {verification.get('verified')})")
-            return {
-                'success': True,
-                'store': store_name,
-                'workspace': workspace,
-                'message': f"Store '{store_name}' created successfully",
-                'created': True,
-                'pre_existed': False,
-                'validated': validated.get('validated', False),
-                'verified': verification.get('verified', False),
-                'geoserver_response': validated,
-            }
+            return OperationResult(
+                success=True,
+                message=f"Store '{store_name}' created successfully",
+                data={
+                    'store': store_name,
+                    'workspace': workspace,
+                    'created': True,
+                    'pre_existed': False,
+                    'validated': validated.get('validated', False),
+                    'verified': verification.get('verified', False),
+                    'geoserver_response': validated,
+                },
+            )
 
         return self._create_resource(
             exists_check=lambda: self.pre_check_store(workspace, store_name).get('exists', False),
-            already_exists_result=lambda: {
-                'success': True,
-                'store': store_name,
-                'workspace': workspace,
-                'message': f"Store '{store_name}' already exists",
-                'created': False,
-                'pre_existed': True,
-            },
+            already_exists_result=lambda: OperationResult(
+                success=True,
+                message=f"Store '{store_name}' already exists",
+                data={'store': store_name, 'workspace': workspace, 'created': False, 'pre_existed': True},
+            ),
             perform_create=_perform_create,
             validate_operation_label=f"create_featurestore({store_name})",
             validation_failure_prefix="Store creation failed validation",
             perform_verify=_perform_verify,
             verify_failure_message=f"Store '{store_name}' could not be verified in GeoServer after create.",
             success_result=_success_result,
-            error_result=lambda e: {
-                'success': False,
-                'store': store_name,
-                'workspace': workspace,
-                'error': str(e),
-                'message': f"Store creation failed: {e}",
-            },
+            error_result=lambda e: OperationResult(
+                success=False,
+                error=str(e),
+                message=f"Store creation failed: {e}",
+                data={'store': store_name, 'workspace': workspace},
+            ),
             error_log_message=lambda e: f"Failed to create store '{store_name}': {e}",
         )
 
-    def delete_store(self, workspace: str, store: str) -> Dict:
+    def delete_store(self, workspace: str, store: str) -> OperationResult:
         """
         Delete PostGIS datastore from GeoServer
 
@@ -1030,20 +1022,17 @@ class GeoServerClient:
             store: Store name
 
         Returns:
-            Dict with success status and details
+            OperationResult with success status and details
         """
         logger.info(f"Deleting store '{store}' from workspace '{workspace}'")
 
-        def _already_deleted_result() -> Dict:
+        def _already_deleted_result() -> OperationResult:
             logger.info(f"Store {store} does not exist in workspace {workspace}, nothing to delete")
-            return {
-                'success': True,
-                'store': store,
-                'workspace': workspace,
-                'message': f"Store '{store}' does not exist",
-                'deleted': False,
-                'already_deleted': True,
-            }
+            return OperationResult(
+                success=True,
+                message=f"Store '{store}' does not exist",
+                data={'store': store, 'workspace': workspace, 'deleted': False, 'already_deleted': True},
+            )
 
         def _perform_delete() -> Optional[Dict]:
             # delete_featurestore() returns a plain string on success and
@@ -1051,16 +1040,18 @@ class GeoServerClient:
             self._client.delete_featurestore(featurestore_name=store, workspace=workspace)
             return None
 
-        def _success_result(validated: Optional[Dict], verification: Dict) -> Dict:
+        def _success_result(validated: Optional[Dict], verification: Dict) -> OperationResult:
             logger.info(f"Store deleted successfully: {store} from workspace {workspace}")
-            return {
-                'success': True,
-                'store': store,
-                'workspace': workspace,
-                'message': f"Store '{store}' deleted successfully",
-                'deleted': True,
-                'verified': verification.get('verified', False),
-            }
+            return OperationResult(
+                success=True,
+                message=f"Store '{store}' deleted successfully",
+                data={
+                    'store': store,
+                    'workspace': workspace,
+                    'deleted': True,
+                    'verified': verification.get('verified', False),
+                },
+            )
 
         return self._delete_resource(
             exists_check=lambda: self.pre_check_store(workspace, store).get('exists', False),
@@ -1071,14 +1062,12 @@ class GeoServerClient:
             perform_verify=lambda: self.post_verify_store(workspace, store, expected_exists=False),
             verify_failure_message=f"Store '{store}' could not be verified as deleted in GeoServer.",
             success_result=_success_result,
-            error_result=lambda e: {
-                'success': False,
-                'store': store,
-                'workspace': workspace,
-                'error': str(e),
-                'message': f"Failed to delete store '{store}': {e}",
-                'deleted': False,
-            },
+            error_result=lambda e: OperationResult(
+                success=False,
+                error=str(e),
+                message=f"Failed to delete store '{store}': {e}",
+                data={'store': store, 'workspace': workspace, 'deleted': False},
+            ),
             error_log_message=lambda e: f"Failed to delete store '{store}' from workspace '{workspace}': {e}",
         )
 

--- a/tosca_api/apps/geodata_providers/results.py
+++ b/tosca_api/apps/geodata_providers/results.py
@@ -1,0 +1,35 @@
+"""
+Typed result for GeoServer-first create/delete orchestration
+(GeoServerClient._create_resource / _delete_resource and their callers:
+create_workspace, delete_workspace, create_store, delete_store).
+
+Supports dict-style read access (get/__getitem__/__contains__) so existing
+callers built around free-form dicts keep working unchanged; new or updated
+call sites should prefer the .success/.message/.error/.data attributes
+directly instead.
+"""
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+_TOP_LEVEL_KEYS = ("success", "message", "error")
+
+
+@dataclass
+class OperationResult:
+    success: bool
+    message: str = ""
+    error: Optional[str] = None
+    data: Dict[str, Any] = field(default_factory=dict)
+
+    def get(self, key: str, default=None):
+        if key in _TOP_LEVEL_KEYS:
+            return getattr(self, key)
+        return self.data.get(key, default)
+
+    def __getitem__(self, key: str):
+        if key in _TOP_LEVEL_KEYS:
+            return getattr(self, key)
+        return self.data[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in _TOP_LEVEL_KEYS or key in self.data

--- a/tosca_api/apps/geodata_providers/services/commands/geodata_engine_service.py
+++ b/tosca_api/apps/geodata_providers/services/commands/geodata_engine_service.py
@@ -322,4 +322,7 @@ class GeodataEngineService:
         try:
             return cls.sync_engine(engine, user=user)
         except Exception as exc:
+            # Post-save hook: a sync failure here must not block the admin
+            # save that triggered it, so it's reported as a failed-sync
+            # result instead of propagating.
             return {'success': False, 'skipped': False, 'error': str(exc)}

--- a/tosca_api/apps/geodata_providers/services/commands/store_service.py
+++ b/tosca_api/apps/geodata_providers/services/commands/store_service.py
@@ -530,6 +530,9 @@ class StoreService:
                 'errors': store_result.get('errors', []) + layer_result.get('errors', []),
             }
         except Exception as exc:
+            # Post-create hook: a sync failure here must not block the admin
+            # save that triggered it, so it's reported as a failed-sync
+            # result instead of propagating.
             return {'success': False, 'skipped': False, 'error': str(exc)}
 
     @classmethod
@@ -541,7 +544,7 @@ class StoreService:
         try:
             service = EngineClientFactory.create_sync_service(engine)
             return service.sync_layers_for_workspace(workspace, created_by=user)
-        except Exception as exc:
+        except Exception as exc:  # Post-update hook — same rationale as above.
             return {'success': False, 'skipped': False, 'error': str(exc)}
 
     @classmethod
@@ -644,6 +647,8 @@ class StoreService:
                     errors=result['errors'],
                 )
             except Exception as exc:
+                # Per-item isolation: one bad source layer must not abort
+                # cloning the rest of the store's layers.
                 result['errors'].append(f"Layer '{source_layer.name}' could not be cloned: {exc}")
 
         result['success'] = not result['errors']

--- a/tosca_api/apps/geodata_providers/services/commands/workspace_service.py
+++ b/tosca_api/apps/geodata_providers/services/commands/workspace_service.py
@@ -45,22 +45,24 @@ class WorkspaceService:
                 'resource': existing,
             }
 
-        remote_result = {'success': True, 'message': 'Created in DB', 'verified': True}
+        remote_verified = True
+        remote_result = None
         if engine:
             client = EngineClientFactory.create_client(engine)
             remote_result = client.create_workspace(normalized_name)
-            if not remote_result.get('success', False):
+            if not remote_result.success:
                 return {
                     'success': False,
                     'already_exists': False,
                     'already_deleted': False,
                     'blocked': False,
-                    'message': remote_result.get('message', 'Workspace create failed.'),
-                    'error': remote_result.get('error', remote_result.get('message', 'Workspace create failed.')),
-                    'verified': remote_result.get('verified', False),
+                    'message': remote_result.message or 'Workspace create failed.',
+                    'error': remote_result.error or remote_result.message or 'Workspace create failed.',
+                    'verified': remote_result.data.get('verified', False),
                     'resource': None,
                     'remote_result': remote_result,
                 }
+            remote_verified = remote_result.data.get('verified', True)
 
         with transaction.atomic():
             workspace = Workspace.objects.create(
@@ -68,7 +70,7 @@ class WorkspaceService:
                 name=normalized_name,
                 description=description,
                 sync_state=(
-                    'SYNCED' if engine and remote_result.get('verified', True)
+                    'SYNCED' if engine and remote_verified
                     else 'STALE' if engine
                     else 'LOCAL_ONLY'
                 ),
@@ -83,7 +85,7 @@ class WorkspaceService:
             'created': True,
             'already_exists': False,
             'already_deleted': False,
-            'verified': remote_result.get('verified'),
+            'verified': remote_verified,
             'message': f"Workspace '{normalized_name}' created successfully.",
             'error': None,
             'resource': workspace,
@@ -107,30 +109,32 @@ class WorkspaceService:
             }
 
         engine = workspace.geodata_engine
-        remote_result = {'success': True, 'message': 'Deleted from DB only.', 'verified': True}
+        already_deleted = False
+        verified = True
+        remote_result = None
         if engine:
             client = EngineClientFactory.create_client(engine)
             remote_result = client.delete_workspace(workspace.name)
-            if not remote_result.get('success', False):
+            if not remote_result.success:
                 cls._mark_failed(
                     workspace,
-                    remote_result.get('error', remote_result.get('message', 'Engine failed to delete the workspace.')),
+                    remote_result.error or remote_result.message or 'Engine failed to delete the workspace.',
                 )
                 return {
                     'success': False,
                     'already_exists': False,
                     'already_deleted': False,
                     'blocked': False,
-                    'message': remote_result.get('message', 'Engine failed to delete the workspace.'),
-                    'error': remote_result.get('error', remote_result.get('message', 'Engine failed to delete the workspace.')),
-                    'verified': remote_result.get('verified', False),
+                    'message': remote_result.message or 'Engine failed to delete the workspace.',
+                    'error': remote_result.error or remote_result.message or 'Engine failed to delete the workspace.',
+                    'verified': remote_result.data.get('verified', False),
                     'resource': workspace,
                     'remote_result': remote_result,
                 }
+            already_deleted = remote_result.data.get('already_deleted', False)
+            verified = remote_result.data.get('verified')
 
         workspace_name = workspace.name
-        already_deleted = remote_result.get('already_deleted', False)
-        verified = remote_result.get('verified')
         workspace.delete()
         return {
             'success': True,

--- a/tosca_api/apps/geodata_providers/sync/layer_syncer.py
+++ b/tosca_api/apps/geodata_providers/sync/layer_syncer.py
@@ -69,6 +69,9 @@ class LayerSyncer(BaseSyncer):
                 str(e),
             )
             raise
+        # Genuinely-unexpected fallback below the known GeoServerConnectionError
+        # case above — kept broad so a bug here still reports a sync error
+        # instead of crashing the admin action that called this.
         except Exception as e:
             error = f"Failed to get layers for workspace {workspace.name}: {e}"
             results['errors'].append(error)
@@ -150,6 +153,8 @@ class LayerSyncer(BaseSyncer):
                     results['synced'] += 1
                     logger.info(f"✅ Synced layer: {workspace.name}/{layer_name}")
 
+            # Per-item isolation: one bad remote layer must not abort
+            # the whole sync loop — record it and keep going.
             except Exception as e:
                 error_msg = f"Failed to sync layer {layer_data.get('name')}: {e}"
                 results['errors'].append(error_msg)
@@ -174,6 +179,7 @@ class LayerSyncer(BaseSyncer):
                 layer.delete()
                 results['deleted'] += 1
                 logger.info(f"🗑️ Deleted layer: {workspace.name}/{layer_name}")
+            # Per-item isolation: same as above, for the delete pass.
             except Exception as e:
                 error_msg = f"Failed to delete layer {layer_name}: {e}"
                 results['errors'].append(error_msg)

--- a/tosca_api/apps/geodata_providers/sync/store_syncer.py
+++ b/tosca_api/apps/geodata_providers/sync/store_syncer.py
@@ -65,6 +65,9 @@ class StoreSyncer(BaseSyncer):
                 str(e),
             )
             raise
+        # Genuinely-unexpected fallback below the known GeoServerConnectionError
+        # case above — kept broad so a bug here still reports a sync error
+        # instead of crashing the admin action that called this.
         except Exception as e:
             error = f"Failed to get stores for workspace {workspace.name}: {e}"
             results['errors'].append(error)
@@ -140,6 +143,8 @@ class StoreSyncer(BaseSyncer):
                     results['synced'] += 1
                     logger.info(f"✅ Synced store: {workspace.name}/{store_name}")
 
+            # Per-item isolation: one bad remote store must not abort
+            # the whole sync loop — record it and keep going.
             except Exception as e:
                 error_msg = f"Failed to sync store {store_data.get('name')}: {e}"
                 results['errors'].append(error_msg)
@@ -164,6 +169,7 @@ class StoreSyncer(BaseSyncer):
                 store.delete()
                 results['deleted'] += 1
                 logger.info(f"🗑️ Deleted store: {workspace.name}/{store_name}")
+            # Per-item isolation: same as above, for the delete pass.
             except Exception as e:
                 error_msg = f"Failed to delete store {store_name}: {e}"
                 results['errors'].append(error_msg)

--- a/tosca_api/apps/geodata_providers/sync/style_syncer.py
+++ b/tosca_api/apps/geodata_providers/sync/style_syncer.py
@@ -67,6 +67,9 @@ class StyleSyncer(BaseSyncer):
                 str(e),
             )
             raise
+        # Genuinely-unexpected fallback below the known GeoServerConnectionError
+        # case above — kept broad so a bug here still reports a sync error
+        # instead of crashing the admin action that called this.
         except Exception as e:
             scope = workspace.name if workspace else 'global'
             error = f"Failed to sync styles for {scope}: {e}"
@@ -133,6 +136,8 @@ class StyleSyncer(BaseSyncer):
                 else:
                     results['synced'] += 1
                     logger.info("✅ Synced style: %s", style.qualified_name)
+            # Per-item isolation: one bad remote style must not abort
+            # the whole sync loop — record it and keep going.
             except Exception as e:
                 error_msg = f"Failed to sync style {style_data.get('name')}: {e}"
                 results['errors'].append(error_msg)
@@ -154,6 +159,7 @@ class StyleSyncer(BaseSyncer):
                 style.delete()
                 results['deleted'] += 1
                 logger.info("🗑️ Deleted style: %s", style_name)
+            # Per-item isolation: same as above, for the delete pass.
             except Exception as e:
                 error_msg = f"Failed to delete style {style_name}: {e}"
                 results['errors'].append(error_msg)

--- a/tosca_api/apps/geodata_providers/sync/workspace_syncer.py
+++ b/tosca_api/apps/geodata_providers/sync/workspace_syncer.py
@@ -55,6 +55,9 @@ class WorkspaceSyncer(BaseSyncer):
             )
             raise
         except Exception as e:
+            # Genuinely-unexpected fallback below the known GeoServerConnectionError
+            # case above — kept broad so a bug here still reports a sync error
+            # instead of crashing the admin action that called this.
             error = f"Failed to sync workspaces: {e}"
             results['errors'].append(error)
             self._mark_queryset_sync_failed(
@@ -97,6 +100,8 @@ class WorkspaceSyncer(BaseSyncer):
                     logger.info(f"✅ Synced workspace: {ws_name}")
 
             except Exception as e:
+                # Per-item isolation: one bad remote workspace must not abort
+                # the whole sync loop — record it and keep going.
                 error_msg = f"Failed to sync workspace {ws_name}: {e}"
                 results['errors'].append(error_msg)
                 logger.error(error_msg)
@@ -121,6 +126,7 @@ class WorkspaceSyncer(BaseSyncer):
                 results['deleted'] += 1
                 logger.info(f"🗑️ Deleted workspace: {ws_name}")
             except Exception as e:
+                # Per-item isolation: same as above, for the delete pass.
                 error_msg = f"Failed to delete workspace {ws_name}: {e}"
                 results['errors'].append(error_msg)
                 logger.error(error_msg)
@@ -157,8 +163,8 @@ class WorkspaceSyncer(BaseSyncer):
 
             # 2. Create in GeoServer
             create_result = self.client.create_workspace(workspace.name)
-            if not create_result.get('success', False):
-                error = create_result.get('error', create_result.get('message', 'Unknown error'))
+            if not create_result.success:
+                error = create_result.error or create_result.message or 'Unknown error'
                 logger.error(f"Push workspace '{workspace.name}' create failed: {error}")
                 self._mark_sync_failed(workspace, error)
                 result['error'] = error
@@ -179,6 +185,8 @@ class WorkspaceSyncer(BaseSyncer):
             return result
 
         except Exception as e:
+            # Genuinely-unexpected fallback for a single-workspace push — the
+            # caller (push_all_workspaces) isolates this per workspace already.
             logger.error(f"Push workspace '{workspace.name}' unexpected error: {e}")
             self._mark_sync_failed(workspace, str(e))
             result['error'] = str(e)
@@ -241,14 +249,14 @@ class WorkspaceSyncer(BaseSyncer):
 
         # 1. Delete from engine FIRST
         delete_result = self.client.delete_workspace(workspace.name)
-        if not delete_result.get('success', False):
-            error = delete_result.get('error', delete_result.get('message', 'Engine delete failed'))
+        if not delete_result.success:
+            error = delete_result.error or delete_result.message or 'Engine delete failed'
             logger.error(f"delete_workspace_safe '{workspace.name}': engine delete failed — {error}")
             result['error'] = error
             result['detail'] = 'Django object NOT deleted — engine deletion must succeed first.'
             return result
 
-        was_already_deleted = bool(delete_result.get('already_deleted'))
+        was_already_deleted = bool(delete_result.data.get('already_deleted'))
 
         # 2. Verify: workspace is actually gone from engine
         try:

--- a/tosca_api/apps/geodata_providers/sync_service.py
+++ b/tosca_api/apps/geodata_providers/sync_service.py
@@ -77,6 +77,10 @@ class GeoServerSyncService:
             return results
 
         except Exception as e:
+            # Final safety net for the whole multi-resource sync — each
+            # sync_* call above already isolates its own per-item errors
+            # into its results dict, so reaching here means something
+            # genuinely unexpected broke the orchestration itself.
             logger.error(f"Sync failed: {e}")
             results['success'] = False
             results['error'] = str(e)

--- a/tosca_api/apps/geodata_providers/tests/test_geoserver_client.py
+++ b/tosca_api/apps/geodata_providers/tests/test_geoserver_client.py
@@ -231,16 +231,11 @@ class CreateWorkspaceTests(TestCase):
         with patch.object(self.client, "workspace_exists", return_value=True):
             result = self.client.create_workspace("mobility")
 
-        self.assertEqual(
-            result,
-            {
-                "success": True,
-                "workspace": "mobility",
-                "message": "Workspace 'mobility' already exists",
-                "created": False,
-                "pre_existed": True,
-            },
-        )
+        self.assertTrue(result.success)
+        self.assertEqual(result.message, "Workspace 'mobility' already exists")
+        self.assertEqual(result["workspace"], "mobility")
+        self.assertFalse(result["created"])
+        self.assertTrue(result["pre_existed"])
 
     def test_success_cycle(self):
         response = MagicMock(status_code=201, text="")
@@ -280,16 +275,11 @@ class DeleteWorkspaceTests(TestCase):
         with patch.object(self.client, "workspace_exists", return_value=False):
             result = self.client.delete_workspace("mobility")
 
-        self.assertEqual(
-            result,
-            {
-                "success": True,
-                "workspace": "mobility",
-                "message": "Workspace 'mobility' does not exist",
-                "deleted": False,
-                "already_deleted": True,
-            },
-        )
+        self.assertTrue(result.success)
+        self.assertEqual(result.message, "Workspace 'mobility' does not exist")
+        self.assertEqual(result["workspace"], "mobility")
+        self.assertFalse(result["deleted"])
+        self.assertTrue(result["already_deleted"])
 
     def test_success_ignores_lingering_post_check(self):
         """delete_workspace's post-check is soft: even if the workspace

--- a/tosca_api/apps/geodata_providers/tests/test_workspace_service.py
+++ b/tosca_api/apps/geodata_providers/tests/test_workspace_service.py
@@ -6,6 +6,7 @@ from django.test import RequestFactory, TestCase
 
 from tosca_api.apps.geodata_providers.admin import DeleteAborted, WorkspaceAdmin, WorkspaceAdminForm
 from tosca_api.apps.geodata_providers.models import GeodataEngine, Layer, Store, Workspace
+from tosca_api.apps.geodata_providers.results import OperationResult
 from tosca_api.apps.geodata_providers.services.commands.workspace_service import WorkspaceService
 
 
@@ -32,7 +33,9 @@ class WorkspaceServiceTestCase(TestCase):
     @patch('tosca_api.apps.geodata_providers.services.commands.workspace_service.EngineClientFactory.create_client')
     def test_create_workspace_persists_after_remote_create(self, mock_create_client):
         client = mock_create_client.return_value
-        client.create_workspace.return_value = {'success': True, 'verified': True, 'message': 'created'}
+        client.create_workspace.return_value = OperationResult(
+            success=True, message='created', data={'verified': True}
+        )
 
         result = WorkspaceService.create_workspace(
             engine=self.engine,
@@ -105,12 +108,9 @@ class WorkspaceServiceTestCase(TestCase):
 
     @patch('tosca_api.apps.geodata_providers.services.commands.workspace_service.EngineClientFactory.create_client')
     def test_delete_workspace_safe_deletes_after_remote_delete(self, mock_create_client):
-        mock_create_client.return_value.delete_workspace.return_value = {
-            'success': True,
-            'verified': True,
-            'already_deleted': False,
-            'message': 'deleted',
-        }
+        mock_create_client.return_value.delete_workspace.return_value = OperationResult(
+            success=True, message='deleted', data={'verified': True, 'already_deleted': False}
+        )
 
         result = WorkspaceService.delete_workspace_safe(self.workspace)
 


### PR DESCRIPTION
GeoServerClient's create/delete-workspace and create/delete-store methods returned free-form dicts with inconsistent shapes, and their shared _create_resource/_delete_resource orchestration helpers were the clearest instance of the report's "repeated GeoServer-first orchestration dicts" finding. Introduced OperationResult(success, message, error, data) and switched these four methods (and their direct callers in WorkspaceSyncer and WorkspaceService) to it, with dict-style get()/[]/in kept for backward compatibility so unmigrated callers are unaffected.

Also swept the remaining except Exception blocks touched by this work — sync loops, post-save sync hooks, the workspace/store/style/ layer syncers — and added a one-line comment on each explaining why it's an accepted integration or per-item-isolation boundary rather than an oversight.

## Summary

- [ ] Description of changes
- [ ] Related issue link

## Testing

- [ ] `uv run pytest`
- [ ] Other (describe)
