### PR TITLE
check geometry validity on public submissions

### DIFF
--- a/tosca_api/apps/feedback/models.py
+++ b/tosca_api/apps/feedback/models.py
@@ -333,6 +333,11 @@ class FeedbackSubmission(TimeStampedModel):
             except GeoFeedback.DoesNotExist:
                 pass  # FK will be validated by Django
 
+        # Reject malformed geometry (e.g. self-intersecting polygons) from
+        # public submissions before it ever reaches GeoServer.
+        if self.geometry and "geometry" not in errors and not self.geometry.valid:
+            errors["geometry"] = f"Geometry is not valid: {self.geometry.valid_reason}"
+
         if errors:
             raise ValidationError(errors)
 

--- a/tosca_api/apps/feedback/tests/test_submission.py
+++ b/tosca_api/apps/feedback/tests/test_submission.py
@@ -681,6 +681,39 @@ class TestFeedbackSubmissionValidation:
             )
         assert "geometry" in exc_info.value.message_dict
 
+    def test_self_intersecting_polygon_rejected(self, feedback_with_drawings, user):
+        """A self-intersecting ("bowtie") polygon must be rejected even
+        though allow_drawings is enabled — geometry can be permitted but
+        still structurally invalid.
+        """
+        bowtie = GEOSGeometry(
+            "POLYGON((0 0, 10 10, 10 0, 0 10, 0 0))", srid=4326
+        )
+        assert not bowtie.valid
+        with pytest.raises(ValidationError) as exc_info:
+            FeedbackSubmission.objects.create(
+                feedback=feedback_with_drawings,
+                submitted_by=user,
+                rating=5,
+                geometry=bowtie,
+            )
+        assert "geometry" in exc_info.value.message_dict
+
+    def test_valid_polygon_accepted_unchanged(self, feedback_with_drawings, user):
+        """A well-formed polygon passes through clean() unchanged."""
+        polygon = Polygon(
+            ((9.99, 53.55), (10.01, 53.55), (10.01, 53.57), (9.99, 53.57), (9.99, 53.55)),
+            srid=4326,
+        )
+        assert polygon.valid
+        sub = FeedbackSubmission.objects.create(
+            feedback=feedback_with_drawings,
+            submitted_by=user,
+            rating=5,
+            geometry=polygon,
+        )
+        assert sub.geometry.valid
+
 
 # =============================================================================
 # __str__ Tests


### PR DESCRIPTION
Added .valid/.valid_reason GEOS check to FeedbackSubmission.clean(), after the allow_drawings check. Tests: self-intersecting bowtie polygon rejected, valid polygon passes unchanged.
