### PR TITLE
Thin LayerViewSet.update and similar fat views

### DIFF
--- a/tosca_api/apps/geodata_providers/api/views.py
+++ b/tosca_api/apps/geodata_providers/api/views.py
@@ -27,7 +27,7 @@ from ..exceptions import GeoServerConnectionError, GeodataEngineError
 from ..models import GeodataEngine, Layer, Store, Workspace
 from ..postgis_inspector import PostGISInspectorError, get_geometry_tables, get_table_bbox
 from ..services.commands.geodata_engine_service import GeodataEngineService
-from ..services.commands.layer_service import LayerService
+from ..services.commands.layer_service import LayerService, LayerUpdateService
 from ..services.commands.store_service import StoreService
 from ..services.commands.workspace_service import WorkspaceService
 from .serializers import GeodataEngineSerializer, LayerSerializer, StoreSerializer, WorkspaceSerializer
@@ -456,53 +456,17 @@ class LayerViewSet(viewsets.ModelViewSet):
     def update(self, request, *args, **kwargs):
         """
         PATCH/PUT /api/v1/providers/provider/layers/<id>/
-
-        Allowed editable fields:
-            title, description  — synced to GeoServer (if PUBLISHED) then Django
-            srid                — Django-only
-
-        All other fields (name, table_name, workspace, store, geometry_*)
-        are silently ignored — they cannot be changed via this endpoint.
+        See LayerUpdateService for the allowed-fields contract.
         """
-        partial = kwargs.pop('partial', True)  # always treat as partial
         layer = self.get_object()
-
-        # Extract only the fields we allow to be changed
-        ALLOWED = {'title', 'description', 'srid'}
-        incoming = {k: v for k, v in request.data.items() if k in ALLOWED}
-
-        if not incoming:
-            return Response(
-                {'detail': 'No editable fields provided. Allowed: title, description, srid.'},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-
-        if layer.publishing_state == 'PUBLISHED' and {'title', 'description'} & set(incoming):
-            try:
-                LayerService.update_published_metadata(
-                    layer=layer,
-                    title=incoming.get('title', layer.title),
-                    description=incoming.get('description', layer.description),
-                )
-            except Exception as exc:
-                logger.error(
-                    'LayerViewSet.update: featuretype update failed for %s/%s: %s',
-                    layer.workspace.name, layer.name, exc,
-                )
-                return Response(
-                    {'success': False, 'error': f'GeoServer featuretype update failed: {exc}'},
-                    status=status.HTTP_400_BAD_REQUEST,
-                )
-            incoming = {key: value for key, value in incoming.items() if key not in {'title', 'description'}}
-            layer.refresh_from_db()
-
-        if incoming:
-            serializer = self.get_serializer(layer, data=incoming, partial=True)
-            serializer.is_valid(raise_exception=True)
-            self.perform_update(serializer)
-            return Response(serializer.data)
-
-        return Response(self.get_serializer(layer).data)
+        result = LayerUpdateService.apply(
+            layer=layer,
+            fields=request.data,
+            serializer_class=self.get_serializer_class(),
+        )
+        if not result['success']:
+            return Response(result['body'], status=result['status_code'])
+        return Response(self.get_serializer(result['layer']).data)
 
     def destroy(self, request, *args, **kwargs):
         layer = self.get_object()

--- a/tosca_api/apps/geodata_providers/services/commands/layer_service.py
+++ b/tosca_api/apps/geodata_providers/services/commands/layer_service.py
@@ -1,3 +1,5 @@
+import logging
+
 from django.db import transaction
 from django.utils import timezone
 
@@ -5,6 +7,8 @@ from ...engine_factory import EngineClientFactory
 from ...exceptions import GeodataEngineError
 from ...models import Layer, Store, Workspace
 from ...postgis_inspector import PostGISInspectorError, get_table_bbox
+
+logger = logging.getLogger(__name__)
 
 
 class LayerService:
@@ -404,3 +408,56 @@ class LayerService:
             )
         except (PostGISInspectorError, Exception):
             return None
+
+
+class LayerUpdateService:
+    """
+    Applies a PATCH/PUT to a Layer for LayerViewSet.update.
+
+    Allowed editable fields:
+        title, description  — synced to GeoServer (if PUBLISHED) then Django
+        srid                — Django-only
+
+    All other fields (name, table_name, workspace, store, geometry_*) are
+    silently ignored — they cannot be changed via this endpoint.
+    """
+
+    ALLOWED_FIELDS = {'title', 'description', 'srid'}
+
+    @classmethod
+    def apply(cls, *, layer: Layer, fields: dict, serializer_class) -> dict:
+        incoming = {k: v for k, v in fields.items() if k in cls.ALLOWED_FIELDS}
+
+        if not incoming:
+            return {
+                'success': False,
+                'status_code': 400,
+                'body': {'detail': 'No editable fields provided. Allowed: title, description, srid.'},
+            }
+
+        if layer.publishing_state == 'PUBLISHED' and {'title', 'description'} & set(incoming):
+            try:
+                LayerService.update_published_metadata(
+                    layer=layer,
+                    title=incoming.get('title', layer.title),
+                    description=incoming.get('description', layer.description),
+                )
+            except Exception as exc:
+                logger.error(
+                    'LayerUpdateService.apply: featuretype update failed for %s/%s: %s',
+                    layer.workspace.name, layer.name, exc,
+                )
+                return {
+                    'success': False,
+                    'status_code': 400,
+                    'body': {'success': False, 'error': f'GeoServer featuretype update failed: {exc}'},
+                }
+            incoming = {key: value for key, value in incoming.items() if key not in {'title', 'description'}}
+            layer.refresh_from_db()
+
+        if incoming:
+            serializer = serializer_class(layer, data=incoming, partial=True)
+            serializer.is_valid(raise_exception=True)
+            serializer.save()
+
+        return {'success': True, 'layer': layer}

--- a/tosca_api/apps/geodata_providers/tests/test_api_views.py
+++ b/tosca_api/apps/geodata_providers/tests/test_api_views.py
@@ -3,6 +3,7 @@ from django.test import TestCase
 from rest_framework.test import APIRequestFactory, force_authenticate
 
 from tosca_api.apps.geodata_providers.api.views import LayerViewSet
+from tosca_api.apps.geodata_providers.models import GeodataEngine, Layer, Store, Workspace
 
 # NOTE: tosca_api/apps/geodata_providers/api/urls.py is not currently included
 # in tosca_api/urls.py, so this endpoint has no resolvable URL yet. The view
@@ -47,3 +48,78 @@ class LayerPreviewEndpointTests(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data['preview']['detected_type'], 'unknown')
+
+
+class LayerUpdateEndpointTests(TestCase):
+    """Regression tests for LayerViewSet.update() (issue 45: thin the view,
+    push the allowed-fields/publish-sync logic into LayerUpdateService).
+    """
+
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        self.user = User.objects.create_user(
+            username='layer_update_user', password='x', is_staff=True, is_superuser=True,
+        )
+        self.engine = GeodataEngine.objects.create(
+            name='Update Endpoint Engine',
+            description='test',
+            engine_type='geoserver',
+            base_url='http://example.com/geoserver',
+            public_url='http://example.com/geoserver',
+            admin_username='admin',
+            admin_password='secret',
+            created_by=self.user,
+        )
+        self.workspace = Workspace.objects.create(
+            geodata_engine=self.engine,
+            name='demo_ws',
+            description='workspace',
+            created_by=self.user,
+        )
+        self.store = Store.objects.create(
+            workspace=self.workspace,
+            name='demo_store',
+            description='store',
+            store_type='postgis',
+            host='db',
+            port=5432,
+            database='gis',
+            username='postgres',
+            password='secret',
+            schema='public',
+            created_by=self.user,
+        )
+        self.layer = Layer.objects.create(
+            workspace=self.workspace,
+            store=self.store,
+            name='roads',
+            title='Old Title',
+            description='old',
+            table_name='roads',
+            geometry_column='geom',
+            geometry_type='LineString',
+            srid=4326,
+            publishing_state='DRAFT',
+            created_by=self.user,
+        )
+        self.view = LayerViewSet.as_view({'patch': 'update'})
+
+    def _patch(self, data):
+        request = self.factory.patch(f'/layers/{self.layer.pk}/', data, format='json')
+        force_authenticate(request, user=self.user)
+        return self.view(request, pk=str(self.layer.pk))
+
+    def test_update_rejects_request_with_no_editable_fields(self):
+        response = self._patch({'name': 'renamed'})
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('detail', response.data)
+
+    def test_update_applies_allowed_fields_and_ignores_the_rest(self):
+        response = self._patch({'title': 'New Title', 'srid': 3857, 'name': 'renamed'})
+
+        self.assertEqual(response.status_code, 200)
+        self.layer.refresh_from_db()
+        self.assertEqual(self.layer.title, 'New Title')
+        self.assertEqual(self.layer.srid, 3857)
+        self.assertEqual(self.layer.name, 'roads')

--- a/tosca_api/apps/geodata_providers/tests/test_layer_service.py
+++ b/tosca_api/apps/geodata_providers/tests/test_layer_service.py
@@ -3,8 +3,9 @@ from unittest.mock import patch
 from django.contrib.auth.models import User
 from django.test import TestCase
 
+from tosca_api.apps.geodata_providers.api.serializers import LayerSerializer
 from tosca_api.apps.geodata_providers.models import GeodataEngine, Layer, Store, Workspace
-from tosca_api.apps.geodata_providers.services.commands.layer_service import LayerService
+from tosca_api.apps.geodata_providers.services.commands.layer_service import LayerService, LayerUpdateService
 
 
 class LayerServiceTestCase(TestCase):
@@ -122,4 +123,114 @@ class LayerServiceTestCase(TestCase):
 
         self.assertTrue(result['success'])
         self.assertFalse(Layer.objects.filter(pk=layer.pk).exists())
+
+
+class LayerUpdateServiceTestCase(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username='layer-update-user', password='testpass123')
+        self.engine = GeodataEngine.objects.create(
+            name='Layer Update Engine',
+            description='test',
+            engine_type='geoserver',
+            base_url='http://example.com/geoserver',
+            public_url='http://example.com/geoserver',
+            admin_username='admin',
+            admin_password='secret',
+            created_by=self.user,
+        )
+        self.workspace = Workspace.objects.create(
+            geodata_engine=self.engine,
+            name='demo_ws',
+            description='workspace',
+            created_by=self.user,
+        )
+        self.store = Store.objects.create(
+            workspace=self.workspace,
+            name='demo_store',
+            description='store',
+            store_type='postgis',
+            host='db',
+            port=5432,
+            database='gis',
+            username='postgres',
+            password='secret',
+            schema='public',
+            created_by=self.user,
+        )
+        self.layer = Layer.objects.create(
+            workspace=self.workspace,
+            store=self.store,
+            name='roads',
+            title='Old Title',
+            description='old',
+            table_name='roads',
+            geometry_column='geom',
+            geometry_type='LineString',
+            srid=4326,
+            publishing_state='DRAFT',
+            created_by=self.user,
+        )
+
+    def test_apply_rejects_empty_field_set(self):
+        result = LayerUpdateService.apply(
+            layer=self.layer,
+            fields={'name': 'should_be_ignored'},
+            serializer_class=LayerSerializer,
+        )
+
+        self.assertFalse(result['success'])
+        self.assertEqual(result['status_code'], 400)
+        self.assertIn('detail', result['body'])
+
+    def test_apply_updates_draft_layer_via_serializer(self):
+        result = LayerUpdateService.apply(
+            layer=self.layer,
+            fields={'title': 'New Title', 'srid': 3857, 'name': 'ignored'},
+            serializer_class=LayerSerializer,
+        )
+
+        self.assertTrue(result['success'])
+        self.layer.refresh_from_db()
+        self.assertEqual(self.layer.title, 'New Title')
+        self.assertEqual(self.layer.srid, 3857)
+        self.assertEqual(self.layer.name, 'roads')
+
+    @patch('tosca_api.apps.geodata_providers.services.commands.layer_service.EngineClientFactory.create_client')
+    def test_apply_syncs_published_layer_metadata_then_updates_django_only_fields(self, mock_create_client):
+        self.layer.publishing_state = 'PUBLISHED'
+        self.layer.save(update_fields=['publishing_state'])
+        client = mock_create_client.return_value
+        client.update_featuretype.return_value = {'success': True}
+        client.verify_featuretype_metadata.return_value = {'verified': True, 'mismatches': {}, 'actual': {}}
+
+        result = LayerUpdateService.apply(
+            layer=self.layer,
+            fields={'title': 'Published Title', 'srid': 3857},
+            serializer_class=LayerSerializer,
+        )
+
+        self.assertTrue(result['success'])
+        self.layer.refresh_from_db()
+        self.assertEqual(self.layer.title, 'Published Title')
+        self.assertEqual(self.layer.srid, 3857)
+        client.update_featuretype.assert_called_once()
+
+    @patch('tosca_api.apps.geodata_providers.services.commands.layer_service.EngineClientFactory.create_client')
+    def test_apply_returns_error_when_published_metadata_sync_fails(self, mock_create_client):
+        self.layer.publishing_state = 'PUBLISHED'
+        self.layer.save(update_fields=['publishing_state'])
+        client = mock_create_client.return_value
+        client.update_featuretype.side_effect = RuntimeError('geoserver unreachable')
+
+        result = LayerUpdateService.apply(
+            layer=self.layer,
+            fields={'title': 'Published Title'},
+            serializer_class=LayerSerializer,
+        )
+
+        self.assertFalse(result['success'])
+        self.assertEqual(result['status_code'], 400)
+        self.assertIn('error', result['body'])
+        self.layer.refresh_from_db()
+        self.assertEqual(self.layer.title, 'Old Title')
 


### PR DESCRIPTION
LayerViewSet.update was 50 lines mixing field-allowlist filtering, a publishing-state check, a GeoServer metadata sync call with inline exception handling, a DB refresh, and conditional serialization. Moved all of that into a new LayerUpdateService.apply(layer, fields, serializer_class) in layer_service.py, which returns a plain success/status_code/body result. The view is now: get the object, call the service, build the Response — no business branching left.

Also fixed the dead `partial` local variable this replaced (a pre-existing ruff finding). Added LayerUpdateServiceTestCase covering the service directly, plus LayerUpdateEndpointTests since no API-level test previously exercised LayerViewSet.update at all.

## Summary

- [ ] Description of changes
- [ ] Related issue link

## Testing

- [ ] `uv run pytest`
- [ ] Other (describe)
