### PR TITLE
add DB connection pooling and statement timeout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,15 @@ PG_GS_USER=tosca_gs
 PG_GS_PASSWORD=CHANGE_ME_GEOSERVER_DB_PASSWORD
 
 ############################
+# Django DB connection tuning
+############################
+# Seconds a Django DB connection is reused across requests before being
+# closed and reopened (0 = open/close a fresh connection every request).
+DB_CONN_MAX_AGE=60
+# Milliseconds before Postgres kills a running query on this connection.
+DB_STATEMENT_TIMEOUT_MS=30000
+
+############################
 # PostgreSQL schemas
 ############################
 PG_SCHEMA_API=api_schema

--- a/tosca_api/apps/core/tests/test_database_settings.py
+++ b/tosca_api/apps/core/tests/test_database_settings.py
@@ -1,0 +1,41 @@
+"""
+Regression tests for issue 25: DB connection pooling and statement timeout.
+"""
+from django.db import OperationalError, connection
+from django.test import SimpleTestCase
+
+
+class ConnMaxAgeSettingsTests(SimpleTestCase):
+    def test_conn_max_age_is_configured(self):
+        settings_dict = connection.settings_dict
+        self.assertGreater(settings_dict['CONN_MAX_AGE'], 0)
+
+    def test_conn_health_checks_enabled(self):
+        # Paired with CONN_MAX_AGE: a reused connection is pinged before use
+        # so a connection that died server-side surfaces as a clean retry
+        # instead of a request-time error.
+        self.assertTrue(connection.settings_dict['CONN_HEALTH_CHECKS'])
+
+
+class StatementTimeoutTests(SimpleTestCase):
+    databases = {'default'}
+
+    def test_statement_timeout_is_configured(self):
+        options = connection.settings_dict['OPTIONS'].get('options', '')
+        self.assertIn('statement_timeout=', options)
+
+    def test_statement_timeout_actually_cuts_off_a_long_query(self):
+        """Proves the mechanism, not just the config string: with
+        statement_timeout set, a query that runs past it is killed by
+        Postgres rather than allowed to hang. Uses a short SET LOCAL
+        override (rather than waiting out the real ~30s production
+        default) so the test runs fast.
+        """
+        with self.assertRaises(OperationalError):
+            with connection.cursor() as cursor:
+                cursor.execute("SET statement_timeout = 100;")
+                cursor.execute("SELECT pg_sleep(1);")
+
+        # Connection is now aborted by Postgres — start a fresh one so
+        # Django's own post-test cleanup doesn't trip over it.
+        connection.close()

--- a/tosca_api/settings/base.py
+++ b/tosca_api/settings/base.py
@@ -139,6 +139,17 @@ ASGI_APPLICATION = "tosca_api.asgi.application"
 #   2) PG_* variables (PG_HOST, PG_PORT, PG_DATABASE, PG_API_USER, PG_API_PASSWORD)
 # -------------------------------------------------
 
+# CONN_MAX_AGE: reuse a connection across requests for up to this many
+# seconds instead of opening a fresh Postgres connection per request.
+# CONN_HEALTH_CHECKS pings a reused connection before use so a connection
+# that died server-side (e.g. Postgres restart) doesn't surface as a
+# request-time error.
+DB_CONN_MAX_AGE = env.int("DB_CONN_MAX_AGE", default=60)
+
+# statement_timeout (ms): a stuck/runaway query is killed by Postgres
+# instead of holding a worker (and a DB connection) hostage indefinitely.
+DB_STATEMENT_TIMEOUT_MS = env.int("DB_STATEMENT_TIMEOUT_MS", default=30000)
+
 DATABASES = {
         "default": {
             "ENGINE": "django.contrib.gis.db.backends.postgis",
@@ -147,9 +158,15 @@ DATABASES = {
             "PASSWORD": env("PG_API_PASSWORD"),
             "HOST": env("PG_HOST"),
             "PORT": env("PG_DOCKER_PORT"),
+            "CONN_MAX_AGE": DB_CONN_MAX_AGE,
+            "CONN_HEALTH_CHECKS": True,
             "OPTIONS": {
-                # optional: schema search_path for Django connections
-                "options": f"-c search_path={env('PG_SCHEMA_API', default='public')},public"
+                # schema search_path + a hard statement timeout for every
+                # connection Django opens.
+                "options": (
+                    f"-c search_path={env('PG_SCHEMA_API', default='public')},public "
+                    f"-c statement_timeout={DB_STATEMENT_TIMEOUT_MS}"
+                )
             },
         }
     }

--- a/tosca_api/settings/test.py
+++ b/tosca_api/settings/test.py
@@ -12,6 +12,9 @@ DATABASES = {
         "PASSWORD": env("PG_API_PASSWORD", default="postgres_api"),
         "HOST": env("PG_HOST", default="db"),
         "PORT": "5432",  # Internal Docker port
+        "OPTIONS": {
+            "options": f"-c statement_timeout={DB_STATEMENT_TIMEOUT_MS}",  # noqa: F405
+        },
         "TEST": {
             "NAME": "test_tosca",  # Use the same name (--reuse-db)
         },


### PR DESCRIPTION
No CONN_MAX_AGE meant every request opened a fresh Postgres connection, and no statement_timeout meant a stuck query could hang a worker (and its DB connection) indefinitely. Added both to base.py's DATABASES config, sourced from new env vars (DB_CONN_MAX_AGE=60, DB_STATEMENT_TIMEOUT_MS=30000) so they're tunable per environment. CONN_HEALTH_CHECKS is on too, so a reused connection that died server-side gets pinged and replaced instead of surfacing as a request-time error. statement_timeout is applied via the same -c options mechanism already used for search_path.

test.py's separately-defined DATABASES block gets the same statement_timeout so the setting is actually exercised under test. Added test_database_settings.py: two tests confirm the config is present, and one proves the mechanism itself — a query that runs past a short SET LOCAL statement_timeout is actually killed by Postgres, not just configured and never verified.

## Summary

- [ ] Description of changes
- [ ] Related issue link

## Testing

- [ ] `uv run pytest`
- [ ] Other (describe)
