### PR TITLE
delete the Martin/PG_Tileserv placeholder abstraction

### DIFF
--- a/tosca_api/apps/geodata_providers/admin.py
+++ b/tosca_api/apps/geodata_providers/admin.py
@@ -243,6 +243,17 @@ class GeodataEngineForm(forms.ModelForm):
             'description': forms.Textarea(attrs={'rows': 3}),
         }
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # MARTIN/PG_TILESERV have no working client implementation — hide them
+        # from selection, but keep a pre-existing row's own type selectable so
+        # editing it doesn't fail on a field the user isn't even changing.
+        current = getattr(self.instance, 'engine_type', None)
+        allowed = {GeodataEngine.EngineType.GEOSERVER, current} if current else {GeodataEngine.EngineType.GEOSERVER}
+        self.fields['engine_type'].choices = [
+            choice for choice in GeodataEngine.EngineType.choices if choice[0] in allowed
+        ]
+
     def clean(self):
         cleaned_data = super().clean()
         if self.errors:

--- a/tosca_api/apps/geodata_providers/api/serializers.py
+++ b/tosca_api/apps/geodata_providers/api/serializers.py
@@ -109,7 +109,18 @@ class GeodataEngineSerializer(serializers.ModelSerializer):
             'updated_at',
         ]
         read_only_fields = ['id', 'created_at', 'updated_at', 'engine_url', 'geoserver_url']
-    
+
+    def validate_engine_type(self, value):
+        # MARTIN/PG_TILESERV have no working client implementation — block
+        # selecting them, but allow a pre-existing row to keep its own value
+        # unchanged so unrelated field updates on it don't get rejected.
+        current = getattr(self.instance, 'engine_type', None)
+        if value != GeodataEngine.EngineType.GEOSERVER and value != current:
+            raise serializers.ValidationError(
+                f"Engine type '{value}' is not currently supported. Only 'geoserver' can be selected."
+            )
+        return value
+
     def update(self, instance, validated_data):
         password = validated_data.pop('admin_password', None)
         # Only update the password if it's provided

--- a/tosca_api/apps/geodata_providers/engine_factory.py
+++ b/tosca_api/apps/geodata_providers/engine_factory.py
@@ -1,62 +1,9 @@
 """Engine client factory for geoengine API workflows."""
 
-from typing import Dict
-
-from .exceptions import GeodataEngineError
+from .exceptions import UnsupportedEngineError
 from .geoserver.client import GeoServerClient
 from .models import GeodataEngine
 from .sync_service import GeoServerSyncService
-
-
-class MartinClientPlaceholder:
-    """Placeholder for future Martin integration."""
-
-    def __init__(self, engine: GeodataEngine):
-        self.engine = engine
-
-    def _not_implemented(self) -> Dict:
-        return {
-            'success': False,
-            'not_implemented': True,
-            'engine_type': 'martin',
-            'message': 'Martin client is not implemented yet',
-        }
-
-    def get_workspaces(self):
-        return []
-
-    def validate_connection(self):
-        return self._not_implemented()
-
-    def create_workspace(self, name: str):
-        return self._not_implemented()
-
-    def delete_workspace(self, name: str):
-        return self._not_implemented()
-
-    def create_store(self, workspace: str, store_data: dict):
-        return self._not_implemented()
-
-    def publish_featuretype(self, **kwargs):
-        return self._not_implemented()
-
-    def delete_layer(self, workspace: str, layer_name: str):
-        return self._not_implemented()
-
-
-class MartinSyncPlaceholder:
-    """Placeholder for future Martin sync implementation."""
-
-    def __init__(self, engine: GeodataEngine):
-        self.engine = engine
-
-    def sync_all_resources(self, created_by) -> Dict:
-        return {
-            'success': False,
-            'not_implemented': True,
-            'engine_type': 'martin',
-            'message': 'Martin sync is not implemented yet',
-        }
 
 
 class EngineClientFactory:
@@ -69,17 +16,11 @@ class EngineClientFactory:
                 password=engine.decrypted_admin_password,
             )
 
-        if engine.engine_type == 'martin':
-            return MartinClientPlaceholder(engine)
-
-        raise GeodataEngineError(f"Unsupported engine type: {engine.engine_type}")
+        raise UnsupportedEngineError(f"Unsupported engine type: {engine.engine_type}")
 
     @staticmethod
     def create_sync_service(engine: GeodataEngine):
         if engine.engine_type == 'geoserver':
             return GeoServerSyncService(engine)
 
-        if engine.engine_type == 'martin':
-            return MartinSyncPlaceholder(engine)
-
-        raise GeodataEngineError(f"Unsupported engine type: {engine.engine_type}")
+        raise UnsupportedEngineError(f"Unsupported engine type: {engine.engine_type}")

--- a/tosca_api/apps/geodata_providers/exceptions.py
+++ b/tosca_api/apps/geodata_providers/exceptions.py
@@ -31,3 +31,8 @@ class GeoServerConnectionError(PublishingError):
 class GeoServerPublishError(PublishingError):
     """Exception raised when GeoServer publishing fails"""
     pass
+
+
+class UnsupportedEngineError(GeodataEngineError):
+    """Exception raised when a GeodataEngine's engine_type has no working client/sync implementation"""
+    pass

--- a/tosca_api/apps/geodata_providers/tests/test_engine_factory.py
+++ b/tosca_api/apps/geodata_providers/tests/test_engine_factory.py
@@ -1,0 +1,110 @@
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+from tosca_api.apps.geodata_providers.admin import GeodataEngineForm
+from tosca_api.apps.geodata_providers.api.serializers import GeodataEngineSerializer
+from tosca_api.apps.geodata_providers.engine_factory import EngineClientFactory
+from tosca_api.apps.geodata_providers.exceptions import UnsupportedEngineError
+from tosca_api.apps.geodata_providers.geoserver.client import GeoServerClient
+from tosca_api.apps.geodata_providers.models import GeodataEngine
+from tosca_api.apps.geodata_providers.sync_service import GeoServerSyncService
+
+
+class EngineClientFactoryTestCase(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username='factory-user', password='testpass123')
+
+    def _make_engine(self, engine_type: str) -> GeodataEngine:
+        return GeodataEngine.objects.create(
+            name=f'{engine_type}-engine',
+            description='test',
+            engine_type=engine_type,
+            base_url='http://example.com/engine',
+            public_url='http://example.com/engine',
+            admin_username='admin',
+            admin_password='secret',
+            created_by=self.user,
+        )
+
+    def test_create_client_returns_geoserver_client_for_geoserver_engine(self):
+        engine = self._make_engine('geoserver')
+
+        client = EngineClientFactory.create_client(engine)
+
+        self.assertIsInstance(client, GeoServerClient)
+
+    def test_create_sync_service_returns_geoserver_sync_service_for_geoserver_engine(self):
+        engine = self._make_engine('geoserver')
+
+        service = EngineClientFactory.create_sync_service(engine)
+
+        self.assertIsInstance(service, GeoServerSyncService)
+
+    def test_create_client_raises_unsupported_engine_error_for_martin(self):
+        engine = self._make_engine('martin')
+
+        with self.assertRaises(UnsupportedEngineError):
+            EngineClientFactory.create_client(engine)
+
+    def test_create_sync_service_raises_unsupported_engine_error_for_martin(self):
+        engine = self._make_engine('martin')
+
+        with self.assertRaises(UnsupportedEngineError):
+            EngineClientFactory.create_sync_service(engine)
+
+    def test_create_client_raises_unsupported_engine_error_for_pg_tileserv(self):
+        engine = self._make_engine('pg_tileserv')
+
+        with self.assertRaises(UnsupportedEngineError):
+            EngineClientFactory.create_client(engine)
+
+    def test_create_sync_service_raises_unsupported_engine_error_for_pg_tileserv(self):
+        engine = self._make_engine('pg_tileserv')
+
+        with self.assertRaises(UnsupportedEngineError):
+            EngineClientFactory.create_sync_service(engine)
+
+
+class EngineTypeChoiceHidingTestCase(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username='choice-user', password='testpass123')
+
+    def test_admin_form_hides_martin_for_new_engine(self):
+        form = GeodataEngineForm()
+
+        choice_values = {value for value, _ in form.fields['engine_type'].choices}
+
+        self.assertIn('geoserver', choice_values)
+        self.assertNotIn('martin', choice_values)
+        self.assertNotIn('pg_tileserv', choice_values)
+
+    def test_admin_form_keeps_existing_martin_engine_editable(self):
+        engine = GeodataEngine.objects.create(
+            name='legacy-martin',
+            description='test',
+            engine_type='martin',
+            base_url='http://example.com/engine',
+            public_url='http://example.com/engine',
+            admin_username='admin',
+            admin_password='secret',
+            created_by=self.user,
+        )
+
+        form = GeodataEngineForm(instance=engine)
+
+        choice_values = {value for value, _ in form.fields['engine_type'].choices}
+        self.assertIn('martin', choice_values)
+
+    def test_serializer_rejects_martin_for_new_engine(self):
+        serializer = GeodataEngineSerializer(data={
+            'name': 'new-martin',
+            'description': 'test',
+            'engine_type': 'martin',
+            'base_url': 'http://example.com/engine',
+            'public_url': 'http://example.com/engine',
+            'admin_username': 'admin',
+            'admin_password': 'secret',
+        })
+
+        self.assertFalse(serializer.is_valid())
+        self.assertIn('engine_type', serializer.errors)


### PR DESCRIPTION
MartinClientPlaceholder and MartinSyncPlaceholder built real abstraction machinery for two engine types that never worked, with no contract enforcing what a "real" client/sync implementation would need to look like. Removed both classes; EngineClientFactory now raises a new UnsupportedEngineError for any non-GeoServer engine type, which the existing GeodataEngineError handlers at every call site already catch.

Also hid martin/pg_tileserv from the engine_type choices in the admin form and API serializer so they can't be newly selected, while still allowing a pre-existing row of either type to be viewed and edited without its own saved value getting rejected. Added test_engine_factory.py covering the new error path and the choice restriction.

## Summary

- [ ] Description of changes
- [ ] Related issue link

## Testing

- [ ] `uv run pytest`
- [ ] Other (describe)
