### PR TITLE
fix URL routing duplication

### DIFF
--- a/tosca_api/apps/core/tests/test_url_routing.py
+++ b/tosca_api/apps/core/tests/test_url_routing.py
@@ -1,0 +1,62 @@
+"""
+Regression tests for issue 20: tosca_api/urls.py had duplicate imports, a
+duplicate admin/logout/ route registration, and mounts
+tosca_api.apps.authentication.urls at both '' and 'accounts/' — which turned
+out to be load-bearing (LOGIN_REDIRECT_URL uses the root prefix,
+LOGIN_URL/LOGOUT_REDIRECT_URL use the accounts/ prefix), so it's kept as a
+documented, tested alias rather than removed.
+"""
+from django.conf import settings
+from django.test import SimpleTestCase
+from django.urls import Resolver404, resolve, reverse
+
+from tosca_api.apps.authentication.views import KeycloakLogoutView
+from tosca_api.urls import urlpatterns
+
+
+class AdminLogoutRouteTests(SimpleTestCase):
+    def test_admin_logout_registered_exactly_once(self):
+        matches = [
+            pattern for pattern in urlpatterns
+            if getattr(pattern, "pattern", None) is not None
+            and str(pattern.pattern) == "admin/logout/"
+        ]
+        self.assertEqual(len(matches), 1)
+
+    def test_admin_logout_resolves_to_keycloak_logout_view(self):
+        match = resolve("/admin/logout/")
+        self.assertIs(match.func.view_class, KeycloakLogoutView)
+
+
+class SpectacularRoutesTests(SimpleTestCase):
+    def test_schema_docs_redoc_resolve_to_expected_paths(self):
+        self.assertEqual(reverse("schema"), "/api/v1/schema/")
+        self.assertEqual(reverse("swagger-ui"), "/api/v1/docs/")
+        self.assertEqual(reverse("redoc"), "/api/v1/redoc/")
+
+
+class AuthUrlAliasTests(SimpleTestCase):
+    """The root/accounts/ duplication is intentional: settings reference
+    paths under both prefixes, so both must resolve.
+    """
+
+    def test_settings_referenced_auth_paths_all_resolve(self):
+        referenced_paths = {
+            settings.LOGIN_URL,
+            settings.LOGIN_REDIRECT_URL,
+            settings.LOGOUT_REDIRECT_URL,
+        }
+        for path in referenced_paths:
+            with self.subTest(path=path):
+                try:
+                    resolve(path)
+                except Resolver404:
+                    self.fail(f"{path!r} is referenced by settings but does not resolve to any view.")
+
+    def test_authentication_urls_resolve_under_both_prefixes(self):
+        for path in ("/welcome/", "/accounts/welcome/", "/login/", "/accounts/login/", "/logout/", "/accounts/logout/"):
+            with self.subTest(path=path):
+                try:
+                    resolve(path)
+                except Resolver404:
+                    self.fail(f"{path!r} should resolve under the root/accounts/ authentication alias.")

--- a/tosca_api/urls.py
+++ b/tosca_api/urls.py
@@ -10,7 +10,6 @@ from drf_spectacular.views import (
     SpectacularRedocView,
     SpectacularSwaggerView,
 )
-from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 
 from tosca_api.apps.authentication.views import KeycloakLogoutView
 from tosca_api.views import base
@@ -22,7 +21,6 @@ urlpatterns = [
     path('api/v1/docs/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
     path('api/v1/redoc/', SpectacularRedocView.as_view(url_name='schema'), name='redoc'),
     # App URLs
-    path('', include('tosca_api.apps.authentication.urls')),  # ← Include authentication app URLs
     path('api/v1/', include('tosca_api.apps.campaigns.urls')),
     path('api/v1/', include('tosca_api.apps.geostories.urls')),
     path('api/v1/', include('tosca_api.apps.events.urls')),
@@ -30,10 +28,19 @@ urlpatterns = [
     path("api/v1/", include("tosca_api.apps.core.urls")),
     path("api/v1/", include("tosca_api.apps.geocontext.urls")),
     path('api/v1/catalog/', include('tosca_api.apps.catalog_api.urls'), name='catalog_api'),
-    path('admin/logout/', KeycloakLogoutView.as_view(), name='admin_logout'),
+    # Authentication is mounted at both root and accounts/ deliberately:
+    # settings reference paths under both prefixes (LOGIN_REDIRECT_URL=
+    # /welcome/ at root, LOGIN_URL=/accounts/login/ and LOGOUT_REDIRECT_URL=
+    # /accounts/logout/ under accounts/). See test_url_routing.py, which
+    # resolves every settings-referenced auth path against this urlconf.
+    # NOTE: because this root mount is registered before the path('', base)
+    # pattern below, its own '' sub-route (welcome_view, name='home') always
+    # wins for GET / — the base view is unreachable. Pre-existing behavior,
+    # not introduced by this cleanup; left as-is pending a product decision
+    # on what should render at '/'.
+    path('', include('tosca_api.apps.authentication.urls')),
     path('', base, name='base'),
-    path('accounts/', include('tosca_api.apps.authentication.urls')),  # Include allauth URLs for authentication
-    # Backward-compatible alias (can be removed after clients migrate).
+    path('accounts/', include('tosca_api.apps.authentication.urls')),
     path('admin/', admin.site.urls),
 ]
 


### PR DESCRIPTION
tosca_api/urls.py imported SpectacularAPIView/SpectacularSwaggerView twice and registered admin/logout/ twice. Removed both duplicates and added a URL resolution test (test_url_routing.py) asserting admin/logout/ appears exactly once and resolves to KeycloakLogoutView.

The authentication app is also included at both root and accounts/. Investigated whether this was accidental: settings actually reference paths under both prefixes (LOGIN_REDIRECT_URL=/welcome/ at root, LOGIN_URL and LOGOUT_REDIRECT_URL under accounts/), so removing either mount would break real login/logout redirects. Kept both, documented why in urls.py, and added tests resolving every settings-referenced auth path plus the shared route names under each prefix.

## Summary

- [ ] Description of changes
- [ ] Related issue link

## Testing

- [ ] `uv run pytest`
- [ ] Other (describe)
