### PR TITLE
move vendored geoserver-rest out of the app package boundary

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "docker/geoserver_docker"]
 	path = docker/geoserver_docker
 	url = https://github.com/digitalcityscience/geoserver_docker.git
-[submodule "tosca_api/apps/geodata_providers/geoserver/geoserver-rest"]
-	path = tosca_api/apps/geodata_providers/geoserver/geoserver-rest
+[submodule "vendor/geoserver-rest"]
+	path = vendor/geoserver-rest
 	url = https://github.com/orttak/geoserver-rest.git

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,10 @@ markers = [
 [tool.ruff]
 line-length = 100
 target-version = "py314"
+# The geoserver-rest submodule lives under vendor/ specifically so it's
+# outside tosca_api/ and doesn't need excluding here — but exclude it
+# explicitly too in case ruff is ever pointed at the repo root.
+exclude = ["vendor"]
 
 [tool.setuptools.packages.find]
 include = ["tosca_api*"]
@@ -66,7 +70,7 @@ exclude = ["docker*"]
 python-preference = "managed"
 
 [tool.uv.sources]
-geoserver-rest = { path = "tosca_api/apps/geodata_providers/geoserver/geoserver-rest", editable = true }
+geoserver-rest = { path = "vendor/geoserver-rest", editable = true }
 
 [dependency-groups]
 dev = [

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,10 +4,11 @@ python_files = tests.py test_*.py *_tests.py
 addopts = --reuse-db
 markers =
     integration: tests that require live external services such as GeoServer
-# The geoserver-rest submodule ships its own test suite with third-party deps
-# (seaborn, environs) that are not part of this project. Skip its tree.
+# vendor/ holds the geoserver-rest submodule, which ships its own test suite
+# with third-party deps (seaborn, environs) that are not part of this
+# project. Skip its tree.
 norecursedirs =
-    tosca_api/apps/geodata_providers/geoserver/geoserver-rest
+    vendor
     build
     dist
     *.egg-info

--- a/tosca_api/apps/geodata_providers/geoserver/client.py
+++ b/tosca_api/apps/geodata_providers/geoserver/client.py
@@ -1,17 +1,13 @@
 """
 Thin, controlled wrapper around geoserver-rest
 """
-import sys
-import os
 import logging
 from typing import Callable, Dict, Optional
 import requests
 
-# Add geoserver-rest to Python path
-geoserver_rest_path = os.path.join(os.path.dirname(__file__), 'geoserver-rest')
-if geoserver_rest_path not in sys.path:
-    sys.path.insert(0, geoserver_rest_path)
-
+# geo comes from the vendor/geoserver-rest submodule, installed as a normal
+# editable dependency (see pyproject.toml's [tool.uv.sources]) — no sys.path
+# manipulation needed for this import to resolve.
 from geo.Geoserver import Geoserver as GeoServerRestClient
 from ..exceptions import GeoServerConnectionError, GeoServerPublishError
 from ..results import OperationResult

--- a/uv.lock
+++ b/uv.lock
@@ -345,7 +345,7 @@ wheels = [
 [[package]]
 name = "geoserver-rest"
 version = "2.10.0"
-source = { editable = "tosca_api/apps/geodata_providers/geoserver/geoserver-rest" }
+source = { editable = "vendor/geoserver-rest" }
 dependencies = [
     { name = "pygments" },
     { name = "requests" },
@@ -1017,7 +1017,7 @@ requires-dist = [
     { name = "djangorestframework", specifier = ">=3.15.0" },
     { name = "djangorestframework-gis", specifier = ">=1.2.0" },
     { name = "drf-spectacular", specifier = ">=0.29.0" },
-    { name = "geoserver-rest", editable = "tosca_api/apps/geodata_providers/geoserver/geoserver-rest" },
+    { name = "geoserver-rest", editable = "vendor/geoserver-rest" },
     { name = "gunicorn", specifier = ">=22.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11.0" },
     { name = "nh3", specifier = ">=0.3.2" },


### PR DESCRIPTION
The geoserver-rest git submodule lived inside tosca_api/apps/geodata_providers/geoserver/, causing lint noise (ruff had no exclude for it) and unclear ownership. Moved it to vendor/geoserver-rest via git mv, updated .gitmodules, and pointed pyproject.toml's editable source and pytest.ini's norecursedirs at the new path.

client.py's sys.path manipulation for importing `geo` turned out to be dead code — the editable install already registers a proper finder, so a plain `from geo.Geoserver import Geoserver` import resolves regardless of where the submodule physically lives. Removed the hack and the now-unused sys/os imports.

Also fixed docker/django/Dockerfile.prod, which COPYs specific named directories rather than the whole repo: without adding `COPY vendor ./vendor` before `uv sync`, the production image would have silently lost the dependency. Verified by building the prod image end-to-end.

## Summary

- [ ] Description of changes
- [ ] Related issue link

## Testing

- [ ] `uv run pytest`
- [ ] Other (describe)
