### PR TITLE
add pre-commit hook for env files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+  - repo: local
+    hooks:
+      - id: no-env-files
+        name: Block committing real .env files
+        description: >
+          Only .env.example may be committed. .env/.env.dev/.env.prod/.env.test
+          carry live credentials and must never be staged.
+        entry: python scripts/check_no_env_files.py
+        language: system
+        pass_filenames: true

--- a/README.md
+++ b/README.md
@@ -156,6 +156,21 @@ Environment resolution:
 Keep `ENV`, `ENV_TYPE`, `ENV_FILE`, ports, passwords, and public URLs aligned in
 the selected env file.
 
+## Secrets and Env Files
+
+Only `.env.example` is committed, and it holds placeholders only (every
+credential is `CHANGE_ME_...`). `.env`, `.env.dev`, `.env.prod`, and
+`.env.test` are gitignored deliberately — none of them should ever be
+committed, since they carry real (even if dev-only) credentials.
+
+A pre-commit hook enforces this: it blocks committing any `.env*` file other
+than `.env.example`. Set it up once per clone:
+
+```bash
+uv sync --group dev
+uv run pre-commit install
+```
+
 ## Keycloak OIDC Note
 
 When using Keycloak/OIDC, the Keycloak client's valid redirect URIs and the

--- a/docs/features-to-add_local/decisions.md
+++ b/docs/features-to-add_local/decisions.md
@@ -618,3 +618,37 @@ This document tracks key architectural and implementation decisions made during 
 - **Alternatives Considered**: DRF `URLPathVersioning` (deferred, not rejected — see trigger below) and `NamespaceVersioning` (would require app-level URL namespacing, more invasive for the same zero current benefit).
 - **Revisit when**: a real breaking API change is needed, or an external (non-frontend-owned) consumer starts depending on this API. At that point, implement `URLPathVersioning` as scoped above rather than inventing a new scheme.
 - **Raw originals**: Direct `MEDIA_URL` access can expose original uploads, including retained EXIF metadata. Production hardening should lock raw originals behind the intended storage/auth boundary and route public consumption through metadata-clean derivatives.
+
+### [11.2] Typed Result Scope (Issue 43)
+
+- **Decision**: Introduced `OperationResult` only for `GeoServerClient`'s `create_workspace`/`delete_workspace`/`create_store`/`delete_store` and their shared `_create_resource`/`_delete_resource` orchestration helpers — not a full sweep across every dict-returning method in `geodata_providers`.
+- **Rationale**: The full-sweep alternative would touch ~30 methods across `client.py`, `sync_service.py`, `sync/*.py`, and every admin/view/service call site (15-20 files), for a "trivial" priority report finding. Scoping to the methods the report explicitly named ("repeated GeoServer-first orchestration dicts") gets the real duplication fixed at much lower regression risk.
+- **Alternatives Considered**: Full sweep (rejected — disproportionate risk/effort for this priority level).
+- **Compatibility**: `OperationResult` supports `.get()`/`[]`/`in` so untouched call sites keep working unchanged; only the most direct consumers (`WorkspaceSyncer`, `WorkspaceService`) were migrated to real attribute access.
+
+### [11.3] `EventSeries.campaign` Cascade/Nullable Resolution (Issue 36)
+
+- **Decision**: Made `campaign` required (removed `null=True, blank=True`), kept `on_delete=CASCADE`.
+- **Rationale**: `EventSeriesWriteSerializer` already treats `campaign` as effectively required (raises `ValidationError` if missing), and `Event.clean()` already requires `series.campaign_id` to be set for any series actually attached to an event. The nullable FK was a latent trap — a "successfully created but functionally unusable" state — not real optionality. Verified 0 existing rows with null `campaign` in the dev DB before migrating.
+- **Alternatives Considered**: Switch to `on_delete=SET_NULL` (rejected — would leave orphaned series that can never have events per existing validation, and is inconsistent with `Event.campaign`'s own `CASCADE`).
+
+### [11.4] `geocontext` N+1 Audit Outcome (Issue 30)
+
+- **Decision**: No code fix beyond making an existing implicit behavior explicit (`GeoContextAdmin.list_select_related`).
+- **Rationale**: Investigated the report's N+1 claim empirically (query capture, not static reading) and found none — Django's admin changelist already auto-joins FK columns named directly in `list_display`. The `context` FK on Event/GeoStory/GeoFeedback is retrieve-only in every serializer that touches it; list serializers never reference it. Added a calibrated query-count regression test instead of a fix that wasn't needed.
+
+### [11.5] DB Connection Pooling Defaults (Issue 25)
+
+- **Decision**: `CONN_MAX_AGE=60` seconds, `CONN_HEALTH_CHECKS=True`, `statement_timeout=30000` ms — both env-overridable (`DB_CONN_MAX_AGE`, `DB_STATEMENT_TIMEOUT_MS`).
+- **Rationale**: No prior art in this repo for either value; chose conservative, commonly-used defaults rather than tuning against real traffic that doesn't exist yet. `statement_timeout` is applied via the existing `-c` options mechanism already used for `search_path`.
+
+### [11.6] Vendored `geoserver-rest` Location (Issue 24)
+
+- **Decision**: Moved the `geoserver-rest` git submodule from `tosca_api/apps/geodata_providers/geoserver/geoserver-rest` to `vendor/geoserver-rest`, and removed the `sys.path` manipulation in `client.py` entirely (it was dead code — the editable install already provides a proper import finder regardless of path).
+- **Rationale**: Matches the report's suggested fix ("move to `vendor/` ... exclude from app-level lint/test discovery"). Caught a real latent break while verifying: `docker/django/Dockerfile.prod` only `COPY`s specific named directories, so without adding `COPY vendor ./vendor` the production image would have silently lost the dependency. Verified by building the prod image end-to-end, not just running the test suite.
+
+### [11.7] `.env` File Protection (Issue 27)
+
+- **Decision**: `.env.dev`/`.env.prod`/`.env`/`.env.test` were never actually committed (confirmed via `git log --all --full-history`) and are already gitignored; `.env.example` already held placeholders only. The only real gap was enforcement — added a `pre-commit` local hook (`scripts/check_no_env_files.py` + `.pre-commit-config.yaml`) that blocks committing any `.env*` file except `.env.example`.
+- **Rationale**: The report's claim ("`.env.dev` is committed with real-looking credentials") didn't hold for the current repo state — verified before touching anything rather than assuming the report was still accurate. The enforcement gap (no pre-commit check existed) was real, so that's what got fixed.
+- **Setup**: `uv sync --group dev && uv run pre-commit install` (documented in README's new "Secrets and Env Files" section).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dev = [
     "pytest-django>=4.8.0",
     "ruff>=0.5.0",
     "mypy>=1.11.0",
+    "pre-commit>=4.0.0",
 ]
 
 [build-system]
@@ -77,4 +78,5 @@ dev = [
     "pytest>=9.0.3",
     "pytest-django>=4.11.1",
     "ruff>=0.14.7",
+    "pre-commit>=4.0.0",
 ]

--- a/scripts/check_no_env_files.py
+++ b/scripts/check_no_env_files.py
@@ -1,0 +1,41 @@
+"""
+Pre-commit hook: block committing any real `.env*` file.
+
+`.env`, `.env.dev`, `.env.prod`, and `.env.test` all carry live credentials
+and must never be committed — only `.env.example` (placeholders only) is
+allowed to be tracked. Wired up as a local pre-commit hook (see
+.pre-commit-config.yaml), which passes the staged filenames as argv.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ALLOWED_ENV_FILES = {".env.example"}
+
+
+def find_forbidden_env_files(filenames: list[str]) -> list[str]:
+    """Return the subset of filenames that look like a real (non-example) .env file."""
+    forbidden = []
+    for filename in filenames:
+        name = Path(filename).name
+        if name in ALLOWED_ENV_FILES:
+            continue
+        if name == ".env" or name.startswith(".env."):
+            forbidden.append(filename)
+    return forbidden
+
+
+def main(argv: list[str]) -> int:
+    forbidden = find_forbidden_env_files(argv)
+    if forbidden:
+        print("Refusing to commit real .env file(s) — these carry live credentials:")
+        for path in forbidden:
+            print(f"  {path}")
+        print("Only .env.example (placeholders only) may be committed.")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tosca_api/apps/core/tests/test_no_env_files_hook.py
+++ b/tosca_api/apps/core/tests/test_no_env_files_hook.py
@@ -1,0 +1,63 @@
+"""
+Tests for scripts/check_no_env_files.py (issue 27: pre-commit hook blocking
+real .env files from being committed).
+
+Loaded by file path rather than package import since scripts/ isn't a
+Django app and has no __init__.py.
+"""
+import importlib.util
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "check_no_env_files.py"
+
+spec = importlib.util.spec_from_file_location("check_no_env_files", SCRIPT_PATH)
+check_no_env_files = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(check_no_env_files)
+
+find_forbidden_env_files = check_no_env_files.find_forbidden_env_files
+main = check_no_env_files.main
+
+
+def test_env_example_is_allowed():
+    assert find_forbidden_env_files([".env.example"]) == []
+
+
+def test_plain_env_file_is_forbidden():
+    assert find_forbidden_env_files([".env"]) == [".env"]
+
+
+def test_env_dev_is_forbidden():
+    assert find_forbidden_env_files([".env.dev"]) == [".env.dev"]
+
+
+def test_env_prod_and_env_test_are_forbidden():
+    result = find_forbidden_env_files([".env.prod", ".env.test"])
+    assert result == [".env.prod", ".env.test"]
+
+
+def test_env_local_is_forbidden():
+    assert find_forbidden_env_files([".env.local"]) == [".env.local"]
+
+
+def test_nested_path_is_checked_by_basename():
+    assert find_forbidden_env_files(["docker/geoserver_docker/.env.prod"]) == [
+        "docker/geoserver_docker/.env.prod"
+    ]
+
+
+def test_unrelated_files_are_ignored():
+    assert find_forbidden_env_files(["README.md", "pyproject.toml", "tosca_api/urls.py"]) == []
+
+
+def test_mixed_staged_files_only_flags_the_env_ones():
+    result = find_forbidden_env_files(["README.md", ".env.prod", "pyproject.toml", ".env.example"])
+    assert result == [".env.prod"]
+
+
+def test_main_returns_zero_when_nothing_forbidden():
+    assert main([".env.example", "README.md"]) == 0
+
+
+def test_main_returns_nonzero_when_forbidden_file_staged():
+    assert main([".env.dev"]) == 1

--- a/uv.lock
+++ b/uv.lock
@@ -88,6 +88,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cfgv"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.7"
 source = { registry = "https://pypi.org/simple" }
@@ -200,6 +209,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5a/d3/8ae2869247df154b64c1884d7346d412fed0c49df84db635aab2d1c40e62/deprecation-2.1.0.tar.gz", hash = "sha256:72b3bde64e5d778694b0cf68178aed03d15e15477116add3fb773e581f9518ff", size = 173788, upload-time = "2020-04-20T14:23:38.738Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/02/c3/253a89ee03fc9b9682f1541728eb66db7db22148cd94f89ab22528cd1e1b/deprecation-2.1.0-py2.py3-none-any.whl", hash = "sha256:a10811591210e1fb0e768a8c25517cabeabcba6f0bf96564f8ff45189f90b14a", size = 11178, upload-time = "2020-04-20T14:23:36.581Z" },
+]
+
+[[package]]
+name = "distlib"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/02/bd72be9134d25ed783ecbbc38a539ffaefbf90c78418c7fb7229600dbac7/distlib-0.4.3.tar.gz", hash = "sha256:f152097224a0ae24be5a0f6bae1b9359af82133bce63f98a95f86cae1aede9ed", size = 615141, upload-time = "2026-06-12T08:04:52.847Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/08/9c41fb51ab5b43eb21674aff13df270e8ba6c4b29c8624e328dc7a9482af/distlib-0.4.3-py2.py3-none-any.whl", hash = "sha256:4b0ce306c966eb73bc3a7b6abad017c556dadd92c44701562cd528ac7fde4d5b", size = 470628, upload-time = "2026-06-12T08:04:50.506Z" },
 ]
 
 [[package]]
@@ -343,6 +361,15 @@ wheels = [
 ]
 
 [[package]]
+name = "filelock"
+version = "3.29.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/94/00f2059e4835eace3ae8fde680b932c496f8ec7bdc99168dfa53fb2e6b79/filelock-3.29.7.tar.gz", hash = "sha256:5b481979797ae69e72f0b389d89a80bdd585c260c5b3f1fb9c0a5ba9bb3f195d", size = 71521, upload-time = "2026-07-08T05:46:58.716Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/02/be4a57b60c7149b55b9e3b3c13f609cd8eb5307c751f22bd8fb8d262e75b/filelock-3.29.7-py3-none-any.whl", hash = "sha256:987db6f789a3a2a59f55081801b2b3697cb97e2a736b5f1a9e99b559285fbc51", size = 46036, upload-time = "2026-07-08T05:46:57.53Z" },
+]
+
+[[package]]
 name = "geoserver-rest"
 version = "2.10.0"
 source = { editable = "vendor/geoserver-rest" }
@@ -441,6 +468,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "identify"
+version = "2.6.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/63/51723b5f116cc04b061cb6f5a561790abf249d25931d515cd375e063e0f4/identify-2.6.19.tar.gz", hash = "sha256:6be5020c38fcb07da56c53733538a3081ea5aa70d36a156f83044bfbf9173842", size = 99567, upload-time = "2026-04-17T18:39:50.265Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl", hash = "sha256:20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a", size = 99397, upload-time = "2026-04-17T18:39:49.221Z" },
 ]
 
 [[package]]
@@ -617,6 +653,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.1"
 source = { registry = "https://pypi.org/simple" }
@@ -668,12 +713,37 @@ wheels = [
 ]
 
 [[package]]
+name = "platformdirs"
+version = "4.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pre-commit"
+version = "4.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/22/2de9408ac81acbb8a7d05d4cc064a152ccf33b3d480ebe0cd292153db239/pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9", size = 198525, upload-time = "2026-04-21T20:31:41.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl", hash = "sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b", size = 226472, upload-time = "2026-04-21T20:31:40.092Z" },
 ]
 
 [[package]]
@@ -769,6 +839,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/13/2b/db9a193df89e5660137f5428063bcc2ced7ad790003b26974adf5c5ceb3b/pytest_django-4.12.0.tar.gz", hash = "sha256:df94ec819a83c8979c8f6de13d9cdfbe76e8c21d39473cfe2b40c9fc9be3c758", size = 91156, upload-time = "2026-02-14T18:40:49.235Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/83/a5/41d091f697c09609e7ef1d5d61925494e0454ebf51de7de05f0f0a728f1d/pytest_django-4.12.0-py3-none-any.whl", hash = "sha256:3ff300c49f8350ba2953b90297d23bf5f589db69545f56f1ec5f8cff5da83e85", size = 26123, upload-time = "2026-02-14T18:40:47.381Z" },
+]
+
+[[package]]
+name = "python-discovery"
+version = "1.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/81/58c70036dffeccb7fe7d79d6260c69f7a28272bbd3909c29a01ea9422744/python_discovery-1.4.4.tar.gz", hash = "sha256:5cad33982d412c1f3ffb8f9ca4ea292c9680bca3942451d30b69c37fce53a4a3", size = 72212, upload-time = "2026-07-08T23:06:50.691Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/ae/84bc0d2440c95772272bb6f4b3d09ccf08b2898fce89b3d4f969a9fc74e9/python_discovery-1.4.4-py3-none-any.whl", hash = "sha256:abebe9120b43453b68c908acfb1e72a19d1a959ed2cb620ad38fc57d08056dbe", size = 34181, upload-time = "2026-07-08T23:06:49.402Z" },
 ]
 
 [[package]]
@@ -993,6 +1076,7 @@ dependencies = [
 [package.optional-dependencies]
 dev = [
     { name = "mypy" },
+    { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-django" },
     { name = "ruff" },
@@ -1000,6 +1084,7 @@ dev = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-django" },
     { name = "ruff" },
@@ -1022,6 +1107,7 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11.0" },
     { name = "nh3", specifier = ">=0.3.2" },
     { name = "pillow", specifier = ">=10.0.0" },
+    { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2.0" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.8.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
@@ -1039,6 +1125,7 @@ provides-extras = ["dev"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pre-commit", specifier = ">=4.0.0" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-django", specifier = ">=4.11.1" },
     { name = "ruff", specifier = ">=0.14.7" },
@@ -1078,6 +1165,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "virtualenv"
+version = "21.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+    { name = "python-discovery" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/34/d9/b477fddb68840b570af8b22afe9b035cbc277b5fb7b33dea390617a8b10f/virtualenv-21.6.1.tar.gz", hash = "sha256:15f978b7cd329f24855ff4a0c4b4899cc7678589f49adbdcbbb4d3232e641128", size = 5526620, upload-time = "2026-07-10T19:33:53.312Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/7c/4e7225d46d634a0d8d534dd8a6ce0c319d09b4d0cf0337eb314ca4789d8c/virtualenv-21.6.1-py3-none-any.whl", hash = "sha256:afe991df855715a2b2f60edfcc0107ef95a79fdfd8cb4cdaa71603d1c12e463b", size = 5506392, upload-time = "2026-07-10T19:33:51.629Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Added the missing piece: a pre-commit hook (scripts/check_no_env_files.py) blocking any .env* file except .env.example. Documented setup in README.

## Summary

- [ ] Description of changes
- [ ] Related issue link

## Testing

- [ ] `uv run pytest`
- [ ] Other (describe)
