### PR TITLE
chore: use published GeoServer image

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,7 +58,7 @@ PG_SCHEMA_JDBCCONF=gs_jdbcconfig_schema
 ############################
 # GeoServer core
 ############################
-GEOSERVER_VERSION=2.28.3
+GEOSERVER_VERSION=2.28.5
 GEOSERVER_HOST=geoserver
 GEOSERVER_PORT=8080
 GEOSERVER_HOST_PORT=8585

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "docker/geoserver_docker"]
-	path = docker/geoserver_docker
-	url = https://github.com/digitalcityscience/geoserver_docker.git
 [submodule "vendor/geoserver-rest"]
 	path = vendor/geoserver-rest
 	url = https://github.com/orttak/geoserver-rest.git

--- a/Makefile
+++ b/Makefile
@@ -147,16 +147,6 @@ initialize-project: which-env
 	@echo "  make jdbc-settings-activation"
 
 # -------------------------------------------------
-# Run GeoServer JDBC settings activation script
-jdbc-settings-activation: which-env
-	@echo "$(COLOR_BLUE)⚙️  Activating GeoServer JDBC settings (ENV_FILE=$(ENV_FILE))...$(COLOR_RESET)"
-	@cd docker/geoserver_docker && \
-	ENV_FILE="$(abspath $(ENV_FILE))" \
-	./scripts/activate_jdbcS_settings.sh
-	@echo "$(COLOR_GREEN)✅ Done. For all logs: make logs | For Django only: make django-logs$(COLOR_RESET)"
-
-
-# -------------------------------------------------
 # Helpers
 # -------------------------------------------------
 set-env:

--- a/README.md
+++ b/README.md
@@ -206,16 +206,14 @@ form-action 'self' https://*.example.org
 
 ## Docker Model
 
-Development and production intentionally use different GeoServer image sources.
+Development and production both use the CI-published GeoServer image from
+GitHub Container Registry. Pin `GEOSERVER_VERSION` in the active environment
+file to the same tested release in both environments; do not use `latest` for
+deployments that need reproducibility.
 
-- `docker-compose-dev.yml` builds GeoServer from the local submodule at
-  `docker/geoserver_docker`. Use this when changing GeoServer Docker scripts or
-  templates.
-- `docker-compose-prod.yml` uses the production GeoServer image published from
-  GitHub Container Registry.
-
-GeoServer Docker changes should be validated in dev, merged in
-`docker/geoserver_docker`, then consumed through the CI-built production image.
+GeoServer Docker implementation changes belong in the
+`digitalcityscience/geoserver_docker` repository. Publish and test a new image
+there, then update `GEOSERVER_VERSION` here to promote it.
 
 ## GeoServer Admin Bootstrap
 
@@ -248,16 +246,9 @@ GEOSERVER_ENABLE_JDBC_CONFIG=false
 - `GEOSERVER_ENABLE_JDBC_CONFIG=true` enables the advanced JDBCConfig catalog
   path.
 
-After services are running, apply GeoServer JDBC security/config files when the
-selected setup needs them:
-
-```bash
-make jdbc-settings-activation
-```
-
-For JDBC role/auth UI steps, see:
-
-- `docker/geoserver_docker/readme_jdbc.md`
+JDBC setup is part of the published GeoServer image. Configure it through the
+`GEOSERVER_ENABLE_JDBC_*` environment flags and consult the GeoServer image
+repository for its operational documentation.
 
 ## Tests
 

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -33,15 +33,10 @@ services:
     restart: unless-stopped
 
   geoserver:
-    build:
-      context: ./docker/geoserver_docker
-      dockerfile: docker/Dockerfile
-      args:
-        GEOSERVER_VERSION: ${GEOSERVER_VERSION}
-        DEFAULT_OFFICIAL_PLUGINS: ${OFFICIAL_PLUGINS:-gdal,monitor,vectortiles,mbstyle}
-        DEFAULT_COMMUNITY_PLUGINS: ${COMMUNITY_PLUGINS:-}
-        BUILD_JDBC_PLUGINS: ${BUILD_JDBC_PLUGINS:-false}
-    image: tosca-geoserver-dev:${GEOSERVER_VERSION}
+    # Match production: consume the CI-published GeoServer image rather than
+    # building the GeoServer implementation from a source submodule.
+    image: ghcr.io/digitalcityscience/tosca-geoserver:${GEOSERVER_VERSION}
+    pull_policy: always
     container_name: tosca-geoserver
     env_file:
       - ${ENV_FILE}

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -33,9 +33,10 @@ services:
       start_period: 20s
     restart: unless-stopped
 
-  # GeoServer in production is always pulled from GHCR; no local submodule build is used here.
+  # GeoServer is always pulled from GHCR. Pin GEOSERVER_VERSION in the active
+  # environment file to promote the same tested image from development.
   geoserver:
-    image: ghcr.io/digitalcityscience/tosca-geoserver:latest
+    image: ghcr.io/digitalcityscience/tosca-geoserver:${GEOSERVER_VERSION}
     pull_policy: always
     container_name: tosca-geoserver-prod
     env_file:

--- a/tosca_api/apps/core/tests/test_no_env_files_hook.py
+++ b/tosca_api/apps/core/tests/test_no_env_files_hook.py
@@ -41,8 +41,8 @@ def test_env_local_is_forbidden():
 
 
 def test_nested_path_is_checked_by_basename():
-    assert find_forbidden_env_files(["docker/geoserver_docker/.env.prod"]) == [
-        "docker/geoserver_docker/.env.prod"
+    assert find_forbidden_env_files(["docker/example/.env.prod"]) == [
+        "docker/example/.env.prod"
     ]
 
 


### PR DESCRIPTION
This PR removes the local GeoServer Docker submodule from TOSCA Backend.
Development and production now use the same version-pinned GHCR image through GEOSERVER_VERSION. This removes dev/prod image drift and makes GeoServer upgrades a configuration change instead of a submodule update and local image build.
It also removes source-submodule-specific documentation and the obsolete JDBC activation Make target.