### PR TITLE
add health and readiness endpoints

### DIFF
--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -138,7 +138,7 @@ services:
       --timeout ${GUNICORN_TIMEOUT:-120}
       tosca_api.wsgi:application
     healthcheck:
-      test: ["CMD-SHELL", "curl -fsS -H \"Host: $${DJANGO_HEALTHCHECK_HOST:-localhost}\" http://127.0.0.1:8000/ >/dev/null"]
+      test: ["CMD-SHELL", "curl -fsS -H \"Host: $${DJANGO_HEALTHCHECK_HOST:-localhost}\" http://127.0.0.1:8000/readyz >/dev/null"]
       interval: 30s
       timeout: 5s
       retries: 5

--- a/tosca_api/apps/core/tests/test_health_endpoints.py
+++ b/tosca_api/apps/core/tests/test_health_endpoints.py
@@ -1,0 +1,40 @@
+from unittest.mock import patch
+
+from django.db import OperationalError
+from django.test import SimpleTestCase
+from django.urls import reverse
+
+
+class HealthzTests(SimpleTestCase):
+    def test_healthz_returns_200(self):
+        response = self.client.get(reverse('healthz'))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {'status': 'ok'})
+
+    @patch('tosca_api.views.connections')
+    def test_healthz_ignores_database_state(self, mock_connections):
+        # healthz must not touch the DB at all — a broken connection mock
+        # should have zero effect on its response.
+        mock_connections.__getitem__.side_effect = AssertionError('healthz must not query connections')
+
+        response = self.client.get(reverse('healthz'))
+
+        self.assertEqual(response.status_code, 200)
+
+
+class ReadyzTests(SimpleTestCase):
+    databases = {'default'}  # readyz opens a real DB connection on the happy path
+
+    def test_readyz_returns_200_when_db_reachable(self):
+        response = self.client.get(reverse('readyz'))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {'status': 'ok'})
+
+    @patch('tosca_api.views.connections')
+    def test_readyz_returns_503_when_db_unreachable(self, mock_connections):
+        mock_connections['default'].ensure_connection.side_effect = OperationalError('connection refused')
+
+        response = self.client.get(reverse('readyz'))
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.json()['status'], 'unavailable')

--- a/tosca_api/urls.py
+++ b/tosca_api/urls.py
@@ -12,10 +12,14 @@ from drf_spectacular.views import (
 )
 
 from tosca_api.apps.authentication.views import KeycloakLogoutView
-from tosca_api.views import base
+from tosca_api.views import base, healthz, readyz
 
 urlpatterns = [
     path('admin/logout/', KeycloakLogoutView.as_view(), name='admin_logout'),  # Override Django admin logout
+    # Health/readiness (see tosca_api/views.py — healthz is liveness-only,
+    # readyz checks DB connectivity).
+    path('healthz', healthz, name='healthz'),
+    path('readyz', readyz, name='readyz'),
     # API Documentation
     path('api/v1/schema/', SpectacularAPIView.as_view(), name='schema'),
     path('api/v1/docs/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),

--- a/tosca_api/views.py
+++ b/tosca_api/views.py
@@ -1,4 +1,34 @@
+import logging
+
+from django.db import Error as DatabaseError
+from django.db import connections
+from django.http import JsonResponse
 from django.shortcuts import render
 
+logger = logging.getLogger(__name__)
+
+
 def base(request):
-    return render(request, 'base.html')  
+    return render(request, 'base.html')
+
+
+def healthz(request):
+    """
+    Process liveness — 200 whenever Django itself can handle a request.
+    Deliberately checks nothing else (no DB, no GeoServer): a dependency
+    outage should surface via /readyz, not make the process look dead.
+    """
+    return JsonResponse({'status': 'ok'})
+
+
+def readyz(request):
+    """
+    Readiness — DB connectivity only. Kept shallow and fast on purpose:
+    no GeoServer sync or other slow dependency check belongs here.
+    """
+    try:
+        connections['default'].ensure_connection()
+    except DatabaseError as exc:
+        logger.error('readyz: database unreachable: %s', exc)
+        return JsonResponse({'status': 'unavailable', 'error': 'database unreachable'}, status=503)
+    return JsonResponse({'status': 'ok'})


### PR DESCRIPTION
The Docker healthcheck only hit /, which proves Django is up but says nothing about DB reachability. Added two views in tosca_api/views.py: /healthz (pure liveness, always 200, no dependency checks) and /readyz (checks DB connectivity via connections['default'] .ensure_connection(), returns 503 on failure). Kept readyz deliberately shallow — no GeoServer sync or other slow check.

Wired both into tosca_api/urls.py and pointed docker-compose-prod.yml's django healthcheck at /readyz instead of / so an unreachable database now actually fails the container health check. Covered with tests for both the happy path and a simulated DB-down 503.

## Summary

- [ ] Description of changes
- [ ] Related issue link

## Testing

- [ ] `uv run pytest`
- [ ] Other (describe)
