### PR TITLE
add shared visibility queryset helpers

### DIFF
--- a/tosca_api/apps/events/models.py
+++ b/tosca_api/apps/events/models.py
@@ -450,6 +450,12 @@ class EventSeriesDate(TimeStampedModel):
         super().save(*args, **kwargs)
 
 
+class EventQuerySet(models.QuerySet):
+    def published_public(self):
+        """Events visible to an anonymous/non-staff reader: published + public."""
+        return self.filter(status=Event.Status.PUBLISHED, visibility=Event.Visibility.PUBLIC)
+
+
 class Event(TimeStampedModel):
     """
     An event with physical, online, or hybrid delivery modes.
@@ -492,6 +498,8 @@ class Event(TimeStampedModel):
         HOME_VISIT = "home_visit", "Home Visit"
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid7, editable=False)
+
+    objects = EventQuerySet.as_manager()
 
     campaign = models.ForeignKey(
         "campaigns.Campaign",

--- a/tosca_api/apps/events/tests/test_event_visibility.py
+++ b/tosca_api/apps/events/tests/test_event_visibility.py
@@ -100,6 +100,17 @@ def cancelled_event(organizer, campaign):
 
 
 @pytest.mark.django_db
+def test_published_public_queryset_matches_inline_visibility_rule(
+    published_public_event, draft_event, private_event, cancelled_event
+):
+    """Event.objects.published_public() (issue 23) must return exactly the
+    same rows the view's inline status+visibility filter did before it was
+    extracted into a named queryset method.
+    """
+    assert list(Event.objects.published_public()) == [published_public_event]
+
+
+@pytest.mark.django_db
 def test_anon_list_returns_only_published_and_public(
     api_client, published_public_event, draft_event, private_event, cancelled_event
 ):

--- a/tosca_api/apps/events/views.py
+++ b/tosca_api/apps/events/views.py
@@ -124,10 +124,7 @@ class EventViewSet(viewsets.ModelViewSet):
     def _apply_visibility_scope(self, queryset):
         if self._is_admin_reader():
             return queryset
-        return queryset.filter(
-            status=Event.Status.PUBLISHED,
-            visibility=Event.Visibility.PUBLIC,
-        )
+        return queryset.published_public()
 
     def _coerce_public_filters(self, filters: dict) -> dict:
         if not self._is_admin_reader():
@@ -304,10 +301,7 @@ class EventSeriesViewSet(
         user = self.request.user
         if user and user.is_authenticated and user.is_staff:
             return queryset
-        return queryset.filter(
-            events__status=Event.Status.PUBLISHED,
-            events__visibility=Event.Visibility.PUBLIC,
-        ).distinct()
+        return queryset.filter(events__in=Event.objects.published_public()).distinct()
 
     def get_serializer_class(self):
         if self.action == "retrieve":

--- a/tosca_api/apps/feedback/models.py
+++ b/tosca_api/apps/feedback/models.py
@@ -26,6 +26,12 @@ from tosca_api.apps.core.models import TimeStampedModel
 from tosca_api.apps.core.sanitization import sanitize_simple
 
 
+class GeoFeedbackQuerySet(models.QuerySet):
+    def published_public(self):
+        """Feedback visible to an anonymous/non-staff reader: published + public."""
+        return self.filter(status=GeoFeedback.Status.PUBLISHED, visibility=GeoFeedback.Visibility.PUBLIC)
+
+
 class GeoFeedback(TimeStampedModel):
     """
     A feedback collection point within a campaign.
@@ -56,6 +62,8 @@ class GeoFeedback(TimeStampedModel):
         PRIVATE = "private", "Private"
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid7, editable=False)
+
+    objects = GeoFeedbackQuerySet.as_manager()
 
     campaign = models.ForeignKey(
         "campaigns.Campaign",

--- a/tosca_api/apps/feedback/tests/test_api.py
+++ b/tosca_api/apps/feedback/tests/test_api.py
@@ -118,6 +118,15 @@ class TestGeoFeedbackAPI:
         assert resp.status_code == status.HTTP_200_OK
         assert len(resp.data["results"]) == 2
 
+    def test_published_public_queryset_matches_inline_visibility_rule(
+        self, feedback, feedback_draft_private
+    ):
+        """GeoFeedback.objects.published_public() (issue 23) must return
+        exactly the same rows the view's inline status+visibility filter
+        did before it was extracted into a named queryset method.
+        """
+        assert list(GeoFeedback.objects.published_public()) == [feedback]
+
     def test_retrieve_feedback_includes_slug(self, api_client, feedback):
         """Wait, detail read should return custom_form_slug."""
         url = f"/api/v1/feedback/{feedback.id}/"

--- a/tosca_api/apps/feedback/views.py
+++ b/tosca_api/apps/feedback/views.py
@@ -79,10 +79,7 @@ class GeoFeedbackViewSet(viewsets.ModelViewSet):
 
         user = self.request.user
         if not (user and user.is_staff):
-            qs = qs.filter(
-                status=GeoFeedback.Status.PUBLISHED,
-                visibility=GeoFeedback.Visibility.PUBLIC,
-            )
+            qs = qs.published_public()
 
         campaign_id = self.request.query_params.get("campaign_id")
         if campaign_id:

--- a/tosca_api/apps/geodata_providers/api/views.py
+++ b/tosca_api/apps/geodata_providers/api/views.py
@@ -412,7 +412,7 @@ class LayerViewSet(viewsets.ModelViewSet):
         qs = super().get_queryset()
         user = getattr(self.request, 'user', None)
         if not (user and user.is_authenticated):
-            qs = qs.filter(is_public=True)
+            qs = qs.public()
         engine_id = self.request.query_params.get('geodata_engine')
         workspace_id = self.request.query_params.get('workspace')
         if engine_id:

--- a/tosca_api/apps/geodata_providers/models.py
+++ b/tosca_api/apps/geodata_providers/models.py
@@ -344,6 +344,19 @@ class Store(SyncStateMixin, TimeStampedModel, EncryptedCharField):
             return False
 
 
+class LayerQuerySet(models.QuerySet):
+    def public(self):
+        """Layers visible to an anonymous/unauthenticated reader: is_public only.
+
+        Deliberately does NOT also filter publishing_state — that matches
+        LayerViewSet's existing behavior exactly. (catalog_api's
+        CatalogVisibilityService applies a stricter, separate rule for its
+        own GeoServer-compatible surface; not reused here to avoid a
+        behavior change.)
+        """
+        return self.filter(is_public=True)
+
+
 class Layer(SyncStateMixin, TimeStampedModel):
     """
     Logical dataset backed by a PostGIS table or view.
@@ -369,6 +382,9 @@ class Layer(SyncStateMixin, TimeStampedModel):
         UNPUBLISHED = "UNPUBLISHED", "Unpublished"
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid7, editable=False)
+
+    objects = LayerQuerySet.as_manager()
+
     name = models.CharField(max_length=100, help_text="Layer name")
     title = models.CharField(max_length=200, blank=True, help_text="Human-readable title")
     description = models.TextField(blank=True)

--- a/tosca_api/apps/geodata_providers/tests/test_api_views.py
+++ b/tosca_api/apps/geodata_providers/tests/test_api_views.py
@@ -4,6 +4,7 @@ from rest_framework.test import APIRequestFactory, force_authenticate
 
 from tosca_api.apps.geodata_providers.api.views import LayerViewSet
 from tosca_api.apps.geodata_providers.models import GeodataEngine, Layer, Store, Workspace
+from tosca_api.apps.geodata_providers.test_helpers import make_layer
 
 # NOTE: tosca_api/apps/geodata_providers/api/urls.py is not currently included
 # in tosca_api/urls.py, so this endpoint has no resolvable URL yet. The view
@@ -123,3 +124,23 @@ class LayerUpdateEndpointTests(TestCase):
         self.assertEqual(self.layer.title, 'New Title')
         self.assertEqual(self.layer.srid, 3857)
         self.assertEqual(self.layer.name, 'roads')
+
+
+class LayerQuerysetVisibilityTests(TestCase):
+    """Regression test for issue 23: Layer.objects.public() must return
+    exactly the same rows LayerViewSet.get_queryset()'s inline is_public
+    filter did before it was extracted into a named queryset method —
+    deliberately not also filtering publishing_state, matching the
+    pre-existing (if inconsistent with catalog_api) behavior.
+    """
+
+    def test_public_matches_inline_is_public_filter(self):
+        public_published = make_layer('ws:public-published', is_public=True, publishing_state=Layer.PublishingState.PUBLISHED)
+        public_draft = make_layer('ws:public-draft', is_public=True, publishing_state=Layer.PublishingState.DRAFT)
+        make_layer('ws:private-published', is_public=False, publishing_state=Layer.PublishingState.PUBLISHED)
+
+        results = set(Layer.objects.public())
+
+        # is_public=True is included regardless of publishing_state — the
+        # DRAFT layer above is NOT filtered out, matching current behavior.
+        self.assertEqual(results, {public_published, public_draft})

--- a/tosca_api/apps/geostories/models.py
+++ b/tosca_api/apps/geostories/models.py
@@ -25,6 +25,16 @@ def geostory_hero_image_upload_to(instance: "GeoStory", filename: str) -> str:
     return f"geostories/{instance.pk}/hero/{unique_filename}"
 
 
+class GeoStoryQuerySet(models.QuerySet):
+    def published(self):
+        """Stories visible to a reader with no elevated access: published only.
+
+        GeoStory has no separate public/private flag (unlike Event and
+        GeoFeedback) — status is the only visibility axis.
+        """
+        return self.filter(status=GeoStory.Status.PUBLISHED)
+
+
 class GeoStory(TimeStampedModel):
     """
     A specific story or narrative attached to a location/map view.
@@ -46,6 +56,8 @@ class GeoStory(TimeStampedModel):
         ARCHIVED = "archived", "Archived"
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid7, editable=False)
+
+    objects = GeoStoryQuerySet.as_manager()
     title = models.CharField(max_length=255)
     summary = models.TextField(blank=True, default="")
     hero_image = models.ImageField(

--- a/tosca_api/apps/geostories/tests/test_api.py
+++ b/tosca_api/apps/geostories/tests/test_api.py
@@ -84,6 +84,15 @@ def test_geostory_list_unauthenticated(api_client):
     assert response.status_code == 200
 
 
+@pytest.mark.django_db
+def test_published_queryset_matches_inline_visibility_rule(geostory, draft_story):
+    """GeoStory.objects.published() (issue 23) must return exactly the same
+    rows the view's inline status filter did before it was extracted into a
+    named queryset method.
+    """
+    assert list(GeoStory.objects.published()) == [geostory]
+
+
 # =============================================================================
 # List View Tests (Task 1.6)
 # =============================================================================

--- a/tosca_api/apps/geostories/views.py
+++ b/tosca_api/apps/geostories/views.py
@@ -106,10 +106,10 @@ class GeoStoryViewSet(viewsets.ModelViewSet):
         user = self.request.user
         if self.action == "list":
             if not (user and user.is_staff):
-                queryset = queryset.filter(status=GeoStory.Status.PUBLISHED)
+                queryset = queryset.published()
         elif self.action == "retrieve":
             if not (user and user.is_authenticated):
-                queryset = queryset.filter(status=GeoStory.Status.PUBLISHED)
+                queryset = queryset.published()
 
         # Filter by campaign_id if provided
         campaign_id = self.request.query_params.get("campaign_id")


### PR DESCRIPTION
Events, feedback, geostories, and geodata_providers each repeated public/published visibility checks inline across views (and, for events, in three separate places: EventViewSet's own helper plus a third independently-written copy in EventSeriesViewSet). Per the report's own guidance, avoided a generic cross-app abstraction — added one named queryset method per app instead, matching that app's actual domain rules:

- Event.objects.published_public() — status=PUBLISHED, visibility=PUBLIC
- GeoFeedback.objects.published_public() — same shape, own model
- GeoStory.objects.published() — status only, no visibility field exists
- Layer.objects.public() — is_public only, deliberately NOT also checking publishing_state, matching LayerViewSet's existing (if  arguably inconsistent with catalog_api) behavior exactly

Each call site was swapped for the new method with no logic changes. Added one behavior-preservation test per app proving the new method returns exactly the same rows the inline filter did.

## Summary

- [ ] Description of changes
- [ ] Related issue link

## Testing

- [ ] `uv run pytest`
- [ ] Other (describe)
