### PR TITLE
feat: sync default geodata provider on startup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -210,6 +210,9 @@ GUNICORN_WORKERS=3
 GUNICORN_THREADS=2
 GUNICORN_TIMEOUT=120
 RUN_SETUP_DEFAULT_ENGINE=true
+# After migrations and default-engine setup, pull the default provider's
+# GeoServer resources into Django. Set false only for maintenance/troubleshooting.
+RUN_DEFAULT_GEODATA_PROVIDER_SYNC_ON_STARTUP=true
 
 ############################
 # Production web/Nginx

--- a/docker/django/entrypoint.prod.sh
+++ b/docker/django/entrypoint.prod.sh
@@ -33,5 +33,10 @@ if [ "${RUN_SETUP_DEFAULT_ENGINE:-true}" = "true" ]; then
   run_as_appuser uv run python manage.py setup_default_engine
 fi
 
+if [ "${RUN_DEFAULT_GEODATA_PROVIDER_SYNC_ON_STARTUP:-true}" = "true" ]; then
+  echo "🔄 Syncing the default GeoData provider..."
+  run_as_appuser uv run python manage.py sync_geoserver --default
+fi
+
 echo "🚀 Starting Gunicorn..."
 exec gosu "${APP_USER}:${APP_GROUP}" "$@"

--- a/docker/django/entrypoint.sh
+++ b/docker/django/entrypoint.sh
@@ -26,5 +26,10 @@ uv run python manage.py migrate --noinput
 echo "🔧 Setting up default GeoServer engine..."
 uv run python manage.py setup_default_engine
 
+if [ "${RUN_DEFAULT_GEODATA_PROVIDER_SYNC_ON_STARTUP:-true}" = "true" ]; then
+  echo "🔄 Syncing the default GeoData provider..."
+  uv run python manage.py sync_geoserver --default
+fi
+
 echo "�🚀 Starting application..."
 exec "$@"

--- a/tosca_api/apps/geodata_providers/management/commands/sync_geoserver.py
+++ b/tosca_api/apps/geodata_providers/management/commands/sync_geoserver.py
@@ -18,6 +18,11 @@ class Command(BaseCommand):
             help='Sync specific engine by name (default: all active engines)'
         )
         parser.add_argument(
+            '--default',
+            action='store_true',
+            help='Sync only the active default engine'
+        )
+        parser.add_argument(
             '--dry-run',
             action='store_true',
             help='Show what would be synced without making changes'
@@ -54,6 +59,13 @@ class Command(BaseCommand):
             if not engines.exists():
                 self.stdout.write(
                     self.style.ERROR(f'❌ Engine "{options["engine"]}" not found or inactive')
+                )
+                return
+        elif options['default']:
+            engines = GeodataEngine.objects.filter(is_default=True, is_active=True)
+            if not engines.exists():
+                self.stdout.write(
+                    self.style.WARNING('⚠️ No active default GeoServer engine found')
                 )
                 return
         else:

--- a/tosca_api/apps/geodata_providers/tests/test_sync_geoserver_command.py
+++ b/tosca_api/apps/geodata_providers/tests/test_sync_geoserver_command.py
@@ -1,0 +1,53 @@
+"""Tests for selecting GeoServer engines in the startup sync command."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+from django.contrib.auth.models import User
+from django.core.management import call_command
+
+from tosca_api.apps.geodata_providers.models import GeodataEngine
+
+pytestmark = pytest.mark.django_db
+
+_MODULE = "tosca_api.apps.geodata_providers.management.commands.sync_geoserver"
+
+
+def make_engine(*, name, is_default):
+    user = User.objects.get_or_create(username="sync-admin", is_superuser=True)[0]
+    return GeodataEngine.objects.create(
+        name=name,
+        description="test",
+        engine_type="geoserver",
+        base_url="http://gs.internal/geoserver",
+        public_url="http://gs.example/geoserver",
+        admin_username="admin",
+        admin_password="secret",
+        is_active=True,
+        is_default=is_default,
+        created_by=user,
+    )
+
+
+def sync_result():
+    section = {"synced": 0, "created": 0, "deleted": 0, "errors": []}
+    return {
+        "success": True,
+        "workspaces": section,
+        "stores": section,
+        "layers": section,
+    }
+
+
+@patch(f"{_MODULE}.EngineClientFactory.create_sync_service")
+def test_default_option_syncs_only_the_default_active_engine(create_sync_service):
+    default_engine = make_engine(name="Default", is_default=True)
+    make_engine(name="Secondary", is_default=False)
+    service = Mock()
+    service.sync_all_resources.return_value = sync_result()
+    create_sync_service.return_value = service
+
+    call_command("sync_geoserver", "--default")
+
+    create_sync_service.assert_called_once_with(default_engine)
+    service.sync_all_resources.assert_called_once()


### PR DESCRIPTION
This PR automatically synchronizes the default active GeoData provider when Django starts, after migrations and default GeoServer engine setup.
The startup flow calls sync_geoserver --default, so unrelated active providers are not modified. Set RUN_DEFAULT_GEODATA_PROVIDER_SYNC_ON_STARTUP=false to disable it for maintenance or troubleshooting.
Includes coverage for selecting only the default active provider.